### PR TITLE
Update osu nuget packages

### DIFF
--- a/osu.Server.Queues.ScorePump/Queue/UpgradeScores.cs
+++ b/osu.Server.Queues.ScorePump/Queue/UpgradeScores.cs
@@ -132,7 +132,7 @@ namespace osu.Server.Queues.ScorePump.Queue
             ScoreProcessor scoreProcessor = ruleset.CreateScoreProcessor();
             scoreProcessor.Mods.Value = scoreInfo.Mods;
 
-            int totalScore = (int)Math.Round(scoreProcessor.ComputeScore(ScoringMode.Standardised, scoreInfo));
+            long totalScore = scoreProcessor.ComputeScore(ScoringMode.Standardised, scoreInfo);
             double accuracy = scoreProcessor.ComputeAccuracy(scoreInfo);
 
             if (totalScore == score.ScoreInfo.TotalScore && Math.Round(accuracy, 2) == Math.Round(score.ScoreInfo.Accuracy, 2))

--- a/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
@@ -11,11 +11,11 @@
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-        <PackageReference Include="ppy.osu.Game" Version="2022.1101.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.1101.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.1101.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.1101.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.1101.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2022.1123.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.1123.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.1123.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.1123.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.1123.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.812.0" />
     </ItemGroup>
 


### PR DESCRIPTION
Note that lazer taiko scores' PP values will differ from what's expected by the deployed version of `osu-performance` due to https://github.com/ppy/osu/pull/20558, but this isn't a huge deal for now I think?

I'm just doing this to remove the rounding that breaks compilation.