### PR TITLE
Optimise insert performance by batching transactions and using prepared statements

### DIFF
--- a/osu.Server.Queues.ScorePump/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/ImportHighScores.cs
@@ -54,11 +54,11 @@ namespace osu.Server.Queues.ScorePump
                     // pp insert
                     + $"INSERT INTO {SoloScorePerformance.TABLE_NAME} (score_id, pp) VALUES (@@LAST_INSERT_ID, @pp);";
 
-                var insertUserId = insertCommand.Parameters.Add("userId", MySqlDbType.UInt32);
-                var insertBeatmapId = insertCommand.Parameters.Add("beatmapId", MySqlDbType.UInt24);
-                var insertData = insertCommand.Parameters.Add("data", MySqlDbType.JSON);
-                var insertDate = insertCommand.Parameters.Add("date", MySqlDbType.DateTime);
-                var insertPPvalue = insertCommand.Parameters.Add("pp", MySqlDbType.Float);
+                var userId = insertCommand.Parameters.Add("userId", MySqlDbType.UInt32);
+                var beatmapId = insertCommand.Parameters.Add("beatmapId", MySqlDbType.UInt24);
+                var data = insertCommand.Parameters.Add("data", MySqlDbType.JSON);
+                var date = insertCommand.Parameters.Add("date", MySqlDbType.DateTime);
+                var pp = insertCommand.Parameters.Add("pp", MySqlDbType.Float);
 
                 insertCommand.Prepare();
 
@@ -78,7 +78,11 @@ namespace osu.Server.Queues.ScorePump
 
                         var (accuracy, statistics) = getAccuracyAndStatistics(ruleset, highScore);
 
-                        string data = JsonConvert.SerializeObject(new SoloScoreInfo
+                        pp.Value = highScore.pp;
+                        userId.Value = highScore.user_id;
+                        beatmapId.Value = highScore.beatmap_id;
+                        date.Value = highScore.date;
+                        data.Value = JsonConvert.SerializeObject(new SoloScoreInfo
                         {
                             // id will be written below in the UPDATE call.
                             user_id = highScore.user_id,
@@ -93,11 +97,6 @@ namespace osu.Server.Queues.ScorePump
                             statistics = statistics,
                         });
 
-                        insertPPvalue.Value = highScore.pp;
-                        insertUserId.Value = highScore.user_id;
-                        insertBeatmapId.Value = highScore.beatmap_id;
-                        insertData.Value = data;
-                        insertDate.Value = highScore.date;
 
                         insertCommand.Transaction = transaction;
 

--- a/osu.Server.Queues.ScorePump/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/ImportHighScores.cs
@@ -100,8 +100,7 @@ namespace osu.Server.Queues.ScorePump
                         });
 
                         insertCommand.Transaction = transaction;
-
-                        ulong insertId = (ulong)insertCommand.ExecuteScalar()!;
+                        insertCommand.ExecuteNonQuery();
 
                         Interlocked.Increment(ref currentTransactionInsertCount);
 
@@ -113,7 +112,7 @@ namespace osu.Server.Queues.ScorePump
 
                             int inserted = Interlocked.Exchange(ref currentTransactionInsertCount, 0);
 
-                            Console.WriteLine($"Written up to old:{highScore.score_id} new:{insertId} (+{inserted} {inserted / seconds_between_transactions}/s)");
+                            Console.WriteLine($"Written up to {highScore.score_id} (+{inserted} rows {inserted / seconds_between_transactions}/s)");
 
                             transaction = db.BeginTransaction();
                             lastCommitTimestamp = currentTimestamp;


### PR DESCRIPTION
Still using dapper for the outer query, but that's less of an issue.

This brings things from ~690/s to 1200/s. Still not super amazing (limited by 1xRTT per insert) but it's an improvement. The new structure will lend itself better to future optimisations, too.

```csharp


Written up to 7930516 (+2692 rows 1346/s)
Retrieving next 10000 scores starting from 7950567
Written up to 7961249 (+2854 rows 1427/s)
Written up to 7990932 (+2655 rows 1327/s)
Written up to 8018117 (+2773 rows 1386/s)
Written up to 8047042 (+2889 rows 1444/s)
Retrieving next 10000 scores starting from 8053148
Written up to 8075805 (+2817 rows 1408/s)
Written up to 8094364 (+1714 rows 857/s)
Written up to 8119163 (+2457 rows 1228/s)
Written up to 8149078 (+2842 rows 1421/s)
Retrieving next 10000 scores starting from 8158235
Written up to 8182292 (+2840 rows 1420/s)
Written up to 8211152 (+2923 rows 1461/s)
Written up to 8242370 (+2935 rows 1467/s)
Retrieving next 10000 scores starting from 8265086
Written up to 8271560 (+2780 rows 1390/s)
Written up to 8294848 (+2093 rows 1046/s)
Written up to 8314513 (+1828 rows 914/s)
Written up to 8345025 (+2923 rows 1461/s)
Retrieving next 10000 scores starting from 8370595
Written up to 8375052 (+3004 rows 1502/s)
Written up to 8403151 (+2878 rows 1439/s)
Written up to 8436009 (+2951 rows 1475/s)
Written up to 8467301 (+2995 rows 1497/s)
Retrieving next 10000 scores starting from 8474571
```