### PR TITLE
Add option to use realtime difficulty calculation

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -39,7 +39,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         protected DatabaseTest()
         {
             Environment.SetEnvironmentVariable("SCHEMA", "1");
-            Environment.SetEnvironmentVariable("INLINE_DIFFICULTY_CALCULATION", "0");
+            Environment.SetEnvironmentVariable("REALTIME_DIFFICULTY", "0");
 
             Processor = new ScoreStatisticsProcessor();
             Processor.Error += processorOnError;

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -39,6 +39,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         protected DatabaseTest()
         {
             Environment.SetEnvironmentVariable("SCHEMA", "1");
+            Environment.SetEnvironmentVariable("INLINE_DIFFICULTY_CALCULATION", "0");
 
             Processor = new ScoreStatisticsProcessor();
             Processor.Error += processorOnError;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BeatmapStore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BeatmapStore.cs
@@ -1,12 +1,14 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
 using MySqlConnector;
+using osu.Framework.IO.Network;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Legacy;
 using osu.Game.Online.API.Requests.Responses;
@@ -23,6 +25,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
     /// </summary>
     public class BeatmapStore
     {
+        private static readonly bool use_inline_difficulty_calculation = Environment.GetEnvironmentVariable("INLINE_DIFFICULTY_CALCULATION") != "0";
+        private static readonly string beatmap_download_path = Environment.GetEnvironmentVariable("BEATMAP_DOWNLOAD_PATH") ?? "https://osu.ppy.sh/osu/{0}";
+
         private readonly ConcurrentDictionary<int, Beatmap?> beatmapCache = new ConcurrentDictionary<int, Beatmap?>();
         private readonly ConcurrentDictionary<DifficultyAttributeKey, BeatmapDifficultyAttribute[]?> attributeCache = new ConcurrentDictionary<DifficultyAttributeKey, BeatmapDifficultyAttribute[]?>();
         private readonly IReadOnlyDictionary<BlacklistEntry, byte> blacklist;
@@ -59,6 +64,24 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
         /// <returns>The difficulty attributes or <c>null</c> if not existing.</returns>
         public async Task<DifficultyAttributes?> GetDifficultyAttributesAsync(APIBeatmap beatmap, Ruleset ruleset, Mod[] mods, MySqlConnection connection, MySqlTransaction? transaction = null)
         {
+            if (use_inline_difficulty_calculation)
+            {
+                using var req = new WebRequest(string.Format(beatmap_download_path, beatmap.OnlineID))
+                {
+                    AllowInsecureRequests = true
+                };
+
+                await req.PerformAsync().ConfigureAwait(false);
+
+                if (req.ResponseStream.Length == 0)
+                    throw new Exception($"Retrieved zero-length beatmap ({beatmap.OnlineID})!");
+
+                var workingBeatmap = new StreamedWorkingBeatmap(req.ResponseStream);
+                var calculator = ruleset.CreateDifficultyCalculator(workingBeatmap);
+
+                return calculator.Calculate(mods);
+            }
+
             BeatmapDifficultyAttribute[]? rawDifficultyAttributes;
 
             // Todo: We shouldn't be using legacy mods, but this requires difficulty calculation to be performed in-line.

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BeatmapStore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BeatmapStore.cs
@@ -25,7 +25,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
     /// </summary>
     public class BeatmapStore
     {
-        private static readonly bool use_inline_difficulty_calculation = Environment.GetEnvironmentVariable("INLINE_DIFFICULTY_CALCULATION") != "0";
+        private static readonly bool use_realtime_difficulty_calculation = Environment.GetEnvironmentVariable("REALTIME_DIFFICULTY") != "0";
         private static readonly string beatmap_download_path = Environment.GetEnvironmentVariable("BEATMAP_DOWNLOAD_PATH") ?? "https://osu.ppy.sh/osu/{0}";
 
         private readonly ConcurrentDictionary<int, Beatmap?> beatmapCache = new ConcurrentDictionary<int, Beatmap?>();
@@ -64,7 +64,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
         /// <returns>The difficulty attributes or <c>null</c> if not existing.</returns>
         public async Task<DifficultyAttributes?> GetDifficultyAttributesAsync(APIBeatmap beatmap, Ruleset ruleset, Mod[] mods, MySqlConnection connection, MySqlTransaction? transaction = null)
         {
-            if (use_inline_difficulty_calculation)
+            if (use_realtime_difficulty_calculation)
             {
                 using var req = new WebRequest(string.Format(beatmap_download_path, beatmap.OnlineID))
                 {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/StreamedWorkingBeatmap.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/StreamedWorkingBeatmap.cs
@@ -1,0 +1,65 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using osu.Framework.Audio.Track;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Formats;
+using osu.Game.IO;
+using osu.Game.Rulesets.Catch;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Taiko;
+using osu.Game.Skinning;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor
+{
+    public class StreamedWorkingBeatmap : WorkingBeatmap
+    {
+        private readonly Beatmap beatmap;
+
+        public StreamedWorkingBeatmap(Stream stream)
+            : this(new LineBufferedReader(stream))
+        {
+            stream.Dispose();
+        }
+
+        private StreamedWorkingBeatmap(LineBufferedReader reader)
+            : this(Decoder.GetDecoder<Beatmap>(reader).Decode(reader))
+        {
+            reader.Dispose();
+        }
+
+        private StreamedWorkingBeatmap(Beatmap beatmap)
+            : base(beatmap.BeatmapInfo, null)
+        {
+            this.beatmap = beatmap;
+
+            switch (beatmap.BeatmapInfo.Ruleset.OnlineID)
+            {
+                case 0:
+                    beatmap.BeatmapInfo.Ruleset = new OsuRuleset().RulesetInfo;
+                    break;
+
+                case 1:
+                    beatmap.BeatmapInfo.Ruleset = new TaikoRuleset().RulesetInfo;
+                    break;
+
+                case 2:
+                    beatmap.BeatmapInfo.Ruleset = new CatchRuleset().RulesetInfo;
+                    break;
+
+                case 3:
+                    beatmap.BeatmapInfo.Ruleset = new ManiaRuleset().RulesetInfo;
+                    break;
+            }
+        }
+
+        protected override IBeatmap GetBeatmap() => beatmap;
+        protected override Texture GetBackground() => throw new System.NotImplementedException();
+        protected override Track GetBeatmapTrack() => throw new System.NotImplementedException();
+        protected override ISkin GetSkin() => throw new System.NotImplementedException();
+        public override Stream GetStream(string storagePath) => throw new System.NotImplementedException();
+    }
+}


### PR DESCRIPTION
In order to try to resolve https://github.com/ppy/osu/issues/21815, I want to try out performing realtime difficulty calculation to see where bottlenecks appear.

This PR adds two environment variables:
- [ ] `REALTIME_DIFFICULTY` : Set this to `0` to disable it and return to previous functionality (database lookups). Defaults to enabled if not set.
- [ ] Set envvar to `0` ^^.
- [ ] Set envvar to `0` ^^^^.
- `BEATMAP_DOWNLOAD_PATH` : Set this to the `osu` file download path. Defaults to `https://osu.ppy.sh/osu/{0}`.

Of particular importance, `BEATMAP_DOWNLOAD_PATH` should be set to a path that isn't rate-limited, similar to what is done for `osu-difficulty-calculator` and `osu-beatmap-difficulty-lookup-cache`.

**This PR contains no caching** - please advise on whether/how I should consider some form of minimal caching, perhaps at a `WorkingBeatmap` level, though I'm not sure how useful it'll be if the general case is players playing a very wide range of beatmaps.

**I have not considered full reprocesses** - we haven't done these in general yet so some caching and potentially reordering of operations will have to change in order to do that efficiently. This PR **does apply** to full reprocesses.