### PR TITLE
Mark `SoloScoreInfo.id` as non-serialised

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScoreInfo.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScoreInfo.cs
@@ -22,6 +22,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
     [Serializable]
     public class SoloScoreInfo // TODO: hopefully combine with client-side ScoreInfo class.
     {
+        [JsonIgnore]
         public long id { get; set; }
 
         public int user_id { get; set; }


### PR DESCRIPTION
This wasn't being populated in `osu-web` (lazer) inserts, nor in the score pumper.