### PR TITLE
Add command to upgrade scores

### DIFF
--- a/osu.Server.Queues.ScorePump/Queue/UpgradeScores.cs
+++ b/osu.Server.Queues.ScorePump/Queue/UpgradeScores.cs
@@ -1,0 +1,122 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using Dapper.Contrib.Extensions;
+using McMaster.Extensions.CommandLineUtils;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+using osu.Server.Queues.ScoreStatisticsProcessor;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScorePump.Queue
+{
+    [Command("upgrade-scores", Description = "Upgrades scores from the solo scores table, ensuring total score and accuracy values are up-to-date.")]
+    public class UpgradeScores : QueueCommand
+    {
+        private const int batch_size = 10000;
+
+        /// <summary>
+        /// The score ID to start the process from. This can be used to resume an existing job.
+        /// </summary>
+        [Option(CommandOptionType.SingleValue)]
+        public ulong StartId { get; set; }
+
+        /// <summary>
+        /// The amount of time to sleep between score batches.
+        /// </summary>
+        [Option(CommandOptionType.SingleValue)]
+        public int Delay { get; set; }
+
+        public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                Console.WriteLine($"Processing next {batch_size} scores starting from {StartId}");
+
+                using (var db = Queue.GetDatabaseConnection())
+                {
+                    int updateCount = 0;
+
+                    using (var transaction = await db.BeginTransactionAsync(cancellationToken))
+                    {
+                        SoloScore[] scores = (await db.QueryAsync<SoloScore>($"SELECT * FROM {SoloScore.TABLE_NAME} WHERE `id` >= @StartId LIMIT {batch_size}", new
+                        {
+                            StartId = StartId
+                        }, transaction)).ToArray();
+
+                        if (scores.Length == 0)
+                            break;
+
+                        foreach (var score in scores)
+                        {
+                            if (ensureMaximumStatistics(score))
+                            {
+                                await db.UpdateAsync(score, transaction);
+                                updateCount++;
+                            }
+                        }
+
+                        await transaction.CommitAsync(cancellationToken);
+
+                        StartId = scores.Max(s => s.id) + 1;
+                    }
+
+                    Console.WriteLine($"Updated {updateCount} rows");
+                }
+
+                if (Delay > 0)
+                {
+                    Console.WriteLine($"Waiting {Delay}ms...");
+                    await Task.Delay(Delay, cancellationToken);
+                }
+            }
+
+            Console.WriteLine("Finished.");
+            return 0;
+        }
+
+        private bool ensureMaximumStatistics(SoloScore score)
+        {
+            if (score.ScoreInfo.MaximumStatistics.Sum(s => s.Value) > 0)
+                return false;
+
+            Ruleset ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(score.ruleset_id);
+            HitResult maxBasicResult = ruleset.GetHitResults().Select(h => h.result).Where(h => h.IsBasic()).MaxBy(Judgement.ToNumericResult);
+
+            foreach ((HitResult result, int count) in score.ScoreInfo.Statistics)
+            {
+                switch (result)
+                {
+                    case HitResult.LargeTickHit:
+                    case HitResult.LargeTickMiss:
+                        score.ScoreInfo.MaximumStatistics[HitResult.LargeTickHit] = score.ScoreInfo.MaximumStatistics.GetValueOrDefault(HitResult.LargeTickHit) + count;
+                        break;
+
+                    case HitResult.SmallTickHit:
+                    case HitResult.SmallTickMiss:
+                        score.ScoreInfo.MaximumStatistics[HitResult.SmallTickHit] = score.ScoreInfo.MaximumStatistics.GetValueOrDefault(HitResult.SmallTickHit) + count;
+                        break;
+
+                    case HitResult.IgnoreHit:
+                    case HitResult.IgnoreMiss:
+                    case HitResult.SmallBonus:
+                    case HitResult.LargeBonus:
+                        break;
+
+                    default:
+                        score.ScoreInfo.MaximumStatistics[maxBasicResult] = score.ScoreInfo.MaximumStatistics.GetValueOrDefault(maxBasicResult) + count;
+                        break;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/osu.Server.Queues.ScorePump/QueueCommands.cs
+++ b/osu.Server.Queues.ScorePump/QueueCommands.cs
@@ -12,6 +12,7 @@ namespace osu.Server.Queues.ScorePump;
 [Subcommand(typeof(WatchNewScores))]
 [Subcommand(typeof(ClearQueue))]
 [Subcommand(typeof(ImportHighScores))]
+[Subcommand(typeof(UpgradeScores))]
 public sealed class QueueCommands
 {
     public int OnExecute(CommandLineApplication app)

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/osu.Server.Queues.ScoreStatisticsProcessor.Tests.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/osu.Server.Queues.ScoreStatisticsProcessor.Tests.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DeepEqual" Version="4.0.1" />
+        <PackageReference Include="DeepEqual" Version="4.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/osu.Server.Queues.ScoreStatisticsProcessor.sln.DotSettings
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.sln.DotSettings
@@ -128,6 +128,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleMultipleEnumeration/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PrivateVariableCanBeMadeReadonly/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PublicConstructorInAbstractClass/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantAnonymousTypePropertyName/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantArgumentDefaultValue/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantArrayCreationExpression/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantAttributeParentheses/@EntryIndexedValue">WARNING</s:String>

--- a/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
@@ -11,11 +11,11 @@
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-        <PackageReference Include="ppy.osu.Game" Version="2022.909.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.909.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.909.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.909.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.909.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2022.920.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.920.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.920.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.920.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.920.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.812.0" />
     </ItemGroup>
 


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/20262

This PR ports a command which was pushed to the `release` branch, as well adds a new function to it to upgrade existing total score and accuracy values.

The command which was ported from the `release` branch is: https://github.com/ppy/osu-queue-score-statistics/blob/3b329c474e93f858ffad5c6b5d659ba115c7eff6/osu.Server.Queues.ScorePump/AddMaximumStatisticsToLazerScores.cs
This was done mainly because upgrading total score and accuracy values requires `MaximumStatistics` to be fully populated. And as we haven't yet blocked old lazer clients from submitting scores, some still have empty `MaximumStatistics`.

As for the total score upgrades... Of the 10000 scores that were provided to me, here's the full list of changes:
[changes.txt](https://github.com/ppy/osu-queue-score-statistics/files/9547141/changes.txt)
I've gone through some of these rows to identify the reason for the changes:
```
##
## This is a passed=false score which has statistics populated with the full values.
## This comes from a time where we used to mangle statistics with the yet-to-be-completed judgements.
## We no longer do this mangling as of https://github.com/ppy/osu/pull/20010.
##
Updated 48087761 (22515, 57.46%) -> (22515, 2.33%) - (+0.00%, -95.94%)

##
## This is a passed=false RX score? Not sure how this one is possible.
## The mod multiplier was reduced to 10% as of https://github.com/ppy/osu/pull/19715.
##
Updated 48087628 (97389, 97.45%) -> (9739, 10.75%) - (-90.00%, -88.96%)

##
## This is a WU score.
## The mod multiplier was reduced to 50% as of https://github.com/ppy/osu/pull/20206.
##
Updated 48086384 (173285, 71.39%) -> (86642, 71.39%) - (-50.00%, +0.00%)
```
Of those scores, unfortunately, it seems the first case is the most prevalent. Perhaps in the future we could try to use play length as a way to reduce the number of misses stored in these scores' statistics.