### PR TITLE
Fix `watch` command failing with empty `solo_scores_process_history` table

### DIFF
--- a/osu.Server.Queues.ScorePump/Queue/WatchNewScores.cs
+++ b/osu.Server.Queues.ScorePump/Queue/WatchNewScores.cs
@@ -32,7 +32,7 @@ namespace osu.Server.Queues.ScorePump.Queue
             else
             {
                 using (var db = Queue.GetDatabaseConnection())
-                    lastId = db.QuerySingle<long>("SELECT MAX(score_id) FROM solo_scores_process_history");
+                    lastId = db.QuerySingleOrDefault<long?>("SELECT MAX(score_id) FROM solo_scores_process_history") ?? 0;
             }
 
             while (true)


### PR DESCRIPTION
This was brought up in Discord a few days ago and still hasn't been fixed, thought I'd do it myself.