### PR TITLE
Add command to clean up non-preserved scores

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/DeleteNonPreservedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/DeleteNonPreservedScoresCommand.cs
@@ -1,0 +1,52 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using McMaster.Extensions.CommandLineUtils;
+using MySqlConnector;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
+{
+    [Command("cleanup", Description = "Delete non-preserved scores which are stale enough.")]
+    public class DeleteNonPreservedScoresCommand : BaseCommand
+    {
+        /// <summary>
+        /// How many hours non-preserved scores should be retained before being purged.
+        /// </summary>
+        private const int preserve_hours = 48;
+
+        public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
+        {
+            using (var db = Queue.GetDatabaseConnection())
+            using (var deleteCommand = db.CreateCommand())
+            {
+                var scores = await db.QueryAsync<SoloScore>(new CommandDefinition($"SELECT * FROM {SoloScore.TABLE_NAME} WHERE preserve = 0 AND updated_at < DATE_SUB(NOW(), INTERVAL {preserve_hours} HOUR)", flags: CommandFlags.None, cancellationToken: cancellationToken));
+
+                deleteCommand.CommandText =
+                    $"DELETE FROM {SoloScorePerformance.TABLE_NAME} WHERE score_id = @id;" +
+                    $"DELETE FROM {ProcessHistory.TABLE_NAME} WHERE score_id = @id;" +
+                    $"DELETE FROM {SoloScore.TABLE_NAME} WHERE id = @id;";
+
+                var scoreId = deleteCommand.Parameters.Add("id", MySqlDbType.UInt64);
+
+                await deleteCommand.PrepareAsync(cancellationToken);
+
+                foreach (var score in scores)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                        break;
+
+                    Console.WriteLine($"Deleting score {score.id}...");
+                    scoreId.Value = score.id;
+                    await deleteCommand.ExecuteNonQueryAsync(cancellationToken);
+                }
+            }
+
+            return 0;
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/MaintenanceCommands.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/MaintenanceCommands.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading;
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+using osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands
+{
+    [Command(Name = "maintenance", Description = "General database maintenance commands which are usually run on a cron schedule.")]
+    [Subcommand(typeof(DeleteNonPreservedScoresCommand))]
+    public sealed class MaintenanceCommands
+    {
+        public Task<int> OnExecuteAsync(CommandLineApplication app, CancellationToken cancellationToken)
+        {
+            app.ShowHelp(false);
+            return Task.FromResult(1);
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Program.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Program.cs
@@ -9,6 +9,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
     [Command]
     [Subcommand(typeof(QueueCommands))]
     [Subcommand(typeof(PerformanceCommands))]
+    [Subcommand(typeof(MaintenanceCommands))]
     public class Program
     {
         private static readonly CancellationTokenSource cts = new CancellationTokenSource();


### PR DESCRIPTION
Note that cancellation doesn't work because dapper. Will probably want to consider migrating to something that does work.

I'm not aiming for efficiency here because it doesn't need to be that efficient. Currently running on production to test (is cleaning around 500 scores per second).

Addresses part of https://github.com/ppy/osu-queue-score-statistics/issues/141 (deleting of scores which are already in a non-preserved state). Remaining piece is to downgrade preserved scores to non-preserved when they can be.