### PR TITLE
Make the highscore importer provide the `MaximumStatistics` dictionary

### DIFF
--- a/osu.Server.Queues.ScorePump/Queue/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/Queue/ImportHighScores.cs
@@ -393,7 +393,10 @@ namespace osu.Server.Queues.ScorePump.Queue
                     }, transaction);
 
                 if (maxComboFromAttributes == null)
-                    throw new InvalidOperationException($"{highScore.score_id}: Could not find difficulty attributes for beatmap {highScore.beatmap_id} in the database.");
+                {
+                    await Console.Error.WriteLineAsync($"{highScore.score_id}: Could not find difficulty attributes for beatmap {highScore.beatmap_id} in the database.");
+                    return scoreInfo;
+                }
 
 #pragma warning disable CS0618
                 if (maxComboFromAttributes > maxComboFromStatistics)

--- a/osu.Server.Queues.ScorePump/Queue/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/Queue/ImportHighScores.cs
@@ -270,7 +270,7 @@ namespace osu.Server.Queues.ScorePump.Queue
 
                     foreach (var highScore in scores)
                     {
-                        ScoreInfo referenceScore = await createScoreInfo(ruleset, highScore, db, transaction);
+                        ScoreInfo referenceScore = await createReferenceScore(ruleset, highScore, db, transaction);
 
                         pp.Value = highScore.pp;
                         userId.Value = highScore.user_id;
@@ -308,7 +308,17 @@ namespace osu.Server.Queues.ScorePump.Queue
                 }
             }
 
-            private async Task<ScoreInfo> createScoreInfo(Ruleset ruleset, HighScore highScore, MySqlConnection connection, MySqlTransaction transaction)
+            /// <summary>
+            /// Creates a partially-populated "reference" score that provides:
+            /// <list type="bullet">
+            /// <item><term><see cref="ScoreInfo.Ruleset"/></term></item>
+            /// <item><term><see cref="ScoreInfo.Accuracy"/></term></item>
+            /// <item><term><see cref="ScoreInfo.Mods"/></term></item>
+            /// <item><term><see cref="ScoreInfo.Statistics"/></term></item>
+            /// <item><term><see cref="ScoreInfo.MaximumStatistics"/></term></item>
+            /// </list>
+            /// </summary>
+            private async Task<ScoreInfo> createReferenceScore(Ruleset ruleset, HighScore highScore, MySqlConnection connection, MySqlTransaction transaction)
             {
                 var scoreInfo = new ScoreInfo
                 {

--- a/osu.Server.Queues.ScorePump/Queue/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/Queue/ImportHighScores.cs
@@ -363,6 +363,11 @@ namespace osu.Server.Queues.ScorePump.Queue
                 // A special hit result is used to pad out the combo value to match, based on the max combo from the beatmap attributes.
                 int maxComboFromStatistics = scoreInfo.MaximumStatistics.Where(kvp => kvp.Key.AffectsCombo()).Select(kvp => kvp.Value).DefaultIfEmpty(0).Sum();
 
+                // Note that using BeatmapStore will fail if a particular difficulty attribute value doesn't exist in the database.
+                // To get around this, we'll specifically look up the attribute directly from the database, utilising the most primitive mod lookup value
+                // for the ruleset in order to prevent an additional failures if some new mod combinations were added as difficulty adjustment mods.
+                // This is a little bit hacky and wouldn't be required if the databased attributes were always in-line with osu!lazer, but that's not the case.
+
                 int difficultyMods = 0;
 
                 switch (ruleset.RulesetInfo.OnlineID)

--- a/osu.Server.Queues.ScorePump/osu.Server.Queues.ScorePump.csproj
+++ b/osu.Server.Queues.ScorePump/osu.Server.Queues.ScorePump.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
-        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.603.0" />
+        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.812.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/osu.Server.Queues.ScoreStatisticsProcessor.Tests.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/osu.Server.Queues.ScoreStatisticsProcessor.Tests.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DeepEqual" Version="2.0.0" />
+        <PackageReference Include="DeepEqual" Version="4.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
@@ -11,12 +11,12 @@
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-        <PackageReference Include="ppy.osu.Game" Version="2022.719.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.719.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.719.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.719.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.719.0" />
-        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.603.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2022.901.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.901.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.901.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.901.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.901.0" />
+        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.812.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Prereqs:
- [x] Updated osu.Game package.
- [x] osu-difficulty-calculator to have been re-run for osu!mania with https://github.com/ppy/osu-difficulty-calculator/tree/release-diffcalc + https://github.com/ppy/osu/tree/release-diffcalc
- [x] https://github.com/ppy/osu/pull/20028

The purpose of this PR is to add the `MaximumStatistics` dictionary to imported scores.
- First we convert every hit type to the corresponding "accurate" version. For example for an `ok` result, the accurate version is `great` in osu/taiko/catch and `perfect` in mania. This is done via [`Ruleset.GetHitResults()`](https://github.com/ppy/osu/blob/289b6f1a583dc50e84cadff713808f43fddc7ff0/osu.Game/Rulesets/Ruleset.cs#L310-L339) as mentioned at in my [original PR](https://github.com/ppy/osu/pull/19939).
- Then, we compare the combo from those statistics to the combo in the `osu_beatmap_difficulty_attributes` table (`attrib_id = 9`), and add a `legacy_combo_increase` hit result to bring them up to the same level if they don't match. This only shows up for osu/mania - taiko/catch have accurate combo counts from score statistics alone.

I have checked that combo count is accurate for osu, **however** mania combo is a few combo off because osu!stable is silly and allows players to get more maximum combo than should actually be possible via hold notes. I'm unsure how to deal with this yet - but I gather we can do a separate pass over it later on.

Additionally, this PR migrates total score into `LegacyTotalScore`.

Sample files:
[osu.txt](https://github.com/ppy/osu-queue-score-statistics/files/9450699/osu.txt)
[taiko.txt](https://github.com/ppy/osu-queue-score-statistics/files/9450701/taiko.txt)
[catch.txt](https://github.com/ppy/osu-queue-score-statistics/files/9450704/catch.txt)
[mania.txt](https://github.com/ppy/osu-queue-score-statistics/files/9450706/mania.txt)

Imported from the top-1000 dumps on https://data.ppy.sh