### PR TITLE
Add build_id to SoloScoreInfo

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScoreInfo.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScoreInfo.cs
@@ -26,6 +26,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 
         public int ruleset_id { get; set; }
 
+        public int build_id { get; set; }
+
         public bool passed { get; set; }
 
         public int total_score { get; set; }


### PR DESCRIPTION
Separating this one so there's no inter-dependencies between other PRs.