### PR TITLE
Add medal processor

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -207,7 +207,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         private void processorOnError(Exception? exception, ScoreItem _) => firstError ??= exception;
 
 #pragma warning disable CA1816
-        public void Dispose()
+        public virtual void Dispose()
 #pragma warning restore CA1816
         {
             cancellationSource.Cancel();

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -123,7 +124,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             Processor.Error -= processorOnError;
         }
 
-        protected void AddBeatmap(Action<Beatmap, BeatmapSet>? setup = null)
+        /// <summary>
+        /// All beatmaps which where added in this test via <see cref="AddBeatmap"/>.
+        /// </summary>
+        protected IReadOnlyList<Beatmap> AllBeatmaps => beatmaps;
+
+        private readonly List<Beatmap> beatmaps = new List<Beatmap>();
+
+        protected void AddBeatmap(Action<Beatmap>? beatmapSetup = null, Action<BeatmapSet>? beatmapSetSetup = null)
         {
             var beatmap = new Beatmap
             {
@@ -138,7 +146,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 approved = BeatmapOnlineStatus.Ranked,
             };
 
-            setup?.Invoke(beatmap, beatmapSet);
+            beatmapSetup?.Invoke(beatmap);
+            beatmapSetSetup?.Invoke(beatmapSet);
+
+            beatmaps.Add(beatmap);
 
             using (var db = Processor.GetDatabaseConnection())
             {

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -133,21 +133,20 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
         protected void AddBeatmap(Action<Beatmap>? beatmapSetup = null, Action<BeatmapSet>? beatmapSetSetup = null)
         {
-            var beatmap = new Beatmap
-            {
-                beatmap_id = TEST_BEATMAP_ID,
-                beatmapset_id = TEST_BEATMAP_SET_ID,
-                approved = BeatmapOnlineStatus.Ranked,
-            };
-
-            var beatmapSet = new BeatmapSet
-            {
-                beatmapset_id = TEST_BEATMAP_SET_ID,
-                approved = BeatmapOnlineStatus.Ranked,
-            };
+            var beatmap = new Beatmap { approved = BeatmapOnlineStatus.Ranked };
+            var beatmapSet = new BeatmapSet { approved = BeatmapOnlineStatus.Ranked };
 
             beatmapSetup?.Invoke(beatmap);
             beatmapSetSetup?.Invoke(beatmapSet);
+
+            if (beatmap.beatmap_id == 0) beatmap.beatmap_id = TEST_BEATMAP_ID;
+            if (beatmapSet.beatmapset_id == 0) beatmapSet.beatmapset_id = TEST_BEATMAP_SET_ID;
+
+            if (beatmap.beatmapset_id > 0 && beatmap.beatmapset_id != beatmapSet.beatmapset_id)
+                throw new ArgumentException($"{nameof(beatmapSetup)} method specified different {nameof(beatmap.beatmapset_id)} from the one specified in the {nameof(beatmapSetSetup)} method.");
+
+            // Copy over set ID for cases where the setup steps only set it on the beatmapSet.
+            beatmap.beatmapset_id = beatmapSet.beatmapset_id;
 
             beatmaps.Add(beatmap);
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -58,14 +58,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
         private static ulong scoreIDSource;
 
-        public static ScoreItem CreateTestScore(int rulesetId = 0)
+        public static ScoreItem CreateTestScore(int? rulesetId = null, int? beatmapId = null)
         {
             var row = new SoloScore
             {
                 id = Interlocked.Increment(ref scoreIDSource),
                 user_id = 2,
-                beatmap_id = TEST_BEATMAP_ID,
-                ruleset_id = rulesetId,
+                beatmap_id = beatmapId ?? TEST_BEATMAP_ID,
+                ruleset_id = rulesetId ?? 0,
                 created_at = DateTimeOffset.Now,
                 updated_at = DateTimeOffset.Now,
             };

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Dapper.Contrib.Extensions;
+using MySqlConnector;
+using Xunit;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
+{
+    public class MedalProcessorTests : DatabaseTest
+    {
+        [Fact]
+        public void TestSimplePackAwarding()
+        {
+            /*
+                // Pass all songs in Video Game Pack vol.1
+
+                | pack_id | beatmapset_id | min(beatmap_id) |
+                |---------|---------------|-----------------|
+                | 40      | 13022         | 71621           |
+                | 40      | 16520         | 59225           |
+                | 40      | 23073         | 79288           |
+                | 40      | 27936         | 101236          |
+                | 40      | 32162         | 105325          |
+                | 40      | 40233         | 127762          |
+                | 40      | 42158         | 132751          |
+                | 40      | 42956         | 134948          |
+                | 40      | 59370         | 177972          |
+                | 40      | 71476         | 204837          |
+                | 40      | 72137         | 206298          |
+                | 40      | 102913        | 271917          |
+                | 40      | 169848        | 514849          |
+                | 40      | 211704        | 497769          |
+             */
+
+            WaitForDatabaseState("SELECT COUNT(*) FROM osu_user_achievements WHERE user_id = 2", 0, Cts.Token);
+
+            pushAndInsert(71621);
+
+            WaitForDatabaseState("SELECT playcount FROM osu_user_stats WHERE user_id = 2", 1, Cts.Token);
+            WaitForDatabaseState("SELECT COUNT(*) FROM osu_user_achievements WHERE user_id = 2", 0, Cts.Token);
+
+            pushAndInsert(59225);
+            pushAndInsert(79288);
+            pushAndInsert(101236);
+            pushAndInsert(105325);
+            pushAndInsert(127762);
+            pushAndInsert(132751);
+            pushAndInsert(134948);
+            pushAndInsert(177972);
+            pushAndInsert(204837);
+            pushAndInsert(206298);
+            pushAndInsert(271917);
+            pushAndInsert(514849);
+            pushAndInsert(497769);
+
+            WaitForDatabaseState("SELECT playcount FROM osu_user_stats WHERE user_id = 2", 14, Cts.Token);
+            WaitForDatabaseState("SELECT COUNT(*) FROM osu_user_achievements WHERE user_id = 2", 1, Cts.Token);
+        }
+
+        private void pushAndInsert(int beatmapId)
+        {
+            using (MySqlConnection conn = Processor.GetDatabaseConnection())
+            {
+                var score = CreateTestScore(beatmapId: beatmapId);
+
+                conn.Insert(score.Score);
+                Processor.PushToQueue(score);
+            }
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
@@ -55,7 +55,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             foreach (var beatmap in AllBeatmaps)
             {
                 assertNotAwarded();
-                pushAndInsert(beatmap.beatmap_id);
+                setScoreForBeatmap(beatmap.beatmap_id);
             }
 
             assertAwarded(medal_id);
@@ -85,7 +85,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             Assert.Empty(awardedMedals);
         }
 
-        private void pushAndInsert(int beatmapId)
+        private void setScoreForBeatmap(int beatmapId)
         {
             using (MySqlConnection conn = Processor.GetDatabaseConnection())
             {

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PlayTimeProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PlayTimeProcessorTests.cs
@@ -14,7 +14,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
         public PlayTimeProcessorTests()
         {
-            AddBeatmap((b, _) => b.total_length = beatmap_length);
+            AddBeatmap(b => b.total_length = beatmap_length);
         }
 
         [Fact]

--- a/osu.Server.Queues.ScoreStatisticsProcessor.sln.DotSettings
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.sln.DotSettings
@@ -307,6 +307,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=HUD/@EntryIndexedValue">HUD</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ID/@EntryIndexedValue">ID</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IL/@EntryIndexedValue">IL</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IO/@EntryIndexedValue">IO</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IOS/@EntryIndexedValue">IOS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IP/@EntryIndexedValue">IP</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IPC/@EntryIndexedValue">IPC</s:String>

--- a/osu.Server.Queues.ScoreStatisticsProcessor/LegacyDatabaseHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/LegacyDatabaseHelper.cs
@@ -71,7 +71,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         public static HttpResponseMessage RunLegacyIO(string command, string method = "GET", dynamic? postObject = null)
         {
             if (string.IsNullOrEmpty(legacy_io_secret))
+            {
+#if DEBUG
+                return null!;
+#endif
+
                 throw new InvalidOperationException("Attempted to award medal with no legacy IO secret set");
+            }
 
             int retryCount = 3;
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/LegacyDatabaseHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/LegacyDatabaseHelper.cs
@@ -72,11 +72,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         {
             if (string.IsNullOrEmpty(legacy_io_secret))
             {
-#if DEBUG
-                return null!;
-#endif
-
+#if !DEBUG
                 throw new InvalidOperationException("Attempted to award medal with no legacy IO secret set");
+#endif
+                return null!;
             }
 
             int retryCount = 3;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/LegacyDatabaseHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/LegacyDatabaseHelper.cs
@@ -2,6 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using Newtonsoft.Json;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor
 {
@@ -53,6 +61,90 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
                 ReplayTable = $"`{dbName}`.`osu_replays{tableSuffix}`";
                 LastProcessedPpUserCount = $"pp_last_user_id{tableSuffix}";
                 LastProcessedPpScoreCount = $"pp_last_score_id{tableSuffix}";
+            }
+        }
+
+        private static readonly string legacy_io_secret = Environment.GetEnvironmentVariable("LEGACY_IO_SECRET") ?? string.Empty;
+
+        private static readonly HttpClient http = new HttpClient();
+
+        public static HttpResponseMessage RunLegacyIO(string command, string method = "GET", dynamic? postObject = null)
+        {
+            if (string.IsNullOrEmpty(legacy_io_secret))
+                throw new InvalidOperationException("Attempted to award medal with no legacy IO secret set");
+
+            int retryCount = 3;
+
+            retry:
+
+            try
+            {
+                long time = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+                string url = $"https://osu.ppy.sh/_lio/{command}{(command.Contains('?') ? "&" : "?")}timestamp={time}";
+                string signature = hmacEncode(url, Encoding.UTF8.GetBytes(legacy_io_secret));
+
+#pragma warning disable SYSLIB0014
+                var request = WebRequest.CreateHttp(url);
+#pragma warning restore SYSLIB0014
+
+                request.Method = method;
+
+                var httpRequestMessage = new HttpRequestMessage
+                {
+                    RequestUri = new Uri(url),
+                    Method = new HttpMethod(method),
+                    Headers =
+                    {
+                        { "X-LIO-Signature", signature },
+                        { "Accept", "application/json" },
+                    },
+                };
+
+                switch (postObject)
+                {
+                    case string postString:
+                        httpRequestMessage.Content = new StringContent(postString);
+                        httpRequestMessage.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("plain/text");
+                        break;
+
+                    default:
+                        httpRequestMessage.Content = new ByteArrayContent(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(postObject)));
+                        httpRequestMessage.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                        break;
+                }
+
+                var response = http.SendAsync(httpRequestMessage).Result;
+
+                if (!response.IsSuccessStatusCode)
+                    throw new InvalidOperationException($"Failed with {response.StatusCode} ({response.Content.ReadAsStringAsync().Result})");
+
+                if ((int)response.StatusCode >= 300)
+                    throw new Exception($"Issue with legacy IO: {response.StatusCode} {response.ReasonPhrase}");
+
+                return response;
+            }
+            catch (Exception e)
+            {
+                if (retryCount-- > 0)
+                {
+                    Console.WriteLine($"Legacy IO failed with {e}, retrying..");
+                    Thread.Sleep(1000);
+                    goto retry;
+                }
+
+                throw;
+            }
+        }
+
+        private static string hmacEncode(string input, byte[] key)
+        {
+            byte[] byteArray = Encoding.ASCII.GetBytes(input);
+
+            using (var myhmacsha1 = new HMACSHA1(key))
+            {
+                byte[] hashArray = myhmacsha1.ComputeHash(byteArray);
+                return hashArray.Aggregate(string.Empty, (s, e) => s + $"{e:x2}", s => s);
             }
         }
     }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/Medal.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/Medal.cs
@@ -4,24 +4,25 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace osu.Server.Queues.ScoreStatisticsProcessor.Models;
-
-[SuppressMessage("ReSharper", "InconsistentNaming")]
-[Serializable]
-public class Medal
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 {
-    public int achievement_id;
-    public string name = string.Empty;
-    public string description = string.Empty;
-    public string slug = string.Empty;
-    public string image = string.Empty;
-    public string grouping = string.Empty;
-    public int progression;
-    public int ordering;
-    public bool enabled;
-    public int? mode;
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [Serializable]
+    public class Medal
+    {
+        public int achievement_id;
+        public string name = string.Empty;
+        public string description = string.Empty;
+        public string slug = string.Empty;
+        public string image = string.Empty;
+        public string grouping = string.Empty;
+        public int progression;
+        public int ordering;
+        public bool enabled;
+        public int? mode;
 
-    // probably not of immediate interest.
-    public int? quest_ordering;
-    public string quest_instructions = string.Empty;
+        // probably not of immediate interest.
+        public int? quest_ordering;
+        public string quest_instructions = string.Empty;
+    }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/Medal.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/Medal.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+[Serializable]
+public class Medal
+{
+    public int achievement_id;
+    public string name = string.Empty;
+    public string description = string.Empty;
+    public string slug = string.Empty;
+    public string image = string.Empty;
+    public string grouping = string.Empty;
+    public int progression;
+    public int ordering;
+    public bool enabled;
+    public int? mode;
+
+    // probably not of immediate interest.
+    public int? quest_ordering;
+    public string quest_instructions = string.Empty;
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/IMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/IMedalAwarder.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using MySqlConnector;
 using osu.Game.Online.API.Requests.Responses;
@@ -14,6 +15,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
     [UsedImplicitly]
     internal interface IMedalAwarder
     {
-        bool Check(SoloScoreInfo info, Medal medal, MySqlConnection conn);
+        /// <summary>
+        /// For a given score and collection of valid medals, check which should be awarded (if any).
+        /// </summary>
+        /// <param name="score">The score to be checked.</param>
+        /// <param name="medals">All medals available for potential awarding.</param>
+        /// <param name="conn">The MySQL connection.</param>
+        /// <param name="transaction">The active transaction.</param>
+        /// <returns></returns>
+        IEnumerable<Medal> Check(SoloScoreInfo score, IEnumerable<Medal> medals, MySqlConnection conn, MySqlTransaction transaction);
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/IMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/IMedalAwarder.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using JetBrains.Annotations;
+using MySqlConnector;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
+{
+    /// <summary>
+    /// A class which handles conditional awarding of one of more medals.
+    /// </summary>
+    [UsedImplicitly]
+    internal interface IMedalAwarder
+    {
+        bool Check(SoloScoreInfo info, Medal medal, MySqlConnection conn);
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/IMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/IMedalAwarder.cs
@@ -13,7 +13,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
     /// A class which handles conditional awarding of one of more medals.
     /// </summary>
     [UsedImplicitly]
-    internal interface IMedalAwarder
+    public interface IMedalAwarder
     {
         /// <summary>
         /// For a given score and collection of valid medals, check which should be awarded (if any).

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
@@ -16,8 +16,16 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
     {
         public IEnumerable<Medal> Check(SoloScoreInfo score, IEnumerable<Medal> medals, MySqlConnection conn, MySqlTransaction transaction)
         {
+            int beatmapSetId = conn.QuerySingle<int>("SELECT beatmapset_id FROM osu_beatmaps WHERE beatmap_id = @beatmapId", new
+            {
+                beatmapId = score.BeatmapID,
+            }, transaction);
+
             // Do a global check to see if this beatmapset is contained in *any* pack.
-            var validPacksForBeatmapSet = conn.Query<int>("SELECT pack_id FROM osu_beatmappacks_items WHERE beatmapset_id = @beatmapSetId LIMIT 1", transaction);
+            var validPacksForBeatmapSet = conn.Query<int>("SELECT pack_id FROM osu_beatmappacks_items WHERE beatmapset_id = @beatmapSetId LIMIT 1", new
+            {
+                beatmapSetId = beatmapSetId,
+            }, transaction: transaction);
 
             foreach (var medal in medals)
             {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
@@ -13,6 +13,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
     {
         public bool Check(SoloScoreInfo info, Medal medal, MySqlConnection conn)
         {
+            //     //do a global check to see if this beatmapset is contained in *any* pack.
+            //     //this is a huge optimisation since we run this function many times over.
+            //     if ($checkedPacks === null)
+            //         $checkedPacks = $conn->queryMany("SELECT pack_id FROM osu_beatmappacks_items WHERE beatmapset_id = {$beatmapSetId}");
+
             switch (medal.achievement_id)
             {
                 case 7: //Pass all songs in Video Game Pack vol.1 (pack_id 40)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
@@ -36,147 +36,80 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
 
         private bool checkMedal(SoloScoreInfo score, Medal medal, IEnumerable<int> validPacksForBeatmapSet, MySqlConnection conn, MySqlTransaction transaction)
         {
-            // Whether to disallow difficulty reduction mods to still achieve the medal.
-            bool noReductionMods = false;
-            int packId;
-
-            switch (medal.achievement_id)
+            return medal.achievement_id switch
             {
-                default:
+                // Pass all songs in Video Game Pack vol.1
+                7 => checkPack(40),
+                // Pass all songs in Rhythm Game Pack vol.1
+                8 => checkPack(41),
+                // Pass all songs in Internet! Pack vol.1
+                9 => checkPack(42),
+                // Pass all songs in Anime Pack vol.1
+                10 => checkPack(43),
+                // Pass all songs in Game Music Pack vol.2
+                11 => checkPack(48),
+                // Pass all songs in Anime Pack vol.2
+                12 => checkPack(49),
+                // Pass all songs in Internet! Pack vol.2
+                18 => checkPack(93),
+                // Pass all songs in Rhythm Game Pack vol.2
+                19 => checkPack(94),
+                // Pass all songs in Game Music Pack vol.3
+                14 => checkPack(70),
+                // Pass all songs in Anime Pack vol.3
+                25 => checkPack(207),
+                // Pass all songs in Internet! Pack vol.3
+                27 => checkPack(209),
+                // Pass all songs in Rhythm Game Pack vol.3
+                26 => checkPack(208),
+                // Pass all songs in Video Game Pack vol.4
+                37 => checkPack(364),
+                // Pass all songs in Anime vol.4
+                34 => checkPack(363),
+                // Pass all songs in rhythm vol.4
+                35 => checkPack(365),
+                // Pass all songs in internet vol.4
+                36 => checkPack(366),
+
+                _ => false,
+            };
+
+            bool checkPack(int packId, bool noReductionMods = false)
+            {
+                if (!validPacksForBeatmapSet.Contains(packId))
                     return false;
 
-                case 7:
-                    //Pass all songs in Video Game Pack vol.1 (pack_id 40)
-                    packId = 40;
-                    break;
+                string modsCriteria = string.Empty;
+                string rulesetCriteria = string.Empty;
 
-                case 8:
-                    //Pass all songs in Rhythm Game Pack vol.1 (pack_id 41)
-                    packId = 41;
-                    break;
+                if (noReductionMods)
+                {
+                    // TODO: correct this to be valid for `solo_scores`.
+                    modsCriteria = "AND (enabled_mods & diff_reduction_mods) = 0";
+                }
 
-                case 9:
-                    //Pass all songs in Internet! Pack vol.1 (pack_id 42)
-                    packId = 42;
-                    break;
+                // ensure the correct mode, if one is specified
+                int? packRulesetId = conn.QuerySingle<int?>($"SELECT playmode FROM `osu_beatmappacks` WHERE pack_id = {packId}", transaction: transaction);
 
-                case 10:
-                    //Pass all songs in Anime Pack vol.1 (pack_id 43)
-                    packId = 43;
-                    break;
+                if (packRulesetId != null)
+                {
+                    if (score.RulesetID != packRulesetId)
+                        return false;
 
-                case 11:
-                    //Pass all songs in Game Music Pack vol.2 (pack_id 48)
-                    packId = 48;
-                    break;
+                    rulesetCriteria = $"AND ruleset_id = {packRulesetId}";
+                }
 
-                case 12:
-                    //Pass all songs in Anime Pack vol.2 (pack_id 49)
-                    packId = 49;
-                    break;
-
-                case 18:
-                    //Pass all songs in Internet! Pack vol.2 (pack_id 93)
-                    packId = 93;
-                    break;
-
-                case 19:
-                    //Pass all songs in Rhythm Game Pack vol.2 (pack_id 94)
-                    packId = 94;
-                    break;
-
-                case 14:
-                    //Pass all songs in Game Music Pack vol.3 (pack_id 70)
-                    packId = 70;
-                    break;
-
-                case 25:
-                    //Pass all songs in Anime Pack vol.3 (pack_id 207)
-                    packId = 207;
-                    break;
-
-                case 27:
-                    //Pass all songs in Internet! Pack vol.3 (pack_id 209)
-                    packId = 209;
-                    break;
-
-                case 26:
-                    //Pass all songs in Rhythm Game Pack vol.3 (pack_id 208)
-                    packId = 208;
-                    break;
-
-                case 37:
-                    //Pass all songs in Video Game Pack vol.4
-                    packId = 364;
-                    break;
-
-                case 34:
-                    //Pass all songs in Anime vol.4
-                    packId = 363;
-                    break;
-
-                case 35:
-                    //Pass all songs in rhythm vol.4
-                    packId = 365;
-                    break;
-
-                case 36:
-                    //Pass all songs in internet vol.4
-                    packId = 366;
-                    break;
-            }
-
-            if (!validPacksForBeatmapSet.Contains(packId))
-                return false;
-
-            return checkPack(packId, score, conn, transaction, noReductionMods);
-        }
-
-        private bool checkPack(int packId, SoloScoreInfo score, MySqlConnection conn, MySqlTransaction transaction, bool noReductionMods = false)
-        {
-            string modsCriteria = "";
-
-            if (noReductionMods)
-            {
-                // TODO: correct this to be valid for `solo_scores`.
-                modsCriteria = "AND (enabled_mods & $diffReduction) = 0";
-            }
-
-            // ensure the correct mode, if one is specified
-            int packRulesetId = conn.QuerySingle<int>("SELECT IFNULL(playmode, -1) FROM `osu_beatmappacks` WHERE pack_id = $packId", transaction);
-            int countForPack = conn.QuerySingle<int>("SELECT COUNT(*) FROM `osu_beatmappacks_items` WHERE pack_id = $packId", transaction);
-            int completed;
-
-            if (packRulesetId >= 0)
-            {
-                if (score.RulesetID != packRulesetId)
-                    return false;
-
-                // can assume it's for the current ruleset only
-
-                // TODO: this query may require an index on (user_id, beatmap_id) to be efficient. right now it is going to be relying on
-                // (user_id, ruleset) and potentially (beatmap_id) if mysql is smart enough.
-                completed = conn.QuerySingle<int>(
+                int completed = conn.QuerySingle<int>(
                     "SELECT COUNT(distinct p.beatmapset_id)"
                     + "FROM osu_beatmappacks_items p "
                     + "JOIN osu_beatmaps b USING (beatmapset_id) "
                     + "JOIN solo_scores s USING (beatmap_id)"
-                    + $"WHERE s.user_id = {score.UserID} AND pack_id = {packId} AND ruleset_id = {score.RulesetID} {modsCriteria}");
-            }
-            else
-            {
-                // check across all rulesets
+                    + $"WHERE s.user_id = {score.UserID} AND pack_id = {packId} {rulesetCriteria} {modsCriteria}", transaction: transaction);
 
-                // TODO: confirm this is what we want. currently medals are NOT awarded for converts, but this will allow them to be.
-                completed = conn.QuerySingle<int>(
-                    "SELECT COUNT(distinct p.beatmapset_id)"
-                    + "FROM osu_beatmappacks_items p "
-                    + "JOIN osu_beatmaps b USING (beatmapset_id) "
-                    + "JOIN solo_scores s USING (beatmap_id)"
-                    + $"WHERE s.user_id = {score.UserID} AND pack_id = {packId} {modsCriteria}");
-            }
+                int countForPack = conn.QuerySingle<int>($"SELECT COUNT(*) FROM `osu_beatmappacks_items` WHERE pack_id = {packId}", transaction: transaction);
 
-            return completed >= countForPack;
+                return completed >= countForPack;
+            }
         }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
@@ -236,8 +236,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
 
                 if (noReductionMods)
                 {
-                    // TODO: correct this to be valid for `solo_scores`.
-                    modsCriteria = "AND (enabled_mods & diff_reduction_mods) = 0";
+                    modsCriteria = @"AND json_search(data, 'one', 'EZ', null, '$.mods[*].acronym') IS NULL"
+                                   + " AND json_search(data, 'one', 'NF', null, '$.mods[*].acronym') IS NULL"
+                                   + " AND json_search(data, 'one', 'HT', null, '$.mods[*].acronym') IS NULL"
+                                   + " AND json_search(data, 'one', 'SO', null, '$.mods[*].acronym') IS NULL";
                 }
 
                 // ensure the correct mode, if one is specified
@@ -251,6 +253,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
                     rulesetCriteria = $"AND ruleset_id = {packRulesetId}";
                 }
 
+                // TODO: no index on (beatmap_id, user_id) may mean this is too slow.
                 int completed = conn.QuerySingle<int>(
                     "SELECT COUNT(distinct p.beatmapset_id)"
                     + "FROM osu_beatmappacks_items p "

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
@@ -1,0 +1,120 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using JetBrains.Annotations;
+using MySqlConnector;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
+{
+    [UsedImplicitly]
+    public class PackMedalAwarder : IMedalAwarder
+    {
+        public bool Check(SoloScoreInfo info, Medal medal, MySqlConnection conn)
+        {
+            switch (medal.achievement_id)
+            {
+                case 7: //Pass all songs in Video Game Pack vol.1 (pack_id 40)
+                    return checkPack(40, info, conn);
+
+                case 8: //Pass all songs in Rhythm Game Pack vol.1 (pack_id 41)
+                    return checkPack(41, info, conn);
+
+                case 9: //Pass all songs in Internet! Pack vol.1 (pack_id 42)
+                    return checkPack(42, info, conn);
+
+                case 10: //Pass all songs in Anime Pack vol.1 (pack_id 43)
+                    return checkPack(43, info, conn);
+
+                case 11: //Pass all songs in Game Music Pack vol.2 (pack_id 48)
+                    return checkPack(48, info, conn);
+
+                case 12: //Pass all songs in Anime Pack vol.2 (pack_id 49)
+                    return checkPack(49, info, conn);
+
+                case 18: //Pass all songs in Internet! Pack vol.2 (pack_id 93)
+                    return checkPack(93, info, conn);
+
+                case 19: //Pass all songs in Rhythm Game Pack vol.2 (pack_id 94)
+                    return checkPack(94, info, conn);
+
+                case 14: //Pass all songs in Game Music Pack vol.3 (pack_id 70)
+                    return checkPack(70, info, conn);
+
+                case 25: //Pass all songs in Anime Pack vol.3 (pack_id 207)
+                    return checkPack(207, info, conn);
+
+                case 27: //Pass all songs in Internet! Pack vol.3 (pack_id 209)
+                    return checkPack(209, info, conn);
+
+                case 26: //Pass all songs in Rhythm Game Pack vol.3 (pack_id 208)
+                    return checkPack(208, info, conn);
+
+                case 37: //Pass all songs in Video Game Pack vol.4
+                    return checkPack(364, info, conn);
+
+                case 34: //Pass all songs in Anime vol.4
+                    return checkPack(363, info, conn);
+
+                case 35: //Pass all songs in rhythm vol.4
+                    return checkPack(365, info, conn);
+
+                case 36: //Pass all songs in internet vol.4
+                    return checkPack(366, info, conn);
+            }
+
+            return false;
+        }
+
+        private bool checkPack(int packId, SoloScoreInfo score, MySqlConnection conn, bool noReductionMods = false)
+        {
+            //     global $conn, $highScoreTable, $checkedPacks;
+            //
+            //     $beatmapSetId = info['beatmapset_id'];
+            //     $mode = info['mode'];
+            //
+            //     //do a global check to see if this beatmapset is contained in *any* pack.
+            //     //this is a huge optimisation since we run this function many times over.
+            //     if ($checkedPacks === null)
+            //         $checkedPacks = $conn->queryMany("SELECT pack_id FROM osu_beatmappacks_items WHERE beatmapset_id = {$beatmapSetId}");
+            //
+            //     if (!in_array($packId, $checkedPacks))
+            //         return false;
+            //
+            //     $userId = info['user_id'];
+            //
+            //     $modsCriteria = "";
+            //
+            //     if ($noReductionMods)
+            //     {
+            //         $diffReduction = NoFail | Easy | HalfTime | SpunOut;
+            //         $modsCriteria = "AND (enabled_mods & $diffReduction) = 0";
+            //     }
+            //
+            //     // ensure the correct mode, if one is specified
+            //     $packMode = $conn->queryOne("SELECT IFNULL(playmode, -1) FROM `osu_beatmappacks` WHERE pack_id = $packId");
+            //     $countForPack = $conn->queryOne("SELECT COUNT(*) FROM `osu_beatmappacks_items` WHERE pack_id = $packId");
+            //
+            //     if ($packMode >= 0)
+            //     {
+            //         if ($mode != $packMode)
+            //             return false;
+            //
+            //         // can assume it's for the current mode only
+            //         $completed = $conn->queryOne("SELECT COUNT(distinct p.beatmapset_id) FROM osu_beatmappacks_items p JOIN osu_beatmaps b USING (beatmapset_id) JOIN $highScoreTable s USING (beatmap_id) WHERE s.user_id = {$userId} AND pack_id = {$packId} $modsCriteria");
+            //     }
+            //     else
+            //     {
+            //         $completed = $conn->queryOne("SELECT COUNT(*) FROM (
+            //         SELECT p.beatmapset_id FROM osu_beatmappacks_items p JOIN osu_beatmaps b USING (beatmapset_id) JOIN osu_scores_high s USING (beatmap_id) WHERE s.user_id = {$userId} AND b.playmode = 0 AND pack_id = {$packId} $modsCriteria UNION DISTINCT
+            //         SELECT p.beatmapset_id FROM osu_beatmappacks_items p JOIN osu_beatmaps b USING (beatmapset_id) JOIN osu_scores_taiko_high s USING (beatmap_id) WHERE s.user_id = {$userId} AND b.playmode = 1 AND pack_id = {$packId} $modsCriteria UNION DISTINCT
+            //         SELECT p.beatmapset_id FROM osu_beatmappacks_items p JOIN osu_beatmaps b USING (beatmapset_id) JOIN osu_scores_fruits_high s USING (beatmap_id) WHERE s.user_id = {$userId} AND b.playmode = 2 AND pack_id = {$packId} $modsCriteria UNION DISTINCT
+            //         SELECT p.beatmapset_id FROM osu_beatmappacks_items p JOIN osu_beatmaps b USING (beatmapset_id) JOIN osu_scores_mania_high s USING (beatmap_id) WHERE s.user_id = {$userId} AND b.playmode = 3 AND pack_id = {$packId} $modsCriteria) a");
+            //     }
+            //
+            //     return $completed >= $countForPack;
+            return false;
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
@@ -70,6 +70,158 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
                 35 => checkPack(365),
                 // Pass all songs in internet vol.4
                 36 => checkPack(366),
+                // Spotlights January/February 2017 (1186-1189 packid)
+                162 => checkPack(1186) || checkPack(1187) || checkPack(1188) || checkPack(1189),
+                // Spotlights March 2017 (1201-1204 packid)
+                163 => checkPack(1201) || checkPack(1202) || checkPack(1203) || checkPack(1204),
+                // Spotlights April 2017 (1219-1222 packid)
+                164 => checkPack(1219) || checkPack(1220) || checkPack(1221) || checkPack(1222),
+                // Spotlights May 2017 (1228-1232)
+                165 => checkPack(1228) || checkPack(1229) || checkPack(1230) || checkPack(1232),
+                // Spotlights June 2017 (1244-1247)
+                166 => checkPack(1244) || checkPack(1245) || checkPack(1246) || checkPack(1247),
+                // Spotlights July 2017 (1253-1256)
+                167 => checkPack(1253) || checkPack(1254) || checkPack(1255) || checkPack(1256),
+                // Spotlights August 2017 (1264-1268)
+                169 => checkPack(1264) || checkPack(1265) || checkPack(1267) || checkPack(1268),
+                // MOtOLOiD pack (pack_id 1284)
+                179 => checkPack(1284),
+                // Spotlights September 2017 (1280-1283)
+                180 => checkPack(1280) || checkPack(1281) || checkPack(1282) || checkPack(1283),
+                // Spotlights October 2017 (1292-1295)
+                181 => checkPack(1292) || checkPack(1293) || checkPack(1294) || checkPack(1295),
+                // Spotlights November 2017 (1302-1305)
+                182 => checkPack(1302) || checkPack(1303) || checkPack(1304) || checkPack(1305),
+                // Spotlights December 2017 (1331-1334)
+                183 => checkPack(1331) || checkPack(1332) || checkPack(1333) || checkPack(1334),
+                // Spotlights January 2018 (1354-1357)
+                184 => checkPack(1354) || checkPack(1355) || checkPack(1356) || checkPack(1357),
+                // Mappers Guild I, January 22~ 2018 (1365)
+                185 => checkPack(1365),
+                // Spotlights February 2018 (1379-1382)
+                186 => checkPack(1379) || checkPack(1380) || checkPack(1381) || checkPack(1382),
+                // Spotlights March 2018 (1405, 1407, 1408) - this month has no mania cuz ???
+                187 => checkPack(1405) || checkPack(1407) || checkPack(1408),
+                // Spotlights April 2018 (1430, 1431, 1432, 1433)
+                188 => checkPack(1430) || checkPack(1431) || checkPack(1432) || checkPack(1433),
+                // Cranky Pack (1437)
+                189 => checkPack(1437),
+                // Mappers' Guild Pack 2 (1450)
+                190 => checkPack(1450),
+                // Mappers' Guild Pack 3 (1480)
+                191 => checkPack(1480),
+                // Summer Spotlights 2018 (1508-1511)
+                205 => checkPack(1508) || checkPack(1509) || checkPack(1510) || checkPack(1511),
+                // Mappers' Guild Pack 4: Culprate (1535)
+                206 => checkPack(1535),
+                // Seasonal Spotlights: Fall 2018 (1548-1551)
+                207 => checkPack(1548) || checkPack(1549) || checkPack(1550) || checkPack(1551),
+                // Mappers' Guild Pack 5: HyuN (1581)
+                208 => checkPack(1581),
+                // Seasonal Spotlights: Winter 2018 (1623-1626)
+                209 => checkPack(1623) || checkPack(1624) || checkPack(1625) || checkPack(1626),
+                // Seasonal Spotlights: Spring 2019 (1670-1673)
+                210 => checkPack(1670) || checkPack(1671) || checkPack(1672) || checkPack(1673),
+                // ICDD artist pack (1688)
+                213 => checkPack(1688),
+                // Tieff MG artist pack (1649)
+                214 => checkPack(1649),
+                // Seasonal Spotlights: Summer 2019 (1722-1725)
+                215 => checkPack(1722) || checkPack(1723) || checkPack(1724) || checkPack(1725),
+                // Mappers Guild Pack III redux (1689)
+                226 => checkPack(1689),
+                // Mappers' Guild Pack IV redux (1757)
+                227 => checkPack(1757),
+                // Seasonal Spotlights: Autumn 2019 (1798-1801)
+                228 => checkPack(1798) || checkPack(1799) || checkPack(1800) || checkPack(1801),
+                // Afterparty Featured Artist pack (1542)
+                229 => checkPack(1542),
+                // Ben Briggs FA pack (1687)
+                230 => checkPack(1687),
+                // Carpool Tunnel FA pack (1805)
+                231 => checkPack(1805),
+                // Creo FA pack (1807)
+                232 => checkPack(1807),
+                // cYsmix FA pack (1808)
+                233 => checkPack(1808),
+                // Fractal Dreamers FA pack (1809)
+                234 => checkPack(1809),
+                // LukHash FA pack (1758)
+                235 => checkPack(1758),
+                // *namirin FA pack (1704)
+                236 => checkPack(1704),
+                // onumi FA pack (1804)
+                237 => checkPack(1804),
+                // The Flashbulb FA pack (1762)
+                238 => checkPack(1762),
+                // Undead Corporation FA pack (1810)
+                239 => checkPack(1810),
+                // Wisp X FA pack (1806)
+                240 => checkPack(1806),
+                // Seasonal Spotlights: Winter 2020 (1896-1899)
+                241 => checkPack(1896) || checkPack(1897) || checkPack(1898) || checkPack(1899),
+                // Camellia I Beatmap Pack (2051)
+                246 => checkPack(2051),
+                // Camellia II Beatmap Pack (2053, CHALLENGE SET)
+                247 => checkPack(2053, true),
+                // Celldweller Beatmap Pack (2040)
+                248 => checkPack(2040),
+                // Cranky II Beatmap Pack (2049)
+                249 => checkPack(2049),
+                // Cute Anime Girls FA Pack (2031)
+                250 => checkPack(2031),
+                // ELFENSJoN beatmap pack (2047)
+                251 => checkPack(2047),
+                // Hyper Potions beatmap pack (2037)
+                252 => checkPack(2037),
+                // Kola Kid beatmap pack (2044)
+                253 => checkPack(2044),
+                // LeaF beatmap pack (2039)
+                254 => checkPack(2039),
+                // Panda Eyes beatmap pack (2043)
+                255 => checkPack(2043),
+                // PUP beatmap pack (2048)
+                256 => checkPack(2048),
+                // Ricky Montgomery beatmap pack (2046)
+                257 => checkPack(2046),
+                // Rin beatmap pack (1759)
+                258 => checkPack(1759),
+                // S3RL beatmap pack (2045)
+                259 => checkPack(2045),
+                // Sound Souler beatmap pack (2038)
+                260 => checkPack(2038),
+                // Teminite beatmap pack (2042)
+                261 => checkPack(2042),
+                // VINXIS beatmap pack (2041)
+                262 => checkPack(2041),
+                // Mappers' Guild Pack 5 (2032, diff allowed)
+                263 => checkPack(2032),
+                // Mappers' Guild Pack 6 (2033, diff allowed)
+                264 => checkPack(2033),
+                // Mappers' Guild Pack 7 (2034, CHALLENGE SET)
+                265 => checkPack(2034, true),
+                // Mappers' Guild Pack 8 (2035, CHALLENGE SET)
+                266 => checkPack(2035, true),
+                // Mappers' Guild Pack 9 (2036, CHALLENGE SET)
+                267 => checkPack(2036, true),
+                // Touhou Pack (2457)
+                282 => checkPack(2457),
+                // ginkiha Pack (2458)
+                283 => checkPack(2458),
+                // MUZZ Pack (2459, challenge pack)
+                284 => checkPack(2459, true),
+                // Vocaloid Pack (2481)
+                288 => checkPack(2481),
+                // Maduk Pack (2482)
+                289 => checkPack(2482),
+                // Aitsuki Nakuru Pack (2483)
+                290 => checkPack(2483),
+                // Arabl'eyeS Pack (291-293 are taiko/fruits/mania hits progression), (2521, challenge pack)
+                294 => checkPack(2521, true),
+                // Omoi Pack (2522)
+                295 => checkPack(2522),
+                // Chill Pack (2523)
+                296 => checkPack(2523),
 
                 _ => false,
             };

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
@@ -56,8 +56,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
             foreach (var awarder in medal_awarders)
             {
-                Console.WriteLine($"Running checks on {awarder.GetType().Name}...");
-
                 foreach (var awardedMedal in awarder.Check(score, availableMedalsForUser, conn, transaction))
                 {
                     awardMedal(score, awardedMedal);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
@@ -1,6 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Dapper;
 using JetBrains.Annotations;
 using MySqlConnector;
 using osu.Game.Online.API.Requests.Responses;
@@ -14,12 +19,39 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
     [UsedImplicitly]
     public class MedalProcessor : IProcessor
     {
+        private ImmutableArray<Medal>? availableMedals;
+
+        private IEnumerable<Medal> getAvailableMedals(MySqlConnection conn)
+        {
+            return availableMedals ??= conn.Query<Medal>("SELECT * FROM osu_achievements WHERE enabled = 1").ToImmutableArray();
+        }
+
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
         }
 
         public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
         {
+            var medals = getAvailableMedals(conn)
+                .Where(m => m.mode == null || m.mode == score.RulesetID);
+
+            foreach (var m in medals)
+            {
+                Console.WriteLine($"Checking medal {m.name}...");
+
+                bool shouldAward = false;
+
+                // process the medals
+
+                if (shouldAward)
+                    awardMedal(score, m);
+            }
+        }
+
+        private void awardMedal(SoloScoreInfo score, Medal medal)
+        {
+            // Perform LIO request to award the medal.
+            Console.WriteLine($"Awarding medal {medal.name} to user {score.UserID} (score {score.ID})");
         }
 
         public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
@@ -52,6 +52,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         {
             // Perform LIO request to award the medal.
             Console.WriteLine($"Awarding medal {medal.name} to user {score.UserID} (score {score.ID})");
+            LegacyDatabaseHelper.RunLegacyIO($"user-achievement/{score.UserID}/{medal.achievement_id}/{score.BeatmapID}", "POST");
         }
 
         public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
@@ -46,17 +46,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             var medals = getAvailableMedals(conn)
                 .Where(m => m.mode == null || m.mode == score.RulesetID);
 
-            foreach (var m in medals)
+            foreach (var awarder in medal_awarders)
             {
-                Console.WriteLine($"Checking medal {m.name}...");
+                Console.WriteLine($"Running checks on {awarder.GetType().Name}...");
 
-                foreach (var awarder in medal_awarders)
+                foreach (var awardedMedal in awarder.Check(score, availableMedalsForUser, conn, transaction))
                 {
-                    if (awarder.Check(score, m, conn))
-                    {
-                        awardMedal(score, m);
-                        break;
-                    }
+                    awardMedal(score, awardedMedal);
+                    break;
                 }
             }
         }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
@@ -44,9 +44,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             int[] alreadyAchieved = conn.Query<int>("SELECT achievement_id FROM osu_user_achievements WHERE user_id = @userId", new
             {
                 userId = score.UserID
-            }, transaction).ToArray();
+            }, transaction: transaction).ToArray();
 
-            var availableMedalsForUser = getAvailableMedals(conn)
+            var availableMedalsForUser = getAvailableMedals(conn, transaction)
                                          .Where(m => m.mode == null || m.mode == score.RulesetID)
                                          .Where(m => !alreadyAchieved.Contains(m.achievement_id))
                                          .ToArray();
@@ -63,9 +63,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             }
         }
 
-        private IEnumerable<Medal> getAvailableMedals(MySqlConnection conn)
+        private IEnumerable<Medal> getAvailableMedals(MySqlConnection conn, MySqlTransaction transaction)
         {
-            return availableMedals ??= conn.Query<Medal>("SELECT * FROM osu_achievements WHERE enabled = 1").ToImmutableArray();
+            return availableMedals ??= conn.Query<Medal>("SELECT * FROM osu_achievements WHERE enabled = 1", transaction: transaction).ToImmutableArray();
         }
 
         private void awardMedal(SoloScoreInfo score, Medal medal)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
@@ -23,6 +23,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         private ImmutableArray<Medal>? availableMedals;
 
+        // For testing purposes.
+        public static Action<AwardedMedal>? MedalAwarded;
+
         static MedalProcessor()
         {
             // add each processor automagically.
@@ -73,10 +76,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             // Perform LIO request to award the medal.
             Console.WriteLine($"Awarding medal {medal.name} to user {score.UserID} (score {score.ID})");
             LegacyDatabaseHelper.RunLegacyIO($"user-achievement/{score.UserID}/{medal.achievement_id}/{score.BeatmapID}", "POST");
+            MedalAwarded?.Invoke(new AwardedMedal(medal, score));
         }
 
         public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
         {
         }
+
+        public record struct AwardedMedal(Medal Medal, SoloScoreInfo Score);
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using JetBrains.Annotations;
+using MySqlConnector;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
+{
+    /// <summary>
+    /// Award the medals.
+    /// </summary>
+    [UsedImplicitly]
+    public class MedalProcessor : IProcessor
+    {
+        public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
+        {
+        }
+
+        public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
+        {
+        }
+
+        public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
+        {
+        }
+    }
+}


### PR DESCRIPTION
PRing ahead of adding proper testability (currently looking at updating tests to user a more portable means).

Currently only processes a minimal subset of medals, but is designed to be modular and performant enough to handle all existing medals.

- [x] Depends on #110 
- [x] Depends on #114