### PR TITLE
Use `ulong` for highscore imports

### DIFF
--- a/osu.Server.Queues.ScorePump/Queue/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/Queue/ImportHighScores.cs
@@ -37,7 +37,7 @@ namespace osu.Server.Queues.ScorePump.Queue
         /// The high score ID to start the import process from. This can be used to resume an existing job, or perform catch-up on new scores.
         /// </summary>
         [Option(CommandOptionType.SingleValue)]
-        public long StartId { get; set; }
+        public ulong StartId { get; set; }
 
         private long lastCommitTimestamp;
         private long lastLatencyCheckTimestamp;
@@ -279,7 +279,7 @@ namespace osu.Server.Queues.ScorePump.Queue
                         + $"INSERT INTO {SoloScoreLegacyIDMap.TABLE_NAME} (ruleset_id, old_score_id, score_id) VALUES ({ruleset.RulesetInfo.OnlineID}, @oldScoreId, LAST_INSERT_ID());";
 
                     var userId = insertCommand.Parameters.Add("userId", MySqlDbType.UInt32);
-                    var oldScoreId = insertCommand.Parameters.Add("oldScoreId", MySqlDbType.UInt32);
+                    var oldScoreId = insertCommand.Parameters.Add("oldScoreId", MySqlDbType.UInt64);
                     var beatmapId = insertCommand.Parameters.Add("beatmapId", MySqlDbType.UInt24);
                     var data = insertCommand.Parameters.Add("data", MySqlDbType.JSON);
                     var date = insertCommand.Parameters.Add("date", MySqlDbType.DateTime);
@@ -454,7 +454,7 @@ namespace osu.Server.Queues.ScorePump.Queue
         [Serializable]
         private class HighScore
         {
-            public uint score_id { get; set; }
+            public ulong score_id { get; set; }
             public int beatmap_id { get; set; }
             public int user_id { get; set; }
             public int score { get; set; }

--- a/osu.Server.Queues.ScorePump/Queue/WatchNewScores.cs
+++ b/osu.Server.Queues.ScorePump/Queue/WatchNewScores.cs
@@ -18,12 +18,12 @@ namespace osu.Server.Queues.ScorePump.Queue
     public class WatchNewScores : QueueCommand
     {
         [Option("--start_id")]
-        public long? StartId { get; set; }
+        public ulong? StartId { get; set; }
 
         private const int count_per_run = 100;
 
         [UsedImplicitly]
-        private long lastId;
+        private ulong lastId;
 
         public int OnExecute(CancellationToken cancellationToken)
         {
@@ -32,7 +32,7 @@ namespace osu.Server.Queues.ScorePump.Queue
             else
             {
                 using (var db = Queue.GetDatabaseConnection())
-                    lastId = db.QuerySingleOrDefault<long?>($"SELECT MAX($score_id) FROM {ProcessHistory.TABLE_NAME}") ?? 0;
+                    lastId = db.QuerySingleOrDefault<ulong?>($"SELECT MAX($score_id) FROM {ProcessHistory.TABLE_NAME}") ?? 0;
             }
 
             while (true)

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/StatisticsUpdateTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/StatisticsUpdateTests.cs
@@ -414,7 +414,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             waitForDatabaseState("SELECT count300 FROM osu_user_stats WHERE user_id = 2", 5, cts.Token);
         }
 
-        private static long scoreIDSource;
+        private static ulong scoreIDSource;
 
         public static ScoreItem CreateTestScore(int rulesetId = 0)
         {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/ScoreItem.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/ScoreItem.cs
@@ -24,7 +24,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
         public void MarkProcessed() =>
             ProcessHistory = new ProcessHistory
             {
-                score_id = Score.id,
+                score_id = (long)Score.id,
                 processed_version = ScoreStatisticsProcessor.VERSION
             };
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs
@@ -17,7 +17,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
         public const string TABLE_NAME = "solo_scores";
 
         [ExplicitKey]
-        public long id { get; set; }
+        public ulong id { get; set; }
 
         public int user_id { get; set; }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsProcessor.cs
@@ -108,7 +108,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
 
                 elasticQueueProcessor.PushToQueue(new ElasticQueueProcessor.ElasticScoreItem
                 {
-                    ScoreId = item.Score.id,
+                    ScoreId = (long)item.Score.id,
                 });
             }
             catch (Exception e)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
@@ -11,11 +11,11 @@
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-        <PackageReference Include="ppy.osu.Game" Version="2022.902.2" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.902.2" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.902.2" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.902.2" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.902.2" />
+        <PackageReference Include="ppy.osu.Game" Version="2022.909.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.909.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.909.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.909.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.909.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.812.0" />
     </ItemGroup>
 


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/20202
- [ ] https://github.com/ppy/osu-web/pull/9264

---

- `ProcessHistory` left as-is because it's defined as signed in the database.
- `ElasticScoreItem` left as-is because I'm not sure if there'd be any effects in changing the data type yet. Can be done later but isn't really what I'm trying to achieve.