### PR TITLE
Convert legacy total score to standardised when importing high scores

### DIFF
--- a/osu.Server.Queues.ScorePump/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScorePump/Queue/ImportHighScoresCommand.cs
@@ -520,7 +520,11 @@ namespace osu.Server.Queues.ScorePump.Queue
                     return scoreInfo;
                 }
 
-                if (!dbAttributes.ContainsKey(23) || !dbAttributes.ContainsKey(25) || !dbAttributes.ContainsKey(27))
+                const int legacy_accuracy_score = 23;
+                const int legacy_combo_score = 25;
+                const int legacy_bonus_score_ratio = 27;
+
+                if (!dbAttributes.ContainsKey(legacy_accuracy_score) || !dbAttributes.ContainsKey(legacy_combo_score) || !dbAttributes.ContainsKey(legacy_bonus_score_ratio))
                 {
                     await Console.Error.WriteLineAsync($"{highScore.score_id}: Could not find legacy scoring values in the difficulty attributes of beatmap {highScore.beatmap_id}.");
                     return scoreInfo;
@@ -532,9 +536,9 @@ namespace osu.Server.Queues.ScorePump.Queue
                     scoreInfo.MaximumStatistics[HitResult.LegacyComboIncrease] = (int)maxComboAttribute.value - maxComboFromStatistics;
 #pragma warning restore CS0618
 
-                int maximumLegacyAccuracyScore = (int)dbAttributes[23].value;
-                int maximumLegacyComboScore = (int)dbAttributes[25].value;
-                double maximumLegacyBonusRatio = dbAttributes[27].value;
+                int maximumLegacyAccuracyScore = (int)dbAttributes[legacy_accuracy_score].value;
+                int maximumLegacyComboScore = (int)dbAttributes[legacy_combo_score].value;
+                double maximumLegacyBonusRatio = dbAttributes[legacy_bonus_score_ratio].value;
 
                 // Although the combo-multiplied portion is stored into difficulty attributes, attributes are only present for mod combinations that affect difficulty.
                 // For example, an incoming highscore may be +HDHR, but only difficulty attributes for +HR exist in the database.

--- a/osu.Server.Queues.ScorePump/RecalculateScoresCommand.cs
+++ b/osu.Server.Queues.ScorePump/RecalculateScoresCommand.cs
@@ -12,7 +12,6 @@ using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Scoring;
 using osu.Server.Queues.ScoreStatisticsProcessor;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
@@ -58,7 +57,6 @@ namespace osu.Server.Queues.ScorePump
                         foreach (var score in scores)
                         {
                             bool requiresUpdate = ensureMaximumStatistics(score);
-                            requiresUpdate |= ensureCorrectTotalScore(score);
 
                             if (requiresUpdate)
                             {
@@ -119,27 +117,6 @@ namespace osu.Server.Queues.ScorePump
                         break;
                 }
             }
-
-            return true;
-        }
-
-        private bool ensureCorrectTotalScore(SoloScore score)
-        {
-            Ruleset ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(score.ruleset_id);
-            ScoreInfo scoreInfo = score.ScoreInfo.ToScoreInfo(score.ScoreInfo.Mods.Select(m => m.ToMod(ruleset)).ToArray());
-            scoreInfo.Ruleset = ruleset.RulesetInfo;
-
-            ScoreProcessor scoreProcessor = ruleset.CreateScoreProcessor();
-            scoreProcessor.Mods.Value = scoreInfo.Mods;
-
-            long totalScore = scoreProcessor.ComputeScore(ScoringMode.Standardised, scoreInfo);
-            double accuracy = scoreProcessor.ComputeAccuracy(scoreInfo);
-
-            if (totalScore == score.ScoreInfo.TotalScore && Math.Round(accuracy, 2) == Math.Round(score.ScoreInfo.Accuracy, 2))
-                return false;
-
-            score.ScoreInfo.TotalScore = totalScore;
-            score.ScoreInfo.Accuracy = accuracy;
 
             return true;
         }

--- a/osu.Server.Queues.ScorePump/RecalculateScoresCommand.cs
+++ b/osu.Server.Queues.ScorePump/RecalculateScoresCommand.cs
@@ -2,18 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Dapper;
-using Dapper.Contrib.Extensions;
 using McMaster.Extensions.CommandLineUtils;
-using osu.Game.Rulesets;
-using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Scoring;
-using osu.Server.Queues.ScoreStatisticsProcessor;
-using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScorePump
 {
@@ -34,91 +25,11 @@ namespace osu.Server.Queues.ScorePump
         [Option(CommandOptionType.SingleValue)]
         public int Delay { get; set; }
 
-        public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
+        public Task<int> OnExecuteAsync(CancellationToken cancellationToken)
         {
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                Console.WriteLine($"Processing next {batch_size} scores starting from {StartId}");
-
-                using (var db = Queue.GetDatabaseConnection())
-                {
-                    int updateCount = 0;
-
-                    using (var transaction = await db.BeginTransactionAsync(cancellationToken))
-                    {
-                        SoloScore[] scores = (await db.QueryAsync<SoloScore>($"SELECT * FROM {SoloScore.TABLE_NAME} WHERE `id` >= @StartId ORDER BY `id` LIMIT {batch_size}", new
-                        {
-                            StartId = StartId
-                        }, transaction)).ToArray();
-
-                        if (scores.Length == 0)
-                            break;
-
-                        foreach (var score in scores)
-                        {
-                            bool requiresUpdate = ensureMaximumStatistics(score);
-
-                            if (requiresUpdate)
-                            {
-                                await db.UpdateAsync(score, transaction);
-                                updateCount++;
-                            }
-                        }
-
-                        await transaction.CommitAsync(cancellationToken);
-
-                        StartId = scores.Max(s => s.id) + 1;
-                    }
-
-                    Console.WriteLine($"Updated {updateCount} rows");
-                }
-
-                if (Delay > 0)
-                {
-                    Console.WriteLine($"Waiting {Delay}ms...");
-                    await Task.Delay(Delay, cancellationToken);
-                }
-            }
-
-            Console.WriteLine("Finished.");
-            return 0;
-        }
-
-        private bool ensureMaximumStatistics(SoloScore score)
-        {
-            if (score.ScoreInfo.MaximumStatistics.Sum(s => s.Value) > 0)
-                return false;
-
-            Ruleset ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(score.ruleset_id);
-            HitResult maxBasicResult = ruleset.GetHitResults().Select(h => h.result).Where(h => h.IsBasic()).MaxBy(Judgement.ToNumericResult);
-
-            foreach ((HitResult result, int count) in score.ScoreInfo.Statistics)
-            {
-                switch (result)
-                {
-                    case HitResult.LargeTickHit:
-                    case HitResult.LargeTickMiss:
-                        score.ScoreInfo.MaximumStatistics[HitResult.LargeTickHit] = score.ScoreInfo.MaximumStatistics.GetValueOrDefault(HitResult.LargeTickHit) + count;
-                        break;
-
-                    case HitResult.SmallTickHit:
-                    case HitResult.SmallTickMiss:
-                        score.ScoreInfo.MaximumStatistics[HitResult.SmallTickHit] = score.ScoreInfo.MaximumStatistics.GetValueOrDefault(HitResult.SmallTickHit) + count;
-                        break;
-
-                    case HitResult.IgnoreHit:
-                    case HitResult.IgnoreMiss:
-                    case HitResult.SmallBonus:
-                    case HitResult.LargeBonus:
-                        break;
-
-                    default:
-                        score.ScoreInfo.MaximumStatistics[maxBasicResult] = score.ScoreInfo.MaximumStatistics.GetValueOrDefault(maxBasicResult) + count;
-                        break;
-                }
-            }
-
-            return true;
+            // TODO: the logic to actually recalculate scores was removed. should be considered before this command is used.
+            // see https://github.com/ppy/osu-queue-score-statistics/pull/135.
+            throw new NotImplementedException();
         }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/StreamedWorkingBeatmap.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/StreamedWorkingBeatmap.cs
@@ -57,7 +57,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         }
 
         protected override IBeatmap GetBeatmap() => beatmap;
-        protected override Texture GetBackground() => throw new System.NotImplementedException();
+        public override Texture GetBackground() => throw new System.NotImplementedException();
         protected override Track GetBeatmapTrack() => throw new System.NotImplementedException();
         protected override ISkin GetSkin() => throw new System.NotImplementedException();
         public override Stream GetStream(string storagePath) => throw new System.NotImplementedException();

--- a/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
@@ -11,11 +11,11 @@
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-        <PackageReference Include="ppy.osu.Game" Version="2022.1214.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.1214.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.1214.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.1214.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.1214.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.717.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.717.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.717.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.717.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.717.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2022.1220.0" />
     </ItemGroup>
 


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/24072
- [x] Depends on `osu.Game` bump

One questionable/important aspect is that we don't store difficulty attributes for _all_ mod combinations. For example, for +HDHR, we only store the difficulty attributes for +HR. Because of this, there's an extra step here that re-multiplies the `LegacyComboScore` with the correct mod multiplier.  

This could result in an off-by-one score for each hitobject because [legacy scoring truncates at every judgement](https://github.com/ppy/osu/pull/24072/files#diff-c39a8a7ee2d48bcf35309f47a10b371f662af92a1b7638a0f7320d31591fa8edR162), that adds up over time. For example, [chocomint's score on `FREEDOM DiVE [FOUR DIMENSIONS]`](https://osu.ppy.sh/scores/osu/2177560145) converts to `1116538` when imported via this process, but `1116540` when imported directly from replay into lazer.

I've taken the liberty to treat this small discrepancy as acceptable.

---

Required database attributes:

```sql
INSERT INTO osu_difficulty_attribs (attrib_id, name) VALUES (23, 'Legacy Accuracy Score'), (25, 'Legacy Combo Score'), (27, 'Legacy Bonus Score Ratio');
```

We must re-run the difficulty calculator across all ranked beatmaps on all rulesets prior to any new import, with the osu-side changes applied.