### PR TITLE
Add play time processor

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/StatisticsUpdateTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/StatisticsUpdateTests.cs
@@ -34,6 +34,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 db.Execute("TRUNCATE TABLE osu_user_month_playcount");
                 db.Execute($"TRUNCATE TABLE {SoloScore.TABLE_NAME}");
                 db.Execute("TRUNCATE TABLE solo_scores_process_history");
+                db.Execute("TRUNCATE TABLE solo_scores_performance");
             }
 
             Task.Run(() => processor.Run(cts.Token), cts.Token);
@@ -302,13 +303,15 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 updated_at = DateTimeOffset.Now,
             };
 
+            var startTime = new DateTimeOffset(new DateTime(2020, 02, 05));
             var scoreInfo = new SoloScoreInfo
             {
                 id = row.id,
                 user_id = row.user_id,
                 beatmap_id = row.beatmap_id,
                 ruleset_id = row.ruleset_id,
-                started_at = new DateTimeOffset(new DateTime(2020, 02, 05)),
+                started_at = startTime,
+                ended_at = startTime + TimeSpan.FromSeconds(180),
                 max_combo = 1337,
                 total_score = 100000,
                 rank = ScoreRank.S,

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/StatisticsUpdateTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/StatisticsUpdateTests.cs
@@ -347,6 +347,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             {
                 while (true)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     var lastValue = db.QueryFirstOrDefault<T>(sql);
                     if ((expected == null && lastValue == null) || expected?.Equals(lastValue) == true)
                         return;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
@@ -1,0 +1,54 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+using Dapper;
+using JetBrains.Annotations;
+using MySqlConnector;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
+{
+    /// <summary>
+    /// Increment total user play time.
+    /// </summary>
+    [UsedImplicitly]
+    public class PlayTimeProcessor : IProcessor
+    {
+        public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
+        {
+            if (previousVersion >= 6)
+                userStats.total_seconds_played -= getPlayLength(score, conn);
+        }
+
+        public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
+        {
+            if (score.ended_at == null)
+                throw new InvalidOperationException("Attempting to increment play time when score was never finished.");
+
+            userStats.total_seconds_played += getPlayLength(score, conn);
+        }
+
+        public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
+        {
+        }
+
+        private static int getPlayLength(SoloScoreInfo score, MySqlConnection conn)
+        {
+            Debug.Assert(score.started_at != null);
+            Debug.Assert(score.ended_at != null);
+
+            // to ensure sanity, first get the maximum time feasible from the beatmap's length
+            int totalLengthSeconds = conn.QueryFirstOrDefault("SELECT total_length FROM osu_beatmaps WHERE beatmap_id = @beatmap_id", score);
+
+            // TODO: apply rate from mods.
+
+            TimeSpan realTimePassed = score.ended_at.Value - score.started_at.Value;
+
+            // TODO: better handle failed plays once we have incoming data.
+
+            return Math.Min(totalLengthSeconds, (int)realTimePassed.TotalSeconds);
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsProcessor.cs
@@ -20,8 +20,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         /// version 3: fixed incorrect revert condition for beatmap/monthly playcount
         /// version 4: uses SoloScore"V2" (moving all content to json data block)
         /// version 5: added performance processor
+        /// version 6: added play time processor
         /// </summary>
-        public const int VERSION = 5;
+        public const int VERSION = 6;
 
         private readonly List<IProcessor> processors = new List<IProcessor>();
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsProcessor.cs
@@ -3,10 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using Dapper;
 using Dapper.Contrib.Extensions;
 using MySqlConnector;
+using osu.Game.Rulesets;
 using osu.Server.QueueProcessor;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
@@ -23,6 +26,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         /// version 6: added play time processor
         /// </summary>
         public const int VERSION = 6;
+
+        public static readonly List<Ruleset> AVAILABLE_RULESETS = getRulesets();
 
         private readonly List<IProcessor> processors = new List<IProcessor>();
 
@@ -172,6 +177,29 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
                     db.Update(userStatsMania, transaction);
                     break;
             }
+        }
+
+        private static List<Ruleset> getRulesets()
+        {
+            const string ruleset_library_prefix = "osu.Game.Rulesets";
+
+            var rulesetsToProcess = new List<Ruleset>();
+
+            foreach (string file in Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, $"{ruleset_library_prefix}.*.dll"))
+            {
+                try
+                {
+                    var assembly = Assembly.LoadFrom(file);
+                    Type type = assembly.GetTypes().First(t => t.IsPublic && t.IsSubclassOf(typeof(Ruleset)));
+                    rulesetsToProcess.Add((Ruleset)Activator.CreateInstance(type)!);
+                }
+                catch
+                {
+                    throw new Exception($"Failed to load ruleset ({file})");
+                }
+            }
+
+            return rulesetsToProcess;
         }
     }
 }


### PR DESCRIPTION
The basics just to get the ball rolling.

We may want to start sending more accurate fail time data from lazer (ie. actual point in gameplay of failure, either as a 0..1 range or as a raw millisecond value based on gameplay time).