### PR TITLE
Fix `max_combo` overflowing on database reads

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/UserStats.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/UserStats.cs
@@ -34,7 +34,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
         public int replay_popularity { get; set; }
         public int fail_count { get; set; }
         public int exit_count { get; set; }
-        public short max_combo { get; set; }
+        public ushort max_combo { get; set; }
         public string country_acronym { get; set; } = "XX";
         public float rank_score { get; set; }
         public int rank_score_index { get; set; }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MaxComboProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MaxComboProcessor.cs
@@ -43,7 +43,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 return;
 
             // TODO: assert the user's score is not higher than the max combo for the beatmap.
-            userStats.max_combo = (short)Math.Max(userStats.max_combo, score.MaxCombo);
+            userStats.max_combo = Math.Max(userStats.max_combo, (ushort)score.MaxCombo);
         }
 
         public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)


### PR DESCRIPTION
This is hit by https://osu.ppy.sh/users/3909293/mania

```
diffcalc-sheet-generator-ppcalc-1     | Unhandled exception. System.Data.DataException: Error parsing column 21 (max_combo=35512 - UInt16)
diffcalc-sheet-generator-ppcalc-1     |  ---> System.OverflowException: Arithmetic operation resulted in an overflow.
diffcalc-sheet-generator-ppcalc-1     |    at Deserialize3ea6bb68-1c57-4ca9-b908-aa2fb993cdd6(IDataReader )
diffcalc-sheet-generator-ppcalc-1     |    --- End of inner exception stack trace ---
diffcalc-sheet-generator-ppcalc-1     |    at Dapper.SqlMapper.ThrowDataException(Exception ex, Int32 index, IDataReader reader, Object value) in /_/Dapper/SqlMapper.cs:line 3706
diffcalc-sheet-generator-ppcalc-1     |    at Deserialize3ea6bb68-1c57-4ca9-b908-aa2fb993cdd6(IDataReader )
diffcalc-sheet-generator-ppcalc-1     |    at Dapper.SqlMapper.QueryRowAsync[T](IDbConnection cnn, Row row, Type effectiveType, CommandDefinition command)
diffcalc-sheet-generator-ppcalc-1     |    at osu.Server.Queues.ScoreStatisticsProcessor.DatabaseHelper.getUserStatsAsync[T](Int32 userId, Int32 rulesetId, MySqlConnection db, MySqlTransaction transaction)
diffcalc-sheet-generator-ppcalc-1     |    at osu.Server.Queues.ScoreStatisticsProcessor.DatabaseHelper.GetUserStatsAsync(Int32 userId, Int32 rulesetId, MySqlConnection db, MySqlTransaction transaction)
diffcalc-sheet-generator-ppcalc-1     |    at osu.Server.Queues.ScorePump.Performance.PerformanceCommand.<>c__DisplayClass20_0.<<ProcessUserTotals>b__0>d.MoveNext()
diffcalc-sheet-generator-ppcalc-1     | --- End of stack trace from previous location ---
diffcalc-sheet-generator-ppcalc-1     |    at osu.Server.Queues.ScorePump.Performance.PerformanceCommand.<>c__DisplayClass22_0`1.<<ProcessPartitioned>g__processPartition|0>d.MoveNext()
diffcalc-sheet-generator-ppcalc-1     | --- End of stack trace from previous location ---
diffcalc-sheet-generator-ppcalc-1     |    at osu.Server.Queues.ScorePump.Performance.PerformanceCommand.ProcessPartitioned[T](IEnumerable`1 values, Func`2 processFunc, CancellationToken cancellationToken)
diffcalc-sheet-generator-ppcalc-1     |    at osu.Server.Queues.ScorePump.Performance.PerformanceCommand.ProcessUserTotals(Int32[] userIds, CancellationToken cancellationToken)
diffcalc-sheet-generator-ppcalc-1     |    at osu.Server.Queues.ScorePump.Performance.UserTotals.UpdateAllUserTotals.ExecuteAsync(CancellationToken cancellationToken)
diffcalc-sheet-generator-ppcalc-1     |    at osu.Server.Queues.ScorePump.Performance.PerformanceCommand.OnExecuteAsync(CancellationToken cancellationToken)
diffcalc-sheet-generator-ppcalc-1     |    at McMaster.Extensions.CommandLineUtils.Conventions.ExecuteMethodConvention.InvokeAsync(MethodInfo method, Object instance, Object[] arguments)
diffcalc-sheet-generator-ppcalc-1     |    at McMaster.Extensions.CommandLineUtils.Conventions.ExecuteMethodConvention.OnExecute(ConventionContext context, CancellationToken cancellationToken)
diffcalc-sheet-generator-ppcalc-1     |    at McMaster.Extensions.CommandLineUtils.Conventions.ExecuteMethodConvention.<>c__DisplayClass0_0.<<Apply>b__0>d.MoveNext()
diffcalc-sheet-generator-ppcalc-1     | --- End of stack trace from previous location ---
diffcalc-sheet-generator-ppcalc-1     |    at McMaster.Extensions.CommandLineUtils.CommandLineApplication.ExecuteAsync(String[] args, CancellationToken cancellationToken)
diffcalc-sheet-generator-ppcalc-1     |    at McMaster.Extensions.CommandLineUtils.CommandLineApplication.ExecuteAsync[TApp](CommandLineContext context, CancellationToken cancellationToken)
diffcalc-sheet-generator-ppcalc-1     |    at osu.Server.Queues.ScorePump.Program.Main(String[] args)
diffcalc-sheet-generator-ppcalc-1     |    at osu.Server.Queues.ScorePump.Program.<Main>(String[] args)
```

There are a few other ones that differ, but are mostly inconsequential and can be done in separate PRs or not at all (they also ripple through the codebase a bit). For example:
![image](https://user-images.githubusercontent.com/1329837/184793655-d4a26c1a-e312-4035-89e1-c4356c14bd4e.png)
![image](https://user-images.githubusercontent.com/1329837/184794285-5c7dbe64-ddf8-492f-8403-11c55f834593.png)
