### PR TITLE
Backport: Add osu!lazer score `maximum_statistics` upgrade command

### DIFF
--- a/osu.Server.Queues.ScorePump/AddMaximumStatisticsToLazerScores.cs
+++ b/osu.Server.Queues.ScorePump/AddMaximumStatisticsToLazerScores.cs
@@ -50,10 +50,7 @@ namespace osu.Server.Queues.ScorePump
                         }, transaction)).ToArray();
 
                         if (scores.Length == 0)
-                        {
-                            Console.WriteLine("Finished.");
                             break;
-                        }
 
                         foreach (var score in scores)
                         {
@@ -68,9 +65,13 @@ namespace osu.Server.Queues.ScorePump
                 }
 
                 if (Delay > 0)
+                {
+                    Console.WriteLine($"Waiting {Delay}ms...");
                     await Task.Delay(Delay, cancellationToken);
+                }
             }
 
+            Console.WriteLine("Finished.");
             return 0;
         }
 

--- a/osu.Server.Queues.ScorePump/AddMaximumStatisticsToLazerScores.cs
+++ b/osu.Server.Queues.ScorePump/AddMaximumStatisticsToLazerScores.cs
@@ -28,6 +28,12 @@ namespace osu.Server.Queues.ScorePump
         [Option(CommandOptionType.SingleValue)]
         public long StartId { get; set; }
 
+        /// <summary>
+        /// The amount of time to sleep between score batches.
+        /// </summary>
+        [Option(CommandOptionType.SingleValue)]
+        public int Delay { get; set; }
+
         public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
         {
             while (!cancellationToken.IsCancellationRequested)
@@ -60,6 +66,9 @@ namespace osu.Server.Queues.ScorePump
                         StartId = scores.Max(s => s.id) + 1;
                     }
                 }
+
+                if (Delay > 0)
+                    await Task.Delay(Delay, cancellationToken);
             }
 
             return 0;

--- a/osu.Server.Queues.ScorePump/AddMaximumStatisticsToLazerScores.cs
+++ b/osu.Server.Queues.ScorePump/AddMaximumStatisticsToLazerScores.cs
@@ -1,0 +1,105 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using Dapper.Contrib.Extensions;
+using McMaster.Extensions.CommandLineUtils;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+using osu.Server.Queues.ScoreStatisticsProcessor;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScorePump
+{
+    [Command("add-maximum-statistics-to-lazer-scores", Description = "Updates the stored solo score data.")]
+    public class AddMaximumStatisticsToLazerScores : ScorePump
+    {
+        private const int batch_size = 10000;
+
+        /// <summary>
+        /// The score ID to start the process from. This can be used to resume an existing job.
+        /// </summary>
+        [Option(CommandOptionType.SingleValue)]
+        public long StartId { get; set; }
+
+        public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                Console.WriteLine($"Processing next {batch_size} scores starting from {StartId}");
+
+                using (var db = Queue.GetDatabaseConnection())
+                {
+                    using (var transaction = await db.BeginTransactionAsync(cancellationToken))
+                    {
+                        SoloScore[] scores = (await db.QueryAsync<SoloScore>($"SELECT * FROM {SoloScore.TABLE_NAME} WHERE `id` >= @StartId", new
+                        {
+                            StartId = StartId
+                        }, transaction)).ToArray();
+
+                        if (scores.Length == 0)
+                        {
+                            Console.WriteLine("Finished.");
+                            break;
+                        }
+
+                        foreach (var score in scores)
+                        {
+                            if (ensureMaximumStatistics(score))
+                                await db.UpdateAsync(score, transaction);
+                        }
+
+                        await transaction.CommitAsync(cancellationToken);
+
+                        StartId = scores.Max(s => s.id) + 1;
+                    }
+                }
+            }
+
+            return 0;
+        }
+
+        private bool ensureMaximumStatistics(SoloScore score)
+        {
+            if (score.ScoreInfo.maximum_statistics.Count > 0)
+                return false;
+
+            Ruleset ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(score.ruleset_id);
+            HitResult maxBasicResult = ruleset.GetHitResults().Select(h => h.result).Where(h => h.IsBasic()).MaxBy(Judgement.ToNumericResult);
+
+            foreach ((HitResult result, int count) in score.ScoreInfo.statistics)
+            {
+                switch (result)
+                {
+                    case HitResult.LargeTickHit:
+                    case HitResult.LargeTickMiss:
+                        score.ScoreInfo.maximum_statistics[HitResult.LargeTickHit] = score.ScoreInfo.maximum_statistics.GetValueOrDefault(HitResult.LargeTickHit) + count;
+                        break;
+
+                    case HitResult.SmallTickHit:
+                    case HitResult.SmallTickMiss:
+                        score.ScoreInfo.maximum_statistics[HitResult.SmallTickHit] = score.ScoreInfo.maximum_statistics.GetValueOrDefault(HitResult.SmallTickHit) + count;
+                        break;
+
+                    case HitResult.IgnoreHit:
+                    case HitResult.IgnoreMiss:
+                    case HitResult.SmallBonus:
+                    case HitResult.LargeBonus:
+                        break;
+
+                    default:
+                        score.ScoreInfo.maximum_statistics[maxBasicResult] = score.ScoreInfo.maximum_statistics.GetValueOrDefault(maxBasicResult) + count;
+                        break;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/osu.Server.Queues.ScorePump/Program.cs
+++ b/osu.Server.Queues.ScorePump/Program.cs
@@ -8,6 +8,7 @@ namespace osu.Server.Queues.ScorePump
     [Subcommand(typeof(WatchNewScores))]
     [Subcommand(typeof(ClearQueue))]
     [Subcommand(typeof(ImportHighScores))]
+    [Subcommand(typeof(AddMaximumStatisticsToLazerScores))]
     public class Program
     {
         public static void Main(string[] args)

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/StatisticsUpdateTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/StatisticsUpdateTests.cs
@@ -210,7 +210,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                     db.Execute($"UPDATE osu_beatmaps SET approved = 0 WHERE beatmap_id = {test_beatmap_id}");
 
                 var testScore = CreateTestScore();
-                testScore.Score.ScoreInfo.MaxCombo++;
+                testScore.Score.ScoreInfo.max_combo++;
 
                 processor.PushToQueue(testScore);
                 waitForDatabaseState("SELECT max_combo FROM osu_user_stats WHERE user_id = 2", max_combo, cts.Token);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs
@@ -55,9 +55,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
         [JsonIgnore]
         public DateTimeOffset updated_at { get; set; }
 
-        [JsonIgnore]
-        public DateTimeOffset? deleted_at { get; set; }
-
         public override string ToString() => $"score_id: {id} user_id: {user_id}";
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScoreInfo.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScoreInfo.cs
@@ -52,6 +52,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 
         public Dictionary<HitResult, int> statistics { get; set; } = new Dictionary<HitResult, int>();
 
+        public Dictionary<HitResult, int> maximum_statistics { get; set; } = new Dictionary<HitResult, int>();
+
         public override string ToString() => $"score_id: {id} user_id: {user_id}";
 
         [JsonIgnore]


### PR DESCRIPTION
**This is a `release` branch pull request!!**

Also contains https://github.com/ppy/osu-queue-score-statistics/pull/74  
This has only been PR'd to this branch because it's expected to be executed only once.

The `add-maximum-statistics-to-lazer-scores` command adds the `maximum_statistics` dictionary to all scores in the database.

I previously asked for the last 10000 scores in the `solo_scores` table. Here's the results of running this command on them: https://drive.google.com/file/d/1cbcTZEBtU1GnM4-unCZF5g8LP9or4y4U/view?usp=sharing **This is a 10MB text file, be careful!!**