### PR TITLE
Add automatic throttling to `ImportHighScores` based on replication slave latency

### DIFF
--- a/osu.Server.Queues.ScorePump/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/ImportHighScores.cs
@@ -171,7 +171,7 @@ namespace osu.Server.Queues.ScorePump
                 Console.WriteLine($"Current slave latency of {latency} seconds exceeded maximum of {maximum_slave_latency_seconds} seconds.");
                 Console.WriteLine($"Sleeping for {latency} seconds to allow catch-up.");
 
-                Thread.Sleep(latency * 1000);
+                Thread.Sleep(Math.Max(seconds_between_latency_checks * 2, latency * 1000));
 
                 // greatly reduce processing rate to allow for recovery.
                 scoresPerQuery = Math.Max(safe_minimum_scores_per_query, scoresPerQuery / 2);


### PR DESCRIPTION
![Safari 2022-02-24 at 11 22 07](https://user-images.githubusercontent.com/191335/155514993-24b1d960-92dc-4f76-b47c-824f9783e399.png)

worked well until proxysql went and fucking crashed