### PR TITLE
Fix crash on looking up databased attributes when none are present

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BeatmapStore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BeatmapStore.cs
@@ -76,7 +76,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
                     }, transaction: transaction)).ToArray();
             }
 
-            if (rawDifficultyAttributes == null)
+            if (rawDifficultyAttributes == null || rawDifficultyAttributes.Length == 0)
                 return null;
 
             DifficultyAttributes difficultyAttributes = LegacyRulesetHelper.CreateDifficultyAttributes(ruleset.RulesetInfo.OnlineID);


### PR DESCRIPTION
In my test database this would result in a failure like this:

```csharp
System.Collections.Generic.KeyNotFoundException: The given key '19' was not present in the dictionary.
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at osu.Game.Rulesets.Osu.Difficulty.OsuDifficultyAttributes.FromDatabaseAttributes(IReadOnlyDictionary`2 values, IBeatmapOnlineInfo onlineInfo)
   at osu.Server.Queues.ScoreStatisticsProcessor.Stores.BeatmapStore.GetDifficultyAttributesAsync(APIBeatmap beatmap, Ruleset ruleset, Mod[] mods, MySqlConnection connection, MySqlTransaction transaction) in /Users/dean/Projects/osu-queue-score-statistics/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BeatmapStore.cs:line 83
```

Not 100% sure this is the right solution so please double-check.