### PR TITLE
Fix crash from unsigned type mismatches overflowing

### DIFF
--- a/osu.Server.Queues.ScorePump/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/ImportHighScores.cs
@@ -157,14 +157,14 @@ namespace osu.Server.Queues.ScorePump
             public int beatmap_id { get; set; }
             public int user_id { get; set; }
             public int score { get; set; }
-            public short maxcombo { get; set; }
+            public ushort maxcombo { get; set; }
             public string rank { get; set; } = null!; // Actually a ScoreRank, but reading as a string for manual parsing.
-            public short count50 { get; set; }
-            public short count100 { get; set; }
-            public short count300 { get; set; }
-            public short countmiss { get; set; }
-            public short countgeki { get; set; }
-            public short countkatu { get; set; }
+            public ushort count50 { get; set; }
+            public ushort count100 { get; set; }
+            public ushort count300 { get; set; }
+            public ushort countmiss { get; set; }
+            public ushort countgeki { get; set; }
+            public ushort countkatu { get; set; }
             public bool perfect { get; set; }
             public int enabled_mods { get; set; }
             public DateTimeOffset date { get; set; }


### PR DESCRIPTION
Database defines all these as `unsigned smallint`.

```csharp
Unhandled exception. System.Data.DataException: Error parsing column 10 (countgeki=43432 - UInt16)
 ---> System.OverflowException: Arithmetic operation resulted in an overflow.
   at Deserialize6de5264b-9708-4784-9a2c-efbdf4d94bd2(IDataReader )
   --- End of inner exception stack trace ---
   at Dapper.SqlMapper.ThrowDataException(Exception ex, Int32 index, IDataReader reader, Object value) in /_/Dapper/SqlMapper.cs:line 3706
   at Deserialize6de5264b-9708-4784-9a2c-efbdf4d94bd2(IDataReader )
   at Dapper.SqlMapper.QueryImpl[T](IDbConnection cnn, CommandDefinition command, Type effectiveType)+MoveNext()
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at Dapper.SqlMapper.Query[T](IDbConnection cnn, String sql, Object param, IDbTransaction transaction, Boolean buffered, Nullable`1 commandTimeout, Nullable`1 commandType)
   at osu.Server.Queues.ScorePump.ImportHighScores.OnExecute(CancellationToken cancellationToken)
```