### PR TITLE
Fix mod masking differences from osu-performance

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/LegacyModsHelperTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/LegacyModsHelperTests.cs
@@ -6,30 +6,63 @@ using Xunit;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 {
+    // See: https://github.com/ppy/osu-performance/blob/83c02f50315a4ef7feea80acb84c66ee437d7210/include/pp/Common.h#L109-L129
     public class LegacyModsHelperTests
     {
         [Fact]
-        public void OnlyBasicRelevantModsAreReturned()
+        public void OsuWithoutFlashlight()
         {
             Assert.Equal(
                 LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy,
-                LegacyModsHelper.MaskRelevantMods(LegacyMods.NoFail | LegacyMods.Perfect | LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy, false));
+                LegacyModsHelper.MaskRelevantMods(LegacyModsHelper.ALL_MODS & ~LegacyMods.Flashlight, false, 0));
         }
 
         [Fact]
-        public void KeyModsAreRelevantForConvertedBeatmaps()
+        public void OsuWithFlashlight()
         {
             Assert.Equal(
-                LegacyMods.DoubleTime | LegacyMods.Key1,
-                LegacyModsHelper.MaskRelevantMods(LegacyMods.DoubleTime | LegacyMods.Key1, true));
+                LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy | LegacyMods.Flashlight | LegacyMods.Hidden,
+                LegacyModsHelper.MaskRelevantMods(LegacyModsHelper.ALL_MODS, false, 0));
         }
 
         [Fact]
-        public void KeyModsAreNotRelevantForManiaSpecificBeatmaps()
+        public void PartialMods()
         {
             Assert.Equal(
                 LegacyMods.DoubleTime,
-                LegacyModsHelper.MaskRelevantMods(LegacyMods.DoubleTime | LegacyMods.Key1, false));
+                LegacyModsHelper.MaskRelevantMods(LegacyMods.DoubleTime, false, 0));
+        }
+
+        [Fact]
+        public void Taiko()
+        {
+            Assert.Equal(
+                LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy,
+                LegacyModsHelper.MaskRelevantMods(LegacyModsHelper.ALL_MODS, false, 1));
+        }
+
+        [Fact]
+        public void Catch()
+        {
+            Assert.Equal(
+                LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy,
+                LegacyModsHelper.MaskRelevantMods(LegacyModsHelper.ALL_MODS, false, 2));
+        }
+
+        [Fact]
+        public void ManiaNonConvert()
+        {
+            Assert.Equal(
+                LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy,
+                LegacyModsHelper.MaskRelevantMods(LegacyModsHelper.ALL_MODS, false, 3));
+        }
+
+        [Fact]
+        public void ManiaConvert()
+        {
+            Assert.Equal(
+                LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy | LegacyModsHelper.KEY_MODS,
+                LegacyModsHelper.MaskRelevantMods(LegacyModsHelper.ALL_MODS, true, 3));
         }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/LegacyModsHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/LegacyModsHelper.cs
@@ -16,27 +16,20 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         // See: https://github.com/ppy/osu-performance/blob/83c02f50315a4ef7feea80acb84c66ee437d7210/include/pp/Common.h#L109-L129
         public static LegacyMods MaskRelevantMods(LegacyMods mods, bool isConvertedBeatmap, int rulesetId)
         {
-            LegacyMods relevantMods;
+            LegacyMods relevantMods = LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy;
 
             switch (rulesetId)
             {
                 case 0:
                     if ((mods & LegacyMods.Flashlight) > 0)
-                        relevantMods = LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy | LegacyMods.Flashlight | LegacyMods.Hidden;
+                        relevantMods |= LegacyMods.Flashlight | LegacyMods.Hidden;
                     else
-                        relevantMods = LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy | LegacyMods.Flashlight;
-                    break;
-
-                case 1:
-                case 2:
-                    relevantMods = LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy;
+                        relevantMods |= LegacyMods.Flashlight;
                     break;
 
                 case 3:
                     if (isConvertedBeatmap)
-                        relevantMods = LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy | KEY_MODS;
-                    else
-                        relevantMods = LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy;
+                        relevantMods |= KEY_MODS;
                     break;
 
                 default:

--- a/osu.Server.Queues.ScoreStatisticsProcessor/LegacyModsHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/LegacyModsHelper.cs
@@ -1,23 +1,49 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Game.Beatmaps.Legacy;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor
 {
     public class LegacyModsHelper
     {
-        public static LegacyMods MaskRelevantMods(LegacyMods mods, bool isConvertedBeatmap)
-        {
-            LegacyMods relevantMods = LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy;
+        public const LegacyMods ALL_MODS = (LegacyMods)int.MaxValue;
 
-            if (isConvertedBeatmap)
-                relevantMods |= keyMods;
+        public const LegacyMods KEY_MODS = LegacyMods.Key1 | LegacyMods.Key2 | LegacyMods.Key3 | LegacyMods.Key4 | LegacyMods.Key5 | LegacyMods.Key6 | LegacyMods.Key7 | LegacyMods.Key8
+                                           | LegacyMods.Key9 | LegacyMods.KeyCoop;
+
+        // See: https://github.com/ppy/osu-performance/blob/83c02f50315a4ef7feea80acb84c66ee437d7210/include/pp/Common.h#L109-L129
+        public static LegacyMods MaskRelevantMods(LegacyMods mods, bool isConvertedBeatmap, int rulesetId)
+        {
+            LegacyMods relevantMods;
+
+            switch (rulesetId)
+            {
+                case 0:
+                    if ((mods & LegacyMods.Flashlight) > 0)
+                        relevantMods = LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy | LegacyMods.Flashlight | LegacyMods.Hidden;
+                    else
+                        relevantMods = LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy | LegacyMods.Flashlight;
+                    break;
+
+                case 1:
+                case 2:
+                    relevantMods = LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy;
+                    break;
+
+                case 3:
+                    if (isConvertedBeatmap)
+                        relevantMods = LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy | KEY_MODS;
+                    else
+                        relevantMods = LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy;
+                    break;
+
+                default:
+                    throw new ArgumentException($"Invalid ruleset ID: {rulesetId}");
+            }
 
             return mods & relevantMods;
         }
-
-        private static LegacyMods keyMods => LegacyMods.Key1 | LegacyMods.Key2 | LegacyMods.Key3 | LegacyMods.Key4 | LegacyMods.Key5 | LegacyMods.Key6 | LegacyMods.Key7 | LegacyMods.Key8
-                                             | LegacyMods.Key9 | LegacyMods.Key1;
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PerformanceProcessor.cs
@@ -50,7 +50,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             }, transaction);
 
             // Todo: We shouldn't be using legacy mods, but this requires difficulty calculation to be performed in-line.
-            LegacyMods legacyModValue = LegacyModsHelper.MaskRelevantMods(ruleset.ConvertToLegacyMods(mods), score.RulesetID != beatmap.playmode);
+            LegacyMods legacyModValue = LegacyModsHelper.MaskRelevantMods(ruleset.ConvertToLegacyMods(mods), score.RulesetID != beatmap.playmode, score.RulesetID);
 
             var rawDifficultyAttribs = conn.Query<BeatmapDifficultyAttribute>(
                 "SELECT * FROM osu_beatmap_difficulty_attribs WHERE beatmap_id = @BeatmapId AND mode = @RulesetId AND mods = @ModValue", new


### PR DESCRIPTION
Two issues fixed with this one:
1. The old `LegacyModsHelper.keyMods` value doubled up `Key1`, but intended to use `KeyCoop` for that last one.
2. It didn't include all the new FL/FL+HD combos.