### PR TITLE
Fix enum parse failure if `rank` is an empty string

### DIFF
--- a/osu.Server.Queues.ScorePump/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/ImportHighScores.cs
@@ -78,7 +78,7 @@ namespace osu.Server.Queues.ScorePump
                             total_score = highScore.score,
                             accuracy = scoreInfo.Accuracy,
                             max_combo = highScore.maxcombo,
-                            rank = highScore.rank,
+                            rank = Enum.TryParse(highScore.rank, out ScoreRank parsed) ? parsed : ScoreRank.D,
                             mods = ruleset.ConvertFromLegacyMods((LegacyMods)highScore.enabled_mods).Select(m => new APIMod(m)).ToList(),
                             statistics = scoreInfo.Statistics,
                             started_at = highScore.date,
@@ -122,7 +122,7 @@ namespace osu.Server.Queues.ScorePump
             public int user_id { get; set; }
             public int score { get; set; }
             public short maxcombo { get; set; }
-            public ScoreRank rank { get; set; }
+            public string rank { get; set; } = null!; // Actually a ScoreRank, but reading as a string for manual parsing.
             public short count50 { get; set; }
             public short count100 { get; set; }
             public short count300 { get; set; }


### PR DESCRIPTION
They should not ever be empty strings, but some legacy scores have this in the database itself. Rather than leaving parsing to dapper (which will hard bail during enumeration) let's parse this ourselves and handle with a fallback.

Have tested this on production data to fix the issue. Still running strong after ~30m scores.