### PR TITLE
👷 Add Docker builds

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -1,0 +1,63 @@
+name: Build and publish
+
+on:
+  push:
+    branches:
+      - master
+      - production
+    tags:
+      - '*'
+
+jobs:
+  push_to_registry:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - image: pppy/osu-queue-score-statistics
+            context: ./osu.Server.Queues.ScoreStatisticsProcessor
+            file: ./osu.Server.Queues.ScoreStatisticsProcessor/Dockerfile
+          - image: pppy/osu-queue-score-pump
+            context: ./
+            file: ./osu.Server.Queues.ScorePump/Dockerfile
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ${{ matrix.image }}
+          # generate Docker tags based on the following events/attributes
+          # on tag event: tag using git tag, and as latest if the tag doesn't contain hyphens (pre-releases)
+          # on push event: tag using git sha, branch name and as latest-dev
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
+            type=raw,value=latest-dev,enable=${{ github.ref_type == 'branch' && github.ref_name == 'master' }}
+            type=raw,value=${{ github.ref_name }}
+            type=raw,value=${{ github.sha }},enable=${{ github.ref_type == 'branch' }}
+          flavor: |
+            latest=false
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Same workflow as osu-web, but also added builds for the production branch.

- Push as git tag on git tag
- Push as latest on git tag, if tag doesn't contain a -
- Push as master and latest-dev on commit to master
- Push as production on commit to production
- Push as git sha on commit to master or production

Also added builds for pppy/osu-queue-score-pump. I know it's temporary but it didn't cost much