### PR TITLE
Add performance processor

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/StatisticsUpdateTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/StatisticsUpdateTests.cs
@@ -304,6 +304,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             var scoreInfo = new SoloScoreInfo
             {
+                id = row.id,
                 user_id = row.user_id,
                 beatmap_id = row.beatmap_id,
                 ruleset_id = row.ruleset_id,

--- a/osu.Server.Queues.ScoreStatisticsProcessor/DifficultyAttributeExtensions.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/DifficultyAttributeExtensions.cs
@@ -1,0 +1,104 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Game.Rulesets.Catch.Difficulty;
+using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Mania.Difficulty;
+using osu.Game.Rulesets.Osu.Difficulty;
+using osu.Game.Rulesets.Taiko.Difficulty;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor
+{
+    // Todo: Merge with osu-difficulty-calculator.
+    public static class DifficultyAttributeExtensions
+    {
+        public static DifficultyAttributes Map(this Dictionary<int, BeatmapDifficultyAttribute> databasedAttribs, int rulesetId, Beatmap databasedBeatmap)
+        {
+            switch (rulesetId)
+            {
+                case 0:
+                    return new OsuDifficultyAttributes
+                    {
+                        AimStrain = databasedAttribs[1].value,
+                        SpeedStrain = databasedAttribs[3].value,
+                        OverallDifficulty = databasedAttribs[5].value,
+                        ApproachRate = databasedAttribs[7].value,
+                        MaxCombo = Convert.ToInt32(databasedAttribs[9].value),
+                        // Seems to not always be included, weirdly. Likely needs recalc... (beatmap_id=279607)
+                        // StarRating = databasedAttribs[11].value,
+                        HitCircleCount = databasedBeatmap.countNormal,
+                        SpinnerCount = databasedBeatmap.countSpinner,
+                    };
+
+                case 1:
+                    return new TaikoDifficultyAttributes
+                    {
+                        MaxCombo = Convert.ToInt32(databasedAttribs[9].value),
+                        StarRating = databasedAttribs[11].value,
+                        GreatHitWindow = databasedAttribs[13].value
+                    };
+
+                case 2:
+                    return new CatchDifficultyAttributes
+                    {
+                        StarRating = databasedAttribs[1].value,
+                        ApproachRate = databasedAttribs[7].value,
+                        MaxCombo = Convert.ToInt32(databasedAttribs[9].value)
+                    };
+
+                case 3:
+                    return new ManiaDifficultyAttributes
+                    {
+                        StarRating = databasedAttribs[11].value,
+                        GreatHitWindow = databasedAttribs[13].value,
+                        ScoreMultiplier = databasedAttribs[15].value
+                    };
+
+                default:
+                    throw new ArgumentException($"Invalid ruleset ({rulesetId}).", nameof(rulesetId));
+            }
+        }
+
+        public static IEnumerable<(int id, object value)> Map(this DifficultyAttributes attributes)
+        {
+            switch (attributes)
+            {
+                case OsuDifficultyAttributes osu:
+                    yield return (1, osu.AimStrain);
+                    yield return (3, osu.SpeedStrain);
+                    yield return (5, osu.OverallDifficulty);
+                    yield return (7, osu.ApproachRate);
+                    yield return (9, osu.MaxCombo);
+                    yield return (11, attributes.StarRating);
+
+                    break;
+
+                case TaikoDifficultyAttributes taiko:
+                    yield return (9, taiko.MaxCombo);
+                    yield return (11, attributes.StarRating);
+                    yield return (13, taiko.GreatHitWindow);
+
+                    break;
+
+                case CatchDifficultyAttributes @catch:
+                    // Todo: Catch should not output star rating in the 'aim' attribute.
+                    yield return (1, @catch.StarRating);
+                    yield return (7, @catch.ApproachRate);
+                    yield return (9, @catch.MaxCombo);
+
+                    break;
+
+                case ManiaDifficultyAttributes mania:
+                    // Todo: Mania doesn't output MaxCombo attribute for some reason.
+                    yield return (11, attributes.StarRating);
+                    yield return (13, mania.GreatHitWindow);
+                    yield return (15, mania.ScoreMultiplier);
+
+                    break;
+            }
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/DifficultyAttributeExtensions.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/DifficultyAttributeExtensions.cs
@@ -26,7 +26,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
                         SpeedStrain = databasedAttribs[3].value,
                         OverallDifficulty = databasedAttribs[5].value,
                         ApproachRate = databasedAttribs[7].value,
-                        MaxCombo = Convert.ToInt32(databasedAttribs[9].value),
+                        MaxCombo = (int)databasedAttribs[9].value,
                         StarRating = databasedAttribs[11].value,
                         HitCircleCount = databasedBeatmap.countNormal,
                         SpinnerCount = databasedBeatmap.countSpinner,
@@ -35,7 +35,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
                 case 1:
                     return new TaikoDifficultyAttributes
                     {
-                        MaxCombo = Convert.ToInt32(databasedAttribs[9].value),
+                        MaxCombo = (int)databasedAttribs[9].value,
                         StarRating = databasedAttribs[11].value,
                         GreatHitWindow = databasedAttribs[13].value
                     };
@@ -45,7 +45,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
                     {
                         StarRating = databasedAttribs[1].value,
                         ApproachRate = databasedAttribs[7].value,
-                        MaxCombo = Convert.ToInt32(databasedAttribs[9].value)
+                        MaxCombo = (int)databasedAttribs[9].value
                     };
 
                 case 3:

--- a/osu.Server.Queues.ScoreStatisticsProcessor/DifficultyAttributeExtensions.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/DifficultyAttributeExtensions.cs
@@ -27,8 +27,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
                         OverallDifficulty = databasedAttribs[5].value,
                         ApproachRate = databasedAttribs[7].value,
                         MaxCombo = Convert.ToInt32(databasedAttribs[9].value),
-                        // Seems to not always be included, weirdly. Likely needs recalc... (beatmap_id=279607)
-                        // StarRating = databasedAttribs[11].value,
+                        StarRating = databasedAttribs[11].value,
                         HitCircleCount = databasedBeatmap.countNormal,
                         SpinnerCount = databasedBeatmap.countSpinner,
                     };

--- a/osu.Server.Queues.ScoreStatisticsProcessor/LegacyModsHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/LegacyModsHelper.cs
@@ -2,110 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Beatmaps.Legacy;
-using osu.Game.Rulesets.Mania.Mods;
-using osu.Game.Rulesets.Mods;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor
 {
     public class LegacyModsHelper
     {
-        public static LegacyMods ToLegacy(Mod[] mods)
-        {
-            var value = LegacyMods.None;
-
-            foreach (var mod in mods)
-            {
-                switch (mod)
-                {
-                    case ManiaModFadeIn _:
-                        value |= LegacyMods.FadeIn;
-                        break;
-
-                    case ModNoFail _:
-                        value |= LegacyMods.NoFail;
-                        break;
-
-                    case ModEasy _:
-                        value |= LegacyMods.Easy;
-                        break;
-
-                    case ModHidden _:
-                        value |= LegacyMods.Hidden;
-                        break;
-
-                    case ModHardRock _:
-                        value |= LegacyMods.HardRock;
-                        break;
-
-                    case ModSuddenDeath _:
-                        value |= LegacyMods.SuddenDeath;
-                        break;
-
-                    case ModDoubleTime _:
-                        value |= LegacyMods.DoubleTime;
-                        break;
-
-                    case ModRelax _:
-                        value |= LegacyMods.Relax;
-                        break;
-
-                    case ModHalfTime _:
-                        value |= LegacyMods.HalfTime;
-                        break;
-
-                    case ModFlashlight _:
-                        value |= LegacyMods.Flashlight;
-                        break;
-
-                    case ManiaModKey1 _:
-                        value |= LegacyMods.Key1;
-                        break;
-
-                    case ManiaModKey2 _:
-                        value |= LegacyMods.Key2;
-                        break;
-
-                    case ManiaModKey3 _:
-                        value |= LegacyMods.Key3;
-                        break;
-
-                    case ManiaModKey4 _:
-                        value |= LegacyMods.Key4;
-                        break;
-
-                    case ManiaModKey5 _:
-                        value |= LegacyMods.Key5;
-                        break;
-
-                    case ManiaModKey6 _:
-                        value |= LegacyMods.Key6;
-                        break;
-
-                    case ManiaModKey7 _:
-                        value |= LegacyMods.Key7;
-                        break;
-
-                    case ManiaModKey8 _:
-                        value |= LegacyMods.Key8;
-                        break;
-
-                    case ManiaModKey9 _:
-                        value |= LegacyMods.Key9;
-                        break;
-
-                    case ManiaModMirror _:
-                        value |= LegacyMods.Mirror;
-                        break;
-
-                    case ManiaModDualStages _:
-                        value |= LegacyMods.KeyCoop;
-                        break;
-                }
-            }
-
-            return value;
-        }
-
         public static LegacyMods MaskRelevantMods(LegacyMods mods) => mods & (LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy | keyMods);
 
         private static LegacyMods keyMods => LegacyMods.Key1 | LegacyMods.Key2 | LegacyMods.Key3 | LegacyMods.Key4 | LegacyMods.Key5 | LegacyMods.Key6 | LegacyMods.Key7 | LegacyMods.Key8

--- a/osu.Server.Queues.ScoreStatisticsProcessor/LegacyModsHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/LegacyModsHelper.cs
@@ -1,0 +1,114 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps.Legacy;
+using osu.Game.Rulesets.Mania.Mods;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor
+{
+    public class LegacyModsHelper
+    {
+        public static LegacyMods ToLegacy(Mod[] mods)
+        {
+            var value = LegacyMods.None;
+
+            foreach (var mod in mods)
+            {
+                switch (mod)
+                {
+                    case ManiaModFadeIn _:
+                        value |= LegacyMods.FadeIn;
+                        break;
+
+                    case ModNoFail _:
+                        value |= LegacyMods.NoFail;
+                        break;
+
+                    case ModEasy _:
+                        value |= LegacyMods.Easy;
+                        break;
+
+                    case ModHidden _:
+                        value |= LegacyMods.Hidden;
+                        break;
+
+                    case ModHardRock _:
+                        value |= LegacyMods.HardRock;
+                        break;
+
+                    case ModSuddenDeath _:
+                        value |= LegacyMods.SuddenDeath;
+                        break;
+
+                    case ModDoubleTime _:
+                        value |= LegacyMods.DoubleTime;
+                        break;
+
+                    case ModRelax _:
+                        value |= LegacyMods.Relax;
+                        break;
+
+                    case ModHalfTime _:
+                        value |= LegacyMods.HalfTime;
+                        break;
+
+                    case ModFlashlight _:
+                        value |= LegacyMods.Flashlight;
+                        break;
+
+                    case ManiaModKey1 _:
+                        value |= LegacyMods.Key1;
+                        break;
+
+                    case ManiaModKey2 _:
+                        value |= LegacyMods.Key2;
+                        break;
+
+                    case ManiaModKey3 _:
+                        value |= LegacyMods.Key3;
+                        break;
+
+                    case ManiaModKey4 _:
+                        value |= LegacyMods.Key4;
+                        break;
+
+                    case ManiaModKey5 _:
+                        value |= LegacyMods.Key5;
+                        break;
+
+                    case ManiaModKey6 _:
+                        value |= LegacyMods.Key6;
+                        break;
+
+                    case ManiaModKey7 _:
+                        value |= LegacyMods.Key7;
+                        break;
+
+                    case ManiaModKey8 _:
+                        value |= LegacyMods.Key8;
+                        break;
+
+                    case ManiaModKey9 _:
+                        value |= LegacyMods.Key9;
+                        break;
+
+                    case ManiaModMirror _:
+                        value |= LegacyMods.Mirror;
+                        break;
+
+                    case ManiaModDualStages _:
+                        value |= LegacyMods.KeyCoop;
+                        break;
+                }
+            }
+
+            return value;
+        }
+
+        public static LegacyMods MaskRelevantMods(LegacyMods mods) => mods & (LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy | keyMods);
+
+        private static LegacyMods keyMods => LegacyMods.Key1 | LegacyMods.Key2 | LegacyMods.Key3 | LegacyMods.Key4 | LegacyMods.Key5 | LegacyMods.Key6 | LegacyMods.Key7 | LegacyMods.Key8
+                                             | LegacyMods.Key9 | LegacyMods.Key1;
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/Beatmap.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/Beatmap.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Dapper.Contrib.Extensions;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
+{
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [Serializable]
+    [Table("osu_beatmaps")]
+    public class Beatmap
+    {
+        [ExplicitKey]
+        public uint beatmap_id { get; set; }
+
+        public ushort countTotal { get; set; }
+        public ushort countNormal { get; set; }
+        public ushort countSlider { get; set; }
+        public ushort countSpinner { get; set; }
+        public float difficultyrating { get; set; }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/BeatmapDifficultyAttribute.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/BeatmapDifficultyAttribute.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Dapper.Contrib.Extensions;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
+{
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [Serializable]
+    [Table("osu_beatmap_difficulty_attribs")]
+    public class BeatmapDifficultyAttribute
+    {
+        [ExplicitKey]
+        public uint beatmap_id { get; set; }
+
+        [ExplicitKey]
+        public ushort mode { get; set; }
+
+        [ExplicitKey]
+        public uint mods { get; set; }
+
+        [ExplicitKey]
+        public ushort attrib_id { get; set; }
+
+        public float value { get; set; }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs
@@ -26,7 +26,15 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
         public string data
         {
             get => ScoreInfo.Serialize();
-            set => ScoreInfo = value.Deserialize<SoloScoreInfo>();
+            set
+            {
+                ScoreInfo = value.Deserialize<SoloScoreInfo>();
+
+                ScoreInfo.id = id;
+                ScoreInfo.beatmap_id = beatmap_id;
+                ScoreInfo.user_id = user_id;
+                ScoreInfo.ruleset_id = ruleset_id;
+            }
         }
 
         public SoloScoreInfo ScoreInfo = new SoloScoreInfo();

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScoreInfo.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScoreInfo.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using osu.Game.Online.API;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 
@@ -54,5 +55,19 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 
         [JsonIgnore]
         public DateTimeOffset? deleted_at { get; set; }
+
+        public ScoreInfo ToScoreInfo(Mod[] mods) => new ScoreInfo
+        {
+            UserID = user_id,
+            BeatmapInfoID = beatmap_id,
+            RulesetID = ruleset_id,
+            Passed = passed,
+            TotalScore = total_score,
+            Accuracy = accuracy,
+            MaxCombo = max_combo,
+            Rank = rank,
+            Mods = mods,
+            Statistics = statistics
+        };
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScorePerformance.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScorePerformance.cs
@@ -9,7 +9,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [Serializable]
-    [Table("solo_scores_v2_performance")] // TODO: change name after osu-web has updated to this format.
+    [Table("solo_scores_performance")]
     public class SoloScorePerformance
     {
         [ExplicitKey]

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScorePerformance.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScorePerformance.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Dapper.Contrib.Extensions;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
+{
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [Serializable]
+    [Table("solo_scores_v2_performance")] // TODO: change name after osu-web has updated to this format.
+    public class SoloScorePerformance
+    {
+        [ExplicitKey]
+        public ulong score_id { get; set; }
+
+        public float? pp { get; set; }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PerformanceProcessor.cs
@@ -54,7 +54,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             var performanceCalculator = ruleset.CreatePerformanceCalculator(difficultyAttributes, scoreInfo);
             var performance = performanceCalculator.Calculate();
 
-            conn.Execute("INSERT INTO solo_scores_v2_performance (`score_id`, `pp`) VALUES (@ScoreId, @Pp) ON DUPLICATE KEY UPDATE `pp` = @Pp", new
+            conn.Execute("INSERT INTO solo_scores_performance (`score_id`, `pp`) VALUES (@ScoreId, @Pp) ON DUPLICATE KEY UPDATE `pp` = @Pp", new
             {
                 ScoreId = score.id,
                 Pp = performance

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PerformanceProcessor.cs
@@ -37,14 +37,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             // Todo: We shouldn't be using legacy mods, but this requires difficulty calculation to be performed in-line.
             LegacyMods legacyModValue = LegacyModsHelper.MaskRelevantMods(ruleset.ConvertToLegacyMods(mods));
 
-            var beatmap = conn.QuerySingleOrDefault<Beatmap?>("SELECT * FROM osu_beatmaps WHERE beatmap_id = @BeatmapId", new
+            var beatmap = conn.QuerySingle<Beatmap>("SELECT * FROM osu_beatmaps WHERE beatmap_id = @BeatmapId", new
             {
                 BeatmapId = score.beatmap_id
             });
-
-            // Todo: REMOVE THIS. This should never be the case (testing-only).
-            if (beatmap == null)
-                return;
 
             var rawDifficultyAttribs = conn.Query<BeatmapDifficultyAttribute>(
                 "SELECT * FROM osu_beatmap_difficulty_attribs WHERE beatmap_id = @BeatmapId AND mode = @RulesetId AND mods = @ModValue", new
@@ -52,14 +48,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                     BeatmapId = score.beatmap_id,
                     RulesetId = score.ruleset_id,
                     ModValue = (uint)legacyModValue
-                })?.ToArray();
-
-            // Todo: REMOVE THIS. This should never be the case (testing-only).
-            if (rawDifficultyAttribs == null || rawDifficultyAttribs.Length == 0)
-                return;
+                }).ToArray();
 
             var difficultyAttributes = rawDifficultyAttribs.ToDictionary(a => (int)a.attrib_id).Map(score.ruleset_id, beatmap);
-
             var performanceCalculator = ruleset.CreatePerformanceCalculator(difficultyAttributes, scoreInfo);
             var performance = performanceCalculator.Calculate();
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PerformanceProcessor.cs
@@ -54,10 +54,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             var performanceCalculator = ruleset.CreatePerformanceCalculator(difficultyAttributes, scoreInfo);
             var performance = performanceCalculator.Calculate();
 
-            conn.Execute("INSERT INTO solo_scores_performance (`score_id`, `pp`) VALUES (@ScoreId, @Pp) ON DUPLICATE KEY UPDATE `pp` = @Pp", new
+            conn.Execute("INSERT INTO solo_scores_performance (`score_id`, `pp`) VALUES (@ScoreId, @PP) ON DUPLICATE KEY UPDATE `pp` = @PP", new
             {
                 ScoreId = score.id,
-                Pp = performance
+                PP = performance
             });
         }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PerformanceProcessor.cs
@@ -1,0 +1,96 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Dapper;
+using MySqlConnector;
+using osu.Game.Beatmaps.Legacy;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Scoring;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
+{
+    public class PerformanceProcessor : IProcessor
+    {
+        private static readonly List<Ruleset> available_rulesets = getRulesets();
+
+        public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
+        {
+        }
+
+        public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
+        {
+        }
+
+        public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
+        {
+            Ruleset ruleset = available_rulesets.Single(r => r.RulesetInfo.ID == score.ruleset_id);
+            Mod[] mods = score.mods.Select(m => m.ToMod(ruleset)).ToArray();
+            ScoreInfo scoreInfo = score.ToScoreInfo(mods);
+
+            // Todo: We shouldn't be using legacy mods, but this requires difficulty calculation to be performed in-line.
+            LegacyMods legacyModValue = LegacyModsHelper.MaskRelevantMods(ruleset.ConvertToLegacyMods(mods));
+
+            var beatmap = conn.QuerySingleOrDefault<Beatmap?>("SELECT * FROM osu_beatmaps WHERE beatmap_id = @BeatmapId", new
+            {
+                BeatmapId = score.beatmap_id
+            });
+
+            // Todo: REMOVE THIS. This should never be the case (testing-only).
+            if (beatmap == null)
+                return;
+
+            var rawDifficultyAttribs = conn.Query<BeatmapDifficultyAttribute>(
+                "SELECT * FROM osu_beatmap_difficulty_attribs WHERE beatmap_id = @BeatmapId AND mode = @RulesetId AND mods = @ModValue", new
+                {
+                    BeatmapId = score.beatmap_id,
+                    RulesetId = score.ruleset_id,
+                    ModValue = (uint)legacyModValue
+                })?.ToArray();
+
+            // Todo: REMOVE THIS. This should never be the case (testing-only).
+            if (rawDifficultyAttribs == null || rawDifficultyAttribs.Length == 0)
+                return;
+
+            var difficultyAttributes = rawDifficultyAttribs.ToDictionary(a => (int)a.attrib_id).Map(score.ruleset_id, beatmap);
+
+            var performanceCalculator = ruleset.CreatePerformanceCalculator(difficultyAttributes, scoreInfo);
+            var performance = performanceCalculator.Calculate();
+
+            conn.Execute("INSERT INTO solo_scores_v2_performance (`score_id`, `pp`) VALUES (@ScoreId, @Pp) ON DUPLICATE KEY UPDATE `pp` = @Pp", new
+            {
+                ScoreId = score.id,
+                Pp = performance
+            });
+        }
+
+        private static List<Ruleset> getRulesets()
+        {
+            const string ruleset_library_prefix = "osu.Game.Rulesets";
+
+            var rulesetsToProcess = new List<Ruleset>();
+
+            foreach (string file in Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, $"{ruleset_library_prefix}.*.dll"))
+            {
+                try
+                {
+                    var assembly = Assembly.LoadFrom(file);
+                    Type type = assembly.GetTypes().First(t => t.IsPublic && t.IsSubclassOf(typeof(Ruleset)));
+                    rulesetsToProcess.Add((Ruleset)Activator.CreateInstance(type)!);
+                }
+                catch
+                {
+                    throw new Exception($"Failed to load ruleset ({file})");
+                }
+            }
+
+            return rulesetsToProcess;
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsProcessor.cs
@@ -19,8 +19,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         /// version 2: total score, hit statistics, beatmap playcount, monthly playcount, max combo
         /// version 3: fixed incorrect revert condition for beatmap/monthly playcount
         /// version 4: uses SoloScore"V2" (moving all content to json data block)
+        /// version 5: added performance processor
         /// </summary>
-        public const int VERSION = 4;
+        public const int VERSION = 5;
 
         private readonly List<IProcessor> processors = new List<IProcessor>();
 


### PR DESCRIPTION
```sql
create table solo_scores_performance
(
    `score_id` bigint unsigned not null
        primary key,
    `pp` double(8, 2)
);
```

For the time being I'm querying the `osu_beatmaps` and `osu_beatmap_difficulty_attribs` tables every time, which is expensive but probably not too bad for the time being. This will need to be optimised in the future - either via the way osu-performance does it (querying all attributes at once) or by calculating attributes in-line which will be required anyway once we start adjusting for lazer mod settings.