### PR TITLE
Use partitioning to allow for parallelised insertion

### DIFF
--- a/osu.Server.Queues.ScorePump/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/ImportHighScores.cs
@@ -54,9 +54,9 @@ namespace osu.Server.Queues.ScorePump
                     $"INSERT INTO {SoloScore.TABLE_NAME} (user_id, beatmap_id, ruleset_id, data, preserve, created_at, updated_at) "
                     + $"VALUES (@userId, @beatmapId, {RulesetId}, @data, 1, @date, @date);"
                     // pp insert
-                    + $"INSERT INTO {SoloScorePerformance.TABLE_NAME} (score_id, pp) VALUES (@@LAST_INSERT_ID, @pp);"
+                    + $"INSERT INTO {SoloScorePerformance.TABLE_NAME} (score_id, pp) VALUES (LAST_INSERT_ID(), @pp);"
                     // mapping insert
-                    + $"INSERT INTO {SoloScoreLegacyIDMap.TABLE_NAME} (ruleset_id, old_score_id, score_id) VALUES ({RulesetId}, @oldScoreId, @@LAST_INSERT_ID);";
+                    + $"INSERT INTO {SoloScoreLegacyIDMap.TABLE_NAME} (ruleset_id, old_score_id, score_id) VALUES ({RulesetId}, @oldScoreId, LAST_INSERT_ID());";
 
                 var userId = insertCommand.Parameters.Add("userId", MySqlDbType.UInt32);
                 var oldScoreId = insertCommand.Parameters.Add("oldScoreId", MySqlDbType.UInt32);

--- a/osu.Server.Queues.ScorePump/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/ImportHighScores.cs
@@ -47,7 +47,6 @@ namespace osu.Server.Queues.ScorePump
             string highScoreTable = LegacyDatabaseHelper.GetRulesetSpecifics(RulesetId).HighScoreTable;
 
             using (var dbMainQuery = Queue.GetDatabaseConnection())
-            using (var db = Queue.GetDatabaseConnection())
             {
                 while (!cancellationToken.IsCancellationRequested)
                 {


### PR DESCRIPTION
Importantly, scores from the same beatmap need to be in the same batch such that the edge case where the `timestamp` is equal for two scores for the same beatmap, the `score_id` will be in correct sequentual order to maintain stable ordering.

Each batch (of 50,000 read scores) is run sequentially, so no special handling is required on the edges of batches.

Before: 7-800 scores per second
After: 8,000 scores per second

Now at the point of replication being the bottleneck, so I'm happy with this where it is for now.