### PR TITLE
Fix beatmap object counts data type

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/Beatmap.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/Beatmap.cs
@@ -21,10 +21,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 
         public int beatmapset_id { get; set; }
 
-        public ushort countTotal { get; set; }
-        public ushort countNormal { get; set; }
-        public ushort countSlider { get; set; }
-        public ushort countSpinner { get; set; }
+        public uint countTotal { get; set; }
+        public uint countNormal { get; set; }
+        public uint countSlider { get; set; }
+        public uint countSpinner { get; set; }
         public int total_length { get; set; }
         public float diff_drain { get; set; }
         public float diff_size { get; set; }
@@ -37,9 +37,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
         public APIBeatmap ToAPIBeatmap() => new APIBeatmap
         {
             OnlineID = beatmap_id,
-            CircleCount = countNormal,
-            SliderCount = countSlider,
-            SpinnerCount = countSpinner,
+            CircleCount = (int)countNormal,
+            SliderCount = (int)countSlider,
+            SpinnerCount = (int)countSpinner,
             DrainRate = diff_drain,
             CircleSize = diff_size,
             OverallDifficulty = diff_overall,


### PR DESCRIPTION
These were recently changed to be `MEDIUMINT UNSIGNED` in the database, which causes errors such as:
```
20963-ppcalc-1  | Unhandled exception. System.Data.DataException: Error parsing column 8 (countTotal=63962 - UInt32)
20963-ppcalc-1  |  ---> System.OverflowException: Arithmetic operation resulted in an overflow.
20963-ppcalc-1  |    at Deserializecf30c795-010e-4dbf-bb01-ce4cdfb1cf4b(IDataReader )
20963-ppcalc-1  |    --- End of inner exception stack trace ---
20963-ppcalc-1  |    at Dapper.SqlMapper.ThrowDataException(Exception ex, Int32 index, IDataReader reader, Object value) in /_/Dapper/SqlMapper.cs:line 3706
20963-ppcalc-1  |    at Deserializecf30c795-010e-4dbf-bb01-ce4cdfb1cf4b(IDataReader )
20963-ppcalc-1  |    at Dapper.SqlMapper.QueryRowAsync[T](IDbConnection cnn, Row row, Type effectiveType, CommandDefinition command)
20963-ppcalc-1  |    at osu.Server.Queues.ScoreStatisticsProcessor.Stores.BeatmapStore.GetBeatmapAsync(Int32 beatmapId, MySqlConnection connection, MySqlTransaction transaction)
```