### PR TITLE
Remove MaximumStatistics assert

### DIFF
--- a/osu.Server.Queues.ScorePump/Queue/UpgradeScores.cs
+++ b/osu.Server.Queues.ScorePump/Queue/UpgradeScores.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/osu.Server.Queues.ScorePump/Queue/UpgradeScores.cs
+++ b/osu.Server.Queues.ScorePump/Queue/UpgradeScores.cs
@@ -121,7 +121,6 @@ namespace osu.Server.Queues.ScorePump.Queue
                 }
             }
 
-            Trace.Assert(score.ScoreInfo.MaximumStatistics.Sum(s => s.Value) > 0);
             return true;
         }
 


### PR DESCRIPTION
On spinner-only catch maps like https://osu.ppy.sh/beatmapsets/23210#fruits/80895, there's no non-bonus judgements, and bonus judgements aren't counted into `MaximumStatistics` because there's no way to tell whether an `IgnoreMiss` was a large or small bonus.