### PR TITLE
Add local checkout scripts for `osu-queue-processor`

### DIFF
--- a/UseLocalQueueProcessor.ps1
+++ b/UseLocalQueueProcessor.ps1
@@ -1,0 +1,16 @@
+# Run this script to use a local copy of osu-queue-processor rather than fetching it from nuget.
+# It expects the osu-queue-processor directory to be at the same level as the osu-queue-score-statistics directory.
+
+
+$CSPROJ="osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj"
+$SLN="osu.Server.Queues.ScoreStatisticsProcessor.sln"
+
+$DEPENDENCIES=@(
+    "..\osu-queue-processor\osu.Server.QueueProcessor\osu.Server.QueueProcessor.csproj"
+)
+
+
+dotnet remove $CSPROJ package ppy.osu.Server.OsuQueueProcessor
+
+dotnet sln $SLN add $DEPENDENCIES
+dotnet add $CSPROJ reference $DEPENDENCIES

--- a/UseLocalQueueProcessor.sh
+++ b/UseLocalQueueProcessor.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Run this script to use a local copy of osu-queue-processor rather than fetching it from nuget.
+# It expects the osu-queue-processor directory to be at the same level as the osu-queue-score-statistics directory.
+
+
+CSPROJ="osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj"
+SLN="osu.Server.Queues.ScoreStatisticsProcessor.sln"
+
+DEPENDENCIES="../osu-queue-processor/osu.Server.QueueProcessor/osu.Server.QueueProcessor.csproj"
+
+
+dotnet remove $CSPROJ package ppy.osu.Server.OsuQueueProcessor
+
+dotnet sln $SLN add $DEPENDENCIES
+dotnet add $CSPROJ reference $DEPENDENCIES


### PR DESCRIPTION
Just happened to need these for some experimentation, so I figured I'd PR them.

They can obviously go on any other queue processor as well but I'm not doing that right now.