### PR TITLE
Add support to `ImportHighScores` to populate old-new mapping pairs

### DIFF
--- a/osu.Server.Queues.ScorePump/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/ImportHighScores.cs
@@ -54,9 +54,12 @@ namespace osu.Server.Queues.ScorePump
                     $"INSERT INTO {SoloScore.TABLE_NAME} (user_id, beatmap_id, ruleset_id, data, preserve, created_at, updated_at) "
                     + $"VALUES (@userId, @beatmapId, {RulesetId}, @data, 1, @date, @date);"
                     // pp insert
-                    + $"INSERT INTO {SoloScorePerformance.TABLE_NAME} (score_id, pp) VALUES (@@LAST_INSERT_ID, @pp);";
+                    + $"INSERT INTO {SoloScorePerformance.TABLE_NAME} (score_id, pp) VALUES (@@LAST_INSERT_ID, @pp);"
+                    // mapping insert
+                    + $"INSERT INTO {SoloScoreLegacyIDMap.TABLE_NAME} (ruleset_id, old_score_id, score_id) VALUES ({RulesetId}, @scoreId, @@LAST_INSERT_ID);";
 
                 var userId = insertCommand.Parameters.Add("userId", MySqlDbType.UInt32);
+                var scoreId = insertCommand.Parameters.Add("scoreId", MySqlDbType.UInt32);
                 var beatmapId = insertCommand.Parameters.Add("beatmapId", MySqlDbType.UInt24);
                 var data = insertCommand.Parameters.Add("data", MySqlDbType.JSON);
                 var date = insertCommand.Parameters.Add("date", MySqlDbType.DateTime);
@@ -82,6 +85,7 @@ namespace osu.Server.Queues.ScorePump
 
                         pp.Value = highScore.pp;
                         userId.Value = highScore.user_id;
+                        scoreId.Value = highScore.score_id;
                         beatmapId.Value = highScore.beatmap_id;
                         date.Value = highScore.date;
                         data.Value = JsonConvert.SerializeObject(new SoloScoreInfo

--- a/osu.Server.Queues.ScorePump/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/ImportHighScores.cs
@@ -56,10 +56,10 @@ namespace osu.Server.Queues.ScorePump
                     // pp insert
                     + $"INSERT INTO {SoloScorePerformance.TABLE_NAME} (score_id, pp) VALUES (@@LAST_INSERT_ID, @pp);"
                     // mapping insert
-                    + $"INSERT INTO {SoloScoreLegacyIDMap.TABLE_NAME} (ruleset_id, old_score_id, score_id) VALUES ({RulesetId}, @scoreId, @@LAST_INSERT_ID);";
+                    + $"INSERT INTO {SoloScoreLegacyIDMap.TABLE_NAME} (ruleset_id, old_score_id, score_id) VALUES ({RulesetId}, @oldScoreId, @@LAST_INSERT_ID);";
 
                 var userId = insertCommand.Parameters.Add("userId", MySqlDbType.UInt32);
-                var scoreId = insertCommand.Parameters.Add("scoreId", MySqlDbType.UInt32);
+                var oldScoreId = insertCommand.Parameters.Add("oldScoreId", MySqlDbType.UInt32);
                 var beatmapId = insertCommand.Parameters.Add("beatmapId", MySqlDbType.UInt24);
                 var data = insertCommand.Parameters.Add("data", MySqlDbType.JSON);
                 var date = insertCommand.Parameters.Add("date", MySqlDbType.DateTime);
@@ -85,7 +85,7 @@ namespace osu.Server.Queues.ScorePump
 
                         pp.Value = highScore.pp;
                         userId.Value = highScore.user_id;
-                        scoreId.Value = highScore.score_id;
+                        oldScoreId.Value = highScore.score_id;
                         beatmapId.Value = highScore.beatmap_id;
                         date.Value = highScore.date;
                         data.Value = JsonConvert.SerializeObject(new SoloScoreInfo

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScoreLegacyIDMap.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScoreLegacyIDMap.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Dapper.Contrib.Extensions;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
+{
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [Serializable]
+    [Table(TABLE_NAME)]
+    public class SoloScoreLegacyIDMap
+    {
+        public const string TABLE_NAME = "solo_scores_legacy_id_map";
+
+        [ExplicitKey]
+        public ushort ruleset_id { get; set; }
+
+        [ExplicitKey]
+        public uint old_score_id { get; set; }
+
+        public ulong score_id { get; set; }
+    }
+}


### PR DESCRIPTION
Not yet tested, PRing for discussion. Not 100% on the naming.