### PR TITLE
Fix missing beatmap ruleset

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -117,11 +117,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 if (!AllModsValidForPerformance(mods))
                     return;
 
-                DifficultyAttributes? difficultyAttributes = await beatmapStore.GetDifficultyAttributesAsync(beatmap, ruleset, mods, connection, transaction);
+                APIBeatmap apiBeatmap = beatmap.ToAPIBeatmap();
+                DifficultyAttributes? difficultyAttributes = await beatmapStore.GetDifficultyAttributesAsync(apiBeatmap, ruleset, mods, connection, transaction);
                 if (difficultyAttributes == null)
                     return;
 
-                ScoreInfo scoreInfo = score.ToScoreInfo(mods);
+                ScoreInfo scoreInfo = score.ToScoreInfo(mods, apiBeatmap);
                 PerformanceAttributes? performanceAttributes = ruleset.CreatePerformanceCalculator()?.Calculate(scoreInfo, difficultyAttributes);
                 if (performanceAttributes == null)
                     return;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
@@ -11,11 +11,11 @@
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-        <PackageReference Include="ppy.osu.Game" Version="2022.927.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.927.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.927.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.927.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.927.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2022.1031.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.1031.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.1031.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.1031.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.1031.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.812.0" />
     </ItemGroup>
 


### PR DESCRIPTION
Makes use of https://github.com/ppy/osu/pull/20984 to fix the beatmap's ruleset not being populated before PP processing, for changes such as https://github.com/ppy/osu/pull/20558 to be able to check whether the beatmap is a convert or not.