### PR TITLE
Fix build cache never being updated until server restart

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "jetbrains.resharper.globaltools": {
-      "version": "2022.1.1",
+      "version": "2022.3.2",
       "commands": [
         "jb"
       ]

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -23,6 +23,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         private BeatmapStore? beatmapStore;
         private BuildStore? buildStore;
 
+        // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
         private readonly Timer cacheResetTimer;
 
         private static readonly bool process_user_totals = Environment.GetEnvironmentVariable("PROCESS_USER_TOTALS") != "0";

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Timers;
 using Dapper;
 using MySqlConnector;
 using osu.Game.Online.API.Requests.Responses;
@@ -22,10 +23,26 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         private BeatmapStore? beatmapStore;
         private BuildStore? buildStore;
 
+        private readonly Timer cacheResetTimer;
+
         private static readonly bool process_user_totals = Environment.GetEnvironmentVariable("PROCESS_USER_TOTALS") != "0";
 
         // This processor needs to run after the score's PP value has been processed.
         public int Order => ScorePerformanceProcessor.ORDER + 1;
+
+        public UserTotalPerformanceProcessor()
+        {
+            cacheResetTimer = new Timer(60000);
+            cacheResetTimer.Elapsed += (_, _) =>
+            {
+                // naive cache clearing, mainly to ensure new builds are picked up on new client releases.
+                beatmapStore = null;
+                buildStore = null;
+            };
+            cacheResetTimer.AutoReset = true;
+            cacheResetTimer.Enabled = true;
+            cacheResetTimer.Start();
+        }
 
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {


### PR DESCRIPTION
While investigating [reports of pp totals not updating](https://github.com/ppy/osu/discussions/22728#discussioncomment-5274115) I noticed that new builds may no be picked up for total calculations.

The fix is a very naive method of refreshing the build/blacklist cache.

I chose 1 minute to generally give it enough time to revalidate cache before someone was to complete a beatmap on a new release. We could potentially make this longer (or smarter) in the future if required.