### PR TITLE
Move table name specifications to constants

### DIFF
--- a/osu.Server.Queues.ScorePump/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/ImportHighScores.cs
@@ -18,7 +18,7 @@ using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScorePump
 {
-    [Command("import-high-scores", Description = "Imports high scores from the osu_scores_high tables into solo_scores.")]
+    [Command("import-high-scores", Description = "Imports high scores from the osu_scores_high tables into the new solo scores table.")]
     public class ImportHighScores : ScorePump
     {
         [Option(CommandOptionType.SingleValue)]
@@ -97,9 +97,9 @@ namespace osu.Server.Queues.ScorePump
                         soloScore.id = db.Insert(soloScore, transaction);
 
                         // Update data to match the row ID.
-                        db.Execute("UPDATE solo_scores s SET s.data = JSON_SET(s.data, '$.id', @id) WHERE s.id = @id", soloScore, transaction);
+                        db.Execute($"UPDATE {SoloScore.TABLE_NAME} s SET s.data = JSON_SET(s.data, '$.id', @id) WHERE s.id = @id", soloScore, transaction);
 
-                        db.Execute("INSERT INTO solo_scores_performance (score_id, pp) VALUES (@scoreId, @pp)", new
+                        db.Execute($"INSERT INTO {SoloScorePerformance.TABLE_NAME} (score_id, pp) VALUES (@scoreId, @pp)", new
                         {
                             scoreId = soloScore.id,
                             highScore.pp

--- a/osu.Server.Queues.ScorePump/PumpAllScores.cs
+++ b/osu.Server.Queues.ScorePump/PumpAllScores.cs
@@ -23,7 +23,7 @@ namespace osu.Server.Queues.ScorePump
             using (var dbMainQuery = Queue.GetDatabaseConnection())
             using (var db = Queue.GetDatabaseConnection())
             {
-                string query = "SELECT * FROM solo_scores WHERE id >= @StartId";
+                string query = $"SELECT * FROM {SoloScore.TABLE_NAME} WHERE id >= @StartId";
 
                 if (!string.IsNullOrEmpty(CustomQuery))
                     query += $" AND {CustomQuery}";

--- a/osu.Server.Queues.ScorePump/WatchNewScores.cs
+++ b/osu.Server.Queues.ScorePump/WatchNewScores.cs
@@ -42,7 +42,7 @@ namespace osu.Server.Queues.ScorePump
 
                 using (var db = Queue.GetDatabaseConnection())
                 {
-                    var scores = db.Query<SoloScore>("SELECT * FROM solo_scores WHERE id > @lastId LIMIT @count_per_run", new
+                    var scores = db.Query<SoloScore>($"SELECT * FROM {SoloScore.TABLE_NAME} WHERE id > @lastId LIMIT @count_per_run", new
                     {
                         lastId,
                         count_per_run

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/SerialisationTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/SerialisationTests.cs
@@ -22,7 +22,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 // will throw if not on test database.
                 db.Query<int>("SELECT * FROM test_database");
 
-                db.Execute("TRUNCATE TABLE solo_scores");
+                db.Execute($"TRUNCATE TABLE {SoloScore.TABLE_NAME}");
                 db.Execute("TRUNCATE TABLE solo_scores_process_history");
             }
         }
@@ -68,7 +68,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
                 db.Insert(score);
 
-                var retrieved = db.QueryFirst<SoloScore>("SELECT * FROM solo_scores");
+                var retrieved = db.QueryFirst<SoloScore>($"SELECT * FROM {SoloScore.TABLE_NAME}");
 
                 // ignore time values for now until we can figure how to test without precision issues.
                 retrieved.created_at = score.created_at;

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/StatisticsUpdateTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/StatisticsUpdateTests.cs
@@ -32,7 +32,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 db.Execute("TRUNCATE TABLE osu_user_stats_mania");
                 db.Execute("TRUNCATE TABLE osu_user_beatmap_playcount");
                 db.Execute("TRUNCATE TABLE osu_user_month_playcount");
-                db.Execute("TRUNCATE TABLE solo_scores");
+                db.Execute($"TRUNCATE TABLE {SoloScore.TABLE_NAME}");
                 db.Execute("TRUNCATE TABLE solo_scores_process_history");
             }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs
@@ -10,9 +10,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [Serializable]
-    [Table("solo_scores")]
+    [Table(TABLE_NAME)]
     public class SoloScore
     {
+        public const string TABLE_NAME = "solo_scores";
+
         [ExplicitKey]
         public long id { get; set; }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScorePerformance.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScorePerformance.cs
@@ -9,9 +9,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [Serializable]
-    [Table("solo_scores_performance")]
+    [Table(TABLE_NAME)]
     public class SoloScorePerformance
     {
+        public const string TABLE_NAME = "solo_scores_performance";
+
         [ExplicitKey]
         public ulong score_id { get; set; }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PerformanceProcessor.cs
@@ -34,7 +34,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
             double performance = computePerformance(ruleset, mods, scoreInfo, conn, transaction);
 
-            conn.Execute("INSERT INTO solo_scores_performance (`score_id`, `pp`) VALUES (@ScoreId, @PP) ON DUPLICATE KEY UPDATE `pp` = @PP", new
+            conn.Execute($"INSERT INTO {SoloScorePerformance.TABLE_NAME} (`score_id`, `pp`) VALUES (@ScoreId, @PP) ON DUPLICATE KEY UPDATE `pp` = @PP", new
             {
                 ScoreId = score.id,
                 PP = performance


### PR DESCRIPTION
The next step is to deploy this on production. However I don't want to write to the main table just yet (to keep things completely separate between lazer and legacy scores), to allow for testing out performance and structural changes without worrying about locking the whole table.

This will allow me to create different named temporary tables to test again. Haven't bothered with `solo_scores_process_history` just yet as it is out of scope for the initial testing.