### PR TITLE
Add missing `ORDER BY` syntax to `solo_scores` pagination

### DIFF
--- a/osu.Server.Queues.ScorePump/Queue/ImportHighScores.cs
+++ b/osu.Server.Queues.ScorePump/Queue/ImportHighScores.cs
@@ -109,7 +109,7 @@ namespace osu.Server.Queues.ScorePump.Queue
 
                     Console.WriteLine($"Retrieving next {scoresPerQuery} scores from {StartId}");
 
-                    var highScores = await dbMainQuery.QueryAsync<HighScore>($"SELECT * FROM {highScoreTable} WHERE score_id >= @startId LIMIT {scoresPerQuery}", new { startId = StartId });
+                    var highScores = await dbMainQuery.QueryAsync<HighScore>($"SELECT * FROM {highScoreTable} WHERE score_id >= @startId ORDER BY score_id LIMIT {scoresPerQuery}", new { startId = StartId });
 
                     if (!highScores.Any())
                     {

--- a/osu.Server.Queues.ScorePump/Queue/UpgradeScores.cs
+++ b/osu.Server.Queues.ScorePump/Queue/UpgradeScores.cs
@@ -47,7 +47,7 @@ namespace osu.Server.Queues.ScorePump.Queue
 
                     using (var transaction = await db.BeginTransactionAsync(cancellationToken))
                     {
-                        SoloScore[] scores = (await db.QueryAsync<SoloScore>($"SELECT * FROM {SoloScore.TABLE_NAME} WHERE `id` >= @StartId LIMIT {batch_size}", new
+                        SoloScore[] scores = (await db.QueryAsync<SoloScore>($"SELECT * FROM {SoloScore.TABLE_NAME} WHERE `id` >= @StartId ORDER BY `id` LIMIT {batch_size}", new
                         {
                             StartId = StartId
                         }, transaction)).ToArray();

--- a/osu.Server.Queues.ScorePump/Queue/WatchNewScores.cs
+++ b/osu.Server.Queues.ScorePump/Queue/WatchNewScores.cs
@@ -42,7 +42,7 @@ namespace osu.Server.Queues.ScorePump.Queue
 
                 using (var db = Queue.GetDatabaseConnection())
                 {
-                    var scores = db.Query<SoloScore>($"SELECT * FROM {SoloScore.TABLE_NAME} WHERE id > @lastId LIMIT @count_per_run", new
+                    var scores = db.Query<SoloScore>($"SELECT * FROM {SoloScore.TABLE_NAME} WHERE id > @lastId ORDER BY id LIMIT @count_per_run", new
                     {
                         lastId,
                         count_per_run


### PR DESCRIPTION
Turns out that without this, things are completely broken since partitioning was added. This is because, as an optimisation, MySQL will return all results from one partition before the next by default. Which meant that these iteration commands would only see `preserve=0` scores.