### PR TITLE
Change CI to use release branch for pushes

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - production
+      - release
     tags:
       - '*'
 


### PR DESCRIPTION
Since we're going to be using `release` for consistency across projects. The branch already exists and has been pushed from `production`. `production` still exists but will be removed when this PR is merged.