### PR TITLE
Add better error handling output

### DIFF
--- a/osu.Server.Queues.ScorePump/Queue/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/Queue/ImportHighScores.cs
@@ -85,6 +85,11 @@ namespace osu.Server.Queues.ScorePump.Queue
 
             DateTimeOffset start = DateTimeOffset.Now;
 
+            Console.WriteLine($"Sourcing from {highScoreTable} for {ruleset.ShortName} starting from {StartId}");
+            Console.WriteLine($"Inserting into {SoloScore.TABLE_NAME}");
+
+            Thread.Sleep(5000);
+
             using (var dbMainQuery = Queue.GetDatabaseConnection())
             {
                 while (!cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
May allow resuming from an error.

```csharp
root@es-scores-staging:~/import-high-scores# ./osu.Server.Queues.ScorePump queue import-high-scores --start-id 3449758
Sourcing from `osu`.`osu_scores_high` for osu starting from 3449758
Inserting into test_solo_scores
Increasing processing rate to 5100 due to latency of 2
Retrieving next 5100 scores from 3449758
Inserting up to 3,502,348 [0 /11] 0 inserted (+0 new 0/s)
ERROR: At least one tasks were faulted. Aborting for safety.
Running batches were processing up to 3502348.

0   3474112 - 3469676: FAILED (One or more errors occurred. (Duplicate entry '0-3474112' for key 'test_solo_scores_legacy_id_map.PRIMARY'))
1   3492035 - 3457612: FAILED (One or more errors occurred. (Duplicate entry '0-3492035' for key 'test_solo_scores_legacy_id_map.PRIMARY'))
2   3453310 - 3476897: FAILED (One or more errors occurred. (Duplicate entry '0-3453310' for key 'test_solo_scores_legacy_id_map.PRIMARY'))
3   3457257 - 3456389: FAILED (One or more errors occurred. (Duplicate entry '0-3457257' for key 'test_solo_scores_legacy_id_map.PRIMARY'))
4   3462622 - 3483014: FAILED (One or more errors occurred. (Duplicate entry '0-3462622' for key 'test_solo_scores_legacy_id_map.PRIMARY'))
5   3489398 - 3465089: FAILED (One or more errors occurred. (Duplicate entry '0-3489398' for key 'test_solo_scores_legacy_id_map.PRIMARY'))
6   3468439 - 3467310: FAILED (One or more errors occurred. (Duplicate entry '0-3468439' for key 'test_solo_scores_legacy_id_map.PRIMARY'))
7   3480195 - 3452862: FAILED (One or more errors occurred. (Duplicate entry '0-3480195' for key 'test_solo_scores_legacy_id_map.PRIMARY'))
8   3473944 - 3462886: FAILED (One or more errors occurred. (Duplicate entry '0-3473944' for key 'test_solo_scores_legacy_id_map.PRIMARY'))
9   3463066 - 3462836: FAILED (One or more errors occurred. (Duplicate entry '0-3463066' for key 'test_solo_scores_legacy_id_map.PRIMARY'))
10  3476689 - 3489360: FAILED (One or more errors occurred. (Duplicate entry '0-3476689' for key 'test_solo_scores_legacy_id_map.PRIMARY'))

System.AggregateException: One or more errors occurred. (Duplicate entry '0-3474112' for key 'test_solo_scores_legacy_id_map.PRIMARY')
 ---> MySqlConnector.MySqlException (0x80004005): Duplicate entry '0-3474112' for key 'test_solo_scores_legacy_id_map.PRIMARY'
   at MySqlConnector.Core.ServerSession.ReceiveReplyAsyncAwaited(ValueTask`1 task) in /_/src/MySqlConnector/Core/ServerSession.cs:line 958
   at MySqlConnector.Core.ResultSet.ReadResultSetHeaderAsync(IOBehavior ioBehavior) in /_/src/MySqlConnector/Core/ResultSet.cs:line 43
   at MySqlConnector.MySqlDataReader.ActivateResultSet(CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlDataReader.cs:line 129
   at MySqlConnector.MySqlDataReader.NextResultAsync(IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlDataReader.cs:line 81
   at MySqlConnector.MySqlDataReader.CreateAsync(CommandListPosition commandListPosition, ICommandPayloadCreator payloadCreator, IDictionary`2 cachedProcedures, IMySqlCommand command, CommandBehavior behavior, Activity activity, IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlDataReader.cs:line 467
   at MySqlConnector.Core.CommandExecutor.ExecuteReaderAsync(IReadOnlyList`1 commands, ICommandPayloadCreator payloadCreator, CommandBehavior behavior, Activity activity, IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/Core/CommandExecutor.cs:line 56
   at MySqlConnector.MySqlCommand.ExecuteNonQueryAsync(IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlCommand.cs:line 282
   at osu.Server.Queues.ScorePump.Queue.ImportHighScores.BatchInserter.Run(HighScore[] scores) in /Users/dean/Projects/osu-queue-score-statistics/osu.Server.Queues.ScorePump/Queue/ImportHighScores.cs:line 327
   --- End of inner exception stack trace ---
root@es-scores-staging:~/import-high-scores#
```

Closes #83