### PR TITLE
Import highscore date into `score->data->ended_at`

### DIFF
--- a/osu.Server.Queues.ScorePump/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/ImportHighScores.cs
@@ -288,6 +288,7 @@ namespace osu.Server.Queues.ScorePump
                             rank = Enum.TryParse(highScore.rank, out ScoreRank parsed) ? parsed : ScoreRank.D,
                             mods = ruleset.ConvertFromLegacyMods((LegacyMods)highScore.enabled_mods).Select(m => new APIMod(m)).ToList(),
                             statistics = statistics,
+                            ended_at = highScore.date
                         });
 
                         insertCommand.Transaction = transaction;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
@@ -39,7 +39,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         private static int getPlayLength(SoloScoreInfo score, MySqlConnection conn, MySqlTransaction transaction)
         {
-            Debug.Assert(score.started_at != null);
             Debug.Assert(score.ended_at != null);
 
             // to ensure sanity, first get the maximum time feasible from the beatmap's length
@@ -52,10 +51,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             foreach (var mod in rateAdjustMods)
                 totalLengthSeconds /= mod.SpeedChange.Value;
 
-            TimeSpan realTimePassed = score.ended_at.Value - score.started_at.Value;
+            if (score.started_at == null)
+                return (int)totalLengthSeconds;
 
             // TODO: better handle failed plays once we have incoming data.
 
+            TimeSpan realTimePassed = score.ended_at.Value - score.started_at.Value;
             return (int)Math.Min(totalLengthSeconds, realTimePassed.TotalSeconds);
         }
     }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-queue-score-statistics/issues/40

I'm not sure how you'd go about fixing the already imported scores server-side - fastest for me was reimporting all scores.

Have tested to make sure the score processors are able to run.