### PR TITLE
Import `has_replay` and `legacy_score_id` into solo scores

### DIFF
--- a/osu.Server.Queues.ScorePump/Queue/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/Queue/ImportHighScores.cs
@@ -292,7 +292,9 @@ namespace osu.Server.Queues.ScorePump.Queue
                             Statistics = referenceScore.Statistics,
                             MaximumStatistics = referenceScore.MaximumStatistics,
                             EndedAt = highScore.date,
-                            LegacyTotalScore = highScore.score
+                            HasReplay = highScore.replay,
+                            LegacyTotalScore = highScore.score,
+                            LegacyScoreId = highScore.score_id
                         });
 
                         insertCommand.Transaction = transaction;

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/osu.Server.Queues.ScoreStatisticsProcessor.Tests.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/osu.Server.Queues.ScoreStatisticsProcessor.Tests.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="DeepEqual" Version="4.0.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>

--- a/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
@@ -11,11 +11,11 @@
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-        <PackageReference Include="ppy.osu.Game" Version="2022.901.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.901.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.901.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.901.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.901.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2022.902.2" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.902.2" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.902.2" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.902.2" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.902.2" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.812.0" />
     </ItemGroup>
 


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/20070

Resolves https://github.com/ppy/osu-queue-score-statistics/issues/70

```
mysql> select * from osu_scores_high where replay=1 limit 1;
+----------+------------+---------+--------+----------+------+---------+----------+----------+-----------+-----------+-----------+---------+--------------+---------------------+---------+--------+--------+-----------------+
| score_id | beatmap_id | user_id | score  | maxcombo | rank | count50 | count100 | count300 | countmiss | countgeki | countkatu | perfect | enabled_mods | date                | pp      | replay | hidden | country_acronym |
+----------+------------+---------+--------+----------+------+---------+----------+----------+-----------+-----------+-----------+---------+--------------+---------------------+---------+--------+--------+-----------------+
|  5230054 |      12943 |   39828 | 583841 |      274 | XH   |       0 |        0 |      116 |         0 |        35 |         0 |       1 |         1136 | 2008-10-16 04:30:01 | 31.0558 |      1 |      0 | PL              |
+----------+------------+---------+--------+----------+------+---------+----------+----------+-----------+-----------+-----------+---------+--------------+---------------------+---------+--------+--------+-----------------+
1 row in set (0.00 sec)

mysql> select * from solo_scores where data->'$.legacy_score_id' = 5230054;
+----+---------+------------+------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------+----------+---------------------+---------------------+
| id | user_id | beatmap_id | ruleset_id | data                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | has_replay | preserve | created_at          | updated_at          |
+----+---------+------------+------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------+----------+---------------------+---------------------+
| 76 |   39828 |      12943 |          0 | {"mods": [{"acronym": "DT"}, {"acronym": "SD"}, {"acronym": "FL"}, {"acronym": "HR"}], "rank": "XH", "passed": true, "user_id": 39828, "accuracy": 1.0, "build_id": null, "ended_at": "2008-10-16T04:30:01+00:00", "max_combo": 274, "beatmap_id": 12943, "has_replay": true, "ruleset_id": 0, "started_at": null, "statistics": {"great": 116}, "total_score": 300000, "legacy_score_id": 5230054, "legacy_total_score": 583841, "maximum_statistics": {"great": 116, "legacy_combo_increase": 158}} |          0 |        1 | 2008-10-16 04:30:01 | 2008-10-16 04:30:01 |
+----+---------+------------+------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------+----------+---------------------+---------------------+
1 row in set (0.21 sec)
```