### PR TITLE
Publish messages about score processing completion to redis

### DIFF
--- a/osu.Server.Queues.ScorePump/osu.Server.Queues.ScorePump.csproj
+++ b/osu.Server.Queues.ScorePump/osu.Server.Queues.ScorePump.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
-        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.1202.0" />
+        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.1220.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/Messages/ScoreProcessed.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/Messages/ScoreProcessed.cs
@@ -1,0 +1,10 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Models.Messages;
+
+public class ScoreProcessed
+{
+    public long ScoreId { get; init; }
+    public byte ProcessedVersion { get; init; }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
@@ -11,12 +11,12 @@
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-        <PackageReference Include="ppy.osu.Game" Version="2022.1208.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.1208.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.1208.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.1208.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.1208.0" />
-        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.1202.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2022.1214.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.1214.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.1214.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.1214.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.1214.0" />
+        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.1220.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-queue-processor/pull/24

Step two to the [proposed flow](https://github.com/ppy/osu/issues/18877#issuecomment-1356880170) required for https://github.com/ppy/osu/issues/18877.

Not much to see here either, but please do advise on data structure design, naming conventions, and error handling. I've made educated guesses but they may well turn out to be incorrect.

Notably, the amount of data in the published message is minimal, placing the burden of refetching the updated user statistics on the subscribers. This feels more versatile but also possibly inconvenient.