### PR TITLE
🔥 Remove unnecessary bloat in Docker image

### DIFF
--- a/osu.Server.Queues.ScorePump/Dockerfile
+++ b/osu.Server.Queues.ScorePump/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 # Copy everything else and build
 COPY . ./
 RUN dotnet publish osu.Server.Queues.ScorePump -c Release -o out
+# get rid of bloat
+RUN rm -rf ./out/runtimes ./out/osu.Game.Resources.dll ./out/osuTK.dll
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/runtime:6.0

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Dockerfile
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Dockerfile
@@ -3,12 +3,13 @@ WORKDIR /app
 
 # Copy csproj and restore as distinct layers
 COPY *.csproj ./
-
 RUN dotnet restore
 
 # Copy everything else and build
 COPY . ./
 RUN dotnet publish -c Release -o out
+# get rid of bloat
+RUN rm -rf ./out/runtimes ./out/osu.Game.Resources.dll ./out/osuTK.dll
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/runtime:6.0


### PR DESCRIPTION
These files are massive and unused in a headless context. Same workaround as applied in osu-difficulty-calculator. Seems to run fine.