### PR TITLE
Add support for realtime legacy score importing (and automatic indexing)

### DIFF
--- a/osu.Server.Queues.ScorePump/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScorePump/Queue/ImportHighScoresCommand.cs
@@ -37,16 +37,27 @@ namespace osu.Server.Queues.ScorePump.Queue
         public int RulesetId { get; set; }
 
         /// <summary>
-        /// The high score ID to start the import process from. This can be used to resume an existing job, or perform catch-up on new scores.
+        /// The high score ID to start the import process from. This can be used to perform batch reimporting for special cases.
         /// </summary>
         [Option(CommandOptionType.SingleValue)]
-        public ulong StartId { get; set; }
+        public ulong? StartId { get; set; }
 
         /// <summary>
-        /// Whether existing legacy score IDs should be skipped rather than fail via an error. Defaults enabled.
+        /// Whether to adjust processing rate based on slave latency. Defaults to <c>false</c>.
         /// </summary>
-        [Option(CommandOptionType.SingleValue, Template = "--skip")]
+        [Option(CommandOptionType.SingleValue, Template = "--check-slave-latency")]
+        public bool CheckSlaveLatency { get; set; }
+
+        /// <summary>
+        /// Whether existing legacy score IDs should be skipped rather than fail via an error. Defaults to <c>true</c>.
+        /// </summary>
+        [Option(CommandOptionType.SingleValue, Template = "--skip-existing")]
         public bool SkipExisting { get; set; } = true;
+
+        /// <summary>
+        /// Whether to exit when there are no scores left at the tail end of the import. Defaults to <c>false</c>.
+        /// </summary>
+        public bool ExitOnCompletion { get; set; }
 
         private long lastCommitTimestamp;
         private long lastLatencyCheckTimestamp;
@@ -96,8 +107,21 @@ namespace osu.Server.Queues.ScorePump.Queue
 
             DateTimeOffset start = DateTimeOffset.Now;
 
-            Console.WriteLine($"Sourcing from {highScoreTable} for {ruleset.ShortName} starting from {StartId}");
-            Console.WriteLine($"Inserting into {SoloScore.TABLE_NAME}");
+            ulong lastId;
+
+            if (StartId.HasValue)
+                lastId = StartId.Value;
+            else
+            {
+                using (var db = Queue.GetDatabaseConnection())
+                    lastId = db.QuerySingleOrDefault<ulong?>($"SELECT MAX(old_score_id) FROM {SoloScoreLegacyIDMap.TABLE_NAME} WHERE ruleset_id = {RulesetId}") ?? 0;
+
+                Console.WriteLine($"StartId not provided, using last legacy ID map entry ({lastId})");
+            }
+
+            Console.WriteLine();
+            Console.WriteLine($"Sourcing from {highScoreTable} for {ruleset.ShortName} starting from {lastId}");
+            Console.WriteLine($"Inserting into {SoloScore.TABLE_NAME} and processing {(ExitOnCompletion ? "as single run" : "indefinitely")}");
 
             Thread.Sleep(5000);
 
@@ -105,16 +129,22 @@ namespace osu.Server.Queues.ScorePump.Queue
             {
                 while (!cancellationToken.IsCancellationRequested)
                 {
-                    checkSlaveLatency(dbMainQuery);
+                    if (CheckSlaveLatency)
+                        checkSlaveLatency(dbMainQuery);
 
-                    Console.WriteLine($"Retrieving next {scoresPerQuery} scores from {StartId}");
-
-                    var highScores = await dbMainQuery.QueryAsync<HighScore>($"SELECT * FROM {highScoreTable} WHERE score_id >= @startId ORDER BY score_id LIMIT {scoresPerQuery}", new { startId = StartId });
+                    var highScores = await dbMainQuery.QueryAsync<HighScore>($"SELECT * FROM {highScoreTable} WHERE score_id >= @lastId ORDER BY score_id LIMIT {scoresPerQuery}",
+                        new { lastId = lastId });
 
                     if (!highScores.Any())
                     {
-                        Console.WriteLine("No scores found");
-                        break;
+                        if (ExitOnCompletion)
+                        {
+                            Console.WriteLine("No scores found, all done!");
+                            break;
+                        }
+
+                        Thread.Sleep(500);
+                        continue;
                     }
 
                     List<BatchInserter> runningBatches = new List<BatchInserter>();
@@ -139,8 +169,8 @@ namespace osu.Server.Queues.ScorePump.Queue
 
                     queueNextBatch();
 
-                    // update StartId to allow the next bulk query to start from the correct location.
-                    StartId = highScores.Max(s => s.score_id);
+                    // update lastId to allow the next bulk query to start from the correct location.
+                    lastId = highScores.Max(s => s.score_id);
 
                     while (!runningBatches.All(t => t.Task.IsCompleted))
                     {
@@ -150,7 +180,7 @@ namespace osu.Server.Queues.ScorePump.Queue
                         {
                             int inserted = Interlocked.Exchange(ref currentReportInsertCount, 0);
 
-                            Console.WriteLine($"Inserting up to {StartId:N0} "
+                            Console.WriteLine($"Inserting up to {lastId:N0} "
                                               + $"[{runningBatches.Count(t => t.Task.IsCompleted),-2}/{runningBatches.Count}] "
                                               + $"{totalInsertCount:N0} inserted {totalSkipCount:N0} skipped (+{inserted:N0} new {inserted / seconds_between_report:N0}/s)");
 
@@ -163,7 +193,7 @@ namespace osu.Server.Queues.ScorePump.Queue
                     if (runningBatches.Any(t => t.Task.IsFaulted))
                     {
                         Console.WriteLine("ERROR: At least one tasks were faulted. Aborting for safety.");
-                        Console.WriteLine($"Running batches were processing up to {StartId}.");
+                        Console.WriteLine($"Running batches were processing up to {lastId}.");
                         Console.WriteLine();
 
                         for (int i = 0; i < runningBatches.Count; i++)
@@ -179,8 +209,8 @@ namespace osu.Server.Queues.ScorePump.Queue
                         return -1;
                     }
 
-                    Console.WriteLine($"Transaction commit at score_id {StartId}");
-                    StartId++;
+                    Console.WriteLine($"Transaction commit at score_id {lastId}");
+                    lastId++;
 
                     void queueNextBatch()
                     {
@@ -200,7 +230,7 @@ namespace osu.Server.Queues.ScorePump.Queue
             {
                 Console.WriteLine($"Cancelled after {(DateTimeOffset.Now - start).TotalSeconds} seconds.");
                 Console.WriteLine($"Final stats: {totalInsertCount} inserted, {totalSkipCount} skipped");
-                Console.WriteLine($"Resume from start id {StartId}");
+                Console.WriteLine($"Resume from start id {lastId}");
             }
             else
             {

--- a/osu.Server.Queues.ScorePump/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScorePump/Queue/ImportHighScoresCommand.cs
@@ -63,6 +63,7 @@ namespace osu.Server.Queues.ScorePump.Queue
         /// <summary>
         /// Whether to exit when there are no scores left at the tail end of the import. Defaults to <c>false</c>.
         /// </summary>
+        [Option(CommandOptionType.SingleValue, Template = "--exit-on-completion")]
         public bool ExitOnCompletion { get; set; }
 
         private long lastCommitTimestamp;

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -37,6 +37,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
         protected DatabaseTest()
         {
+            Environment.SetEnvironmentVariable("SCHEMA", "1");
+
             Processor = new ScoreStatisticsProcessor();
             Processor.Error += processorOnError;
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ElasticQueueProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ElasticQueueProcessor.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Server.QueueProcessor;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor
+{
+    /// <summary>
+    /// Minimal implementation of queue processor to push to queue.
+    /// This should be replaced with a dependency on `osu-elastic-indexer` ASAP.
+    /// </summary>
+    public class ElasticQueueProcessor : QueueProcessor<ElasticQueueProcessor.ElasticScoreItem>
+    {
+        private static readonly string queue_name = $"score-index-{Environment.GetEnvironmentVariable("SCHEMA")}";
+
+        public ElasticQueueProcessor()
+            : base(new QueueConfiguration { InputQueueName = queue_name })
+        {
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SCHEMA")))
+                throw new ArgumentException("Elasticsearch schema should be specified via environment variable SCHEMA");
+
+            // TODO: automate schema version lookup
+            // see https://github.com/ppy/osu-elastic-indexer/blob/316e3e2134933e22363f4911e0be4175984ae15e/osu.ElasticIndexer/Redis.cs#L10
+        }
+
+        protected override void ProcessResult(ElasticScoreItem scoreItem)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Serializable]
+        public class ElasticScoreItem : QueueItem
+        {
+            public long? ScoreId { get; init; }
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsProcessor.cs
@@ -161,28 +161,5 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
 
             return rulesetsToProcess;
         }
-
-        private class ElasticQueueProcessor : QueueProcessor<ElasticQueueProcessor.ElasticScoreItem>
-        {
-            private static readonly string queue_name = $"score-index-{Environment.GetEnvironmentVariable("SCHEMA")}";
-
-            internal ElasticQueueProcessor()
-                : base(new QueueConfiguration { InputQueueName = queue_name })
-            {
-                // TODO: automate schema version lookup
-                // see https://github.com/ppy/osu-elastic-indexer/blob/316e3e2134933e22363f4911e0be4175984ae15e/osu.ElasticIndexer/Redis.cs#L10
-            }
-
-            protected override void ProcessResult(ElasticScoreItem scoreItem)
-            {
-                throw new NotImplementedException();
-            }
-
-            [Serializable]
-            public class ElasticScoreItem : QueueItem
-            {
-                public long? ScoreId { get; init; }
-            }
-        }
     }
 }


### PR DESCRIPTION
I was originally going to write this as a separate command... but it turns out that it's probably lower effort on all parts to reuse this existing command. Abstracting out the shared parts to a base class was a bit of a pain.

I've tested this locally and it seems to work quite well:


https://user-images.githubusercontent.com/191335/205884294-f76f02ba-2835-4511-9801-253d54bcd096.mp4

