### PR TITLE
Allow reprocessing performance totals of users even when existing pp is zero

### DIFF
--- a/osu.Server.Queues.ScorePump/Performance/PerformanceCommand.cs
+++ b/osu.Server.Queues.ScorePump/Performance/PerformanceCommand.cs
@@ -65,8 +65,7 @@ namespace osu.Server.Queues.ScorePump.Performance
                 {
                     var userStats = await DatabaseHelper.GetUserStatsAsync(userId, RulesetId, db);
 
-                    // Only process users with an existing rank_score.
-                    if (userStats!.rank_score_exp == 0)
+                    if (userStats == null)
                         return;
 
                     await TotalProcessor.UpdateUserStatsAsync(userStats, RulesetId, db);


### PR DESCRIPTION
Not sure why this is the case, but it's weird.