### PR TITLE
Import `has_replay` into column instead

### DIFF
--- a/osu.Server.Queues.ScorePump/Queue/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/Queue/ImportHighScores.cs
@@ -252,8 +252,8 @@ namespace osu.Server.Queues.ScorePump.Queue
                 {
                     insertCommand.CommandText =
                         // main score insert
-                        $"INSERT INTO {SoloScore.TABLE_NAME} (user_id, beatmap_id, ruleset_id, data, preserve, created_at, updated_at) "
-                        + $"VALUES (@userId, @beatmapId, {ruleset.RulesetInfo.OnlineID}, @data, 1, @date, @date);"
+                        $"INSERT INTO {SoloScore.TABLE_NAME} (user_id, beatmap_id, ruleset_id, data, has_replay, preserve, created_at, updated_at) "
+                        + $"VALUES (@userId, @beatmapId, {ruleset.RulesetInfo.OnlineID}, @data, @has_replay, 1, @date, @date);"
                         // pp insert
                         + $"INSERT INTO {SoloScorePerformance.TABLE_NAME} (score_id, pp) VALUES (LAST_INSERT_ID(), @pp);"
                         // mapping insert
@@ -264,6 +264,7 @@ namespace osu.Server.Queues.ScorePump.Queue
                     var beatmapId = insertCommand.Parameters.Add("beatmapId", MySqlDbType.UInt24);
                     var data = insertCommand.Parameters.Add("data", MySqlDbType.JSON);
                     var date = insertCommand.Parameters.Add("date", MySqlDbType.DateTime);
+                    var hasReplay = insertCommand.Parameters.Add("has_replay", MySqlDbType.Bool);
                     var pp = insertCommand.Parameters.Add("pp", MySqlDbType.Float);
 
                     await insertCommand.PrepareAsync();
@@ -277,6 +278,7 @@ namespace osu.Server.Queues.ScorePump.Queue
                         oldScoreId.Value = highScore.score_id;
                         beatmapId.Value = highScore.beatmap_id;
                         date.Value = highScore.date;
+                        hasReplay.Value = highScore.replay;
                         data.Value = JsonConvert.SerializeObject(new SoloScoreInfo
                         {
                             // id will be written below in the UPDATE call.
@@ -292,7 +294,6 @@ namespace osu.Server.Queues.ScorePump.Queue
                             Statistics = referenceScore.Statistics,
                             MaximumStatistics = referenceScore.MaximumStatistics,
                             EndedAt = highScore.date,
-                            HasReplay = highScore.replay,
                             LegacyTotalScore = highScore.score,
                             LegacyScoreId = highScore.score_id
                         });

--- a/osu.Server.Queues.ScorePump/Queue/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/Queue/ImportHighScores.cs
@@ -296,6 +296,9 @@ namespace osu.Server.Queues.ScorePump.Queue
                             EndedAt = highScore.date,
                             LegacyTotalScore = highScore.score,
                             LegacyScoreId = highScore.score_id
+                        }, new JsonSerializerSettings
+                        {
+                            DefaultValueHandling = DefaultValueHandling.Ignore
                         });
 
                         insertCommand.Transaction = transaction;


### PR DESCRIPTION
Re-closes https://github.com/ppy/osu-queue-score-statistics/issues/70

Two changes here:

## 1. Import `has_replay` into column instead.

See: https://github.com/ppy/osu-queue-score-statistics/pull/79#issuecomment-1235164890

```
mysql> select * from solo_scores where has_replay = 1 limit 1;
+----+---------+------------+------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------+----------+---------------------+---------------------+
| id | user_id | beatmap_id | ruleset_id | data                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | has_replay | preserve | created_at          | updated_at          |
+----+---------+------------+------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------+----------+---------------------+---------------------+
| 17 |   84841 |      23919 |          0 | {"mods": [{"acronym": "DT"}, {"acronym": "HR"}, {"acronym": "HD"}], "rank": "SH", "passed": true, "user_id": 84841, "accuracy": 0.9717514124293786, "build_id": null, "ended_at": "2009-06-11T04:44:47+00:00", "max_combo": 207, "beatmap_id": 23919, "has_replay": false, "ruleset_id": 0, "started_at": null, "statistics": {"ok": 5, "great": 113}, "total_score": 291525, "legacy_score_id": 22469362, "legacy_total_score": 404136, "maximum_statistics": {"great": 118, "legacy_combo_increase": 89}} |          1 |        1 | 2009-06-11 04:44:47 | 2009-06-11 04:44:47 |
+----+---------+------------+------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------+----------+---------------------+---------------------+
1 row in set (0.00 sec)
```

## 2. Don't include default values.

My assertion in https://github.com/ppy/osu-queue-score-statistics/pull/79#issuecomment-1235087994 wasn't entirely true, because I was testing using osu!-side's `TestSoloScoreInfoJsonSerialization` which uses our in-house `.Serialize()` method that ignores default values. This project instead uses `JsonConvert` directly, and the default is to actually _include_ them.

**Note:** This also forgoes serialisation of `"ruleset_id": 0`. If that's seen as an issue then it will be an osu!-side change to explicitly include that property.

Before:
```json
[
    {
        "id": 14,
        "user_id": 84841,
        "beatmap_id": 23919,
        "ruleset_id": 0,
        "data": {
            "mods": [
                {
                    "acronym": "DT"
                },
                {
                    "acronym": "HR"
                },
                {
                    "acronym": "HD"
                }
            ],
            "rank": "SH",
            "passed": true,
            "user_id": 84841,
            "accuracy": 0.9717514124293786,
            "build_id": null,
            "ended_at": "2009-06-11T04:44:47+00:00",
            "max_combo": 207,
            "beatmap_id": 23919,
            "has_replay": false,
            "ruleset_id": 0,
            "started_at": null,
            "statistics": {
                "ok": 5,
                "great": 113
            },
            "total_score": 291525,
            "legacy_score_id": 22469362,
            "legacy_total_score": 404136,
            "maximum_statistics": {
                "great": 118,
                "legacy_combo_increase": 89
            }
        },
        "has_replay": 1,
        "preserve": 1,
        "created_at": "2009-06-11 04:44:47",
        "updated_at": "2009-06-11 04:44:47"
    }
]
```

After:
```json
[
    {
        "id": 15,
        "user_id": 84841,
        "beatmap_id": 23919,
        "ruleset_id": 0,
        "data": {
            "mods": [
                {
                    "acronym": "DT"
                },
                {
                    "acronym": "HR"
                },
                {
                    "acronym": "HD"
                }
            ],
            "rank": "SH",
            "passed": true,
            "user_id": 84841,
            "accuracy": 0.9717514124293786,
            "ended_at": "2009-06-11T04:44:47+00:00",
            "max_combo": 207,
            "beatmap_id": 23919,
            "statistics": {
                "ok": 5,
                "great": 113
            },
            "total_score": 291525,
            "legacy_score_id": 22469362,
            "legacy_total_score": 404136,
            "maximum_statistics": {
                "great": 118,
                "legacy_combo_increase": 89
            }
        },
        "has_replay": 1,
        "preserve": 1,
        "created_at": "2009-06-11 04:44:47",
        "updated_at": "2009-06-11 04:44:47"
    }
]
```