### PR TITLE
Add command to revoke preserved flag from scores which no longer require it

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MarkNonPreservedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MarkNonPreservedScoresCommand.cs
@@ -1,0 +1,71 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using McMaster.Extensions.CommandLineUtils;
+using MySqlConnector;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
+{
+    [Command("mark-non-preserved", Description = "Mark any scores which no longer need to be preserved.")]
+    public class MarkNonPreservedScoresCommand : BaseCommand
+    {
+        public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
+        {
+            using (var readConnection = Queue.GetDatabaseConnection())
+            using (var deleteConnection = Queue.GetDatabaseConnection())
+            using (var markCommand = deleteConnection.CreateCommand())
+            {
+                markCommand.CommandText = $"UPDATE {SoloScore.TABLE_NAME} SET preserve = 0 WHERE id = @id;";
+                MySqlParameter scoreId = markCommand.Parameters.Add("id", MySqlDbType.UInt64);
+                await markCommand.PrepareAsync(cancellationToken);
+
+                // We are going to be processing a sheer motherload of scores.
+                // The best way to do this right now is per-user, as we have an index for that (and generally a single user will have 1-50,000 scores, making it a good amount to process at once).
+                // Or maybe we want a queue for it.
+                var scores = await readConnection.QueryAsync<SoloScore>(new CommandDefinition($"SELECT * FROM {SoloScore.TABLE_NAME} WHERE preserve = 1 ORDER BY user_id, ruleset_id", flags: CommandFlags.None, cancellationToken: cancellationToken));
+
+                foreach (var score in scores)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                        break;
+
+                    // TODO: check pinned state
+                    // TODO: check whether multiplayer score that needs saving
+
+                    // TODO: check whether other score is higher than this one for the user (we only need to keep the top)
+
+                    // TODO: fix mod equality check
+                    var maxPPUserScore = scores
+                                         .Where(s => s.beatmap_id == score.beatmap_id && s.ruleset_id == score.ruleset_id && s.ScoreInfo.Mods.SequenceEqual(score.ScoreInfo.Mods))
+                                         .MaxBy(s => s.ScoreInfo.PP);
+
+                    var maxScoreUserScore = scores
+                                            .Where(s => s.beatmap_id == score.beatmap_id && s.ruleset_id == score.ruleset_id && s.ScoreInfo.Mods.SequenceEqual(score.ScoreInfo.Mods))
+                                            .MaxBy(s => s.ScoreInfo.TotalScore);
+
+                    // Check whether this score is the user's highest
+                    if (maxPPUserScore?.id == score.id || maxScoreUserScore?.id == score.id)
+                    {
+                        Console.WriteLine($"Maintaining preservation for {score.id} (is user high)");
+                        continue;
+                    }
+
+                    Console.WriteLine($"Marking score {score.id} non-preserved...");
+                    scoreId.Value = score.id;
+
+                    // TODO: break production
+                    // await markCommand.ExecuteNonQueryAsync(cancellationToken);
+                    // TODO: queue for de-indexing
+                }
+            }
+
+            return 0;
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MarkNonPreservedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MarkNonPreservedScoresCommand.cs
@@ -43,20 +43,18 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
         private async Task processUser(MySqlConnection db, int userId, CancellationToken cancellationToken)
         {
-            IEnumerable<SoloScore> scores = await db.QueryAsync<SoloScore>(new CommandDefinition($"SELECT * FROM {SoloScore.TABLE_NAME} WHERE preserve = 1 AND user_id = @userId AND ruleset_id = @rulesetId", new
+            var parameters = new
             {
                 userId = userId,
                 rulesetId = RulesetId,
-            }, cancellationToken: cancellationToken));
+            };
+
+            IEnumerable<SoloScore> scores = await db.QueryAsync<SoloScore>(new CommandDefinition($"SELECT * FROM {SoloScore.TABLE_NAME} WHERE preserve = 1 AND user_id = @userId AND ruleset_id = @rulesetId", parameters, cancellationToken: cancellationToken));
 
             if (!scores.Any())
                 return;
 
-            IEnumerable<ulong> pins = db.Query<ulong>("SELECT score_id FROM score_pins WHERE user_id = @userId AND ruleset_id = @rulesetId AND score_type = 'solo_score'", new
-            {
-                userId = userId,
-                rulesetId = RulesetId,
-            });
+            IEnumerable<ulong> pins = db.Query<ulong>("SELECT score_id FROM score_pins WHERE user_id = @userId AND ruleset_id = @rulesetId AND score_type = 'solo_score'", parameters);
 
             Console.WriteLine($"Processing user {userId} ({scores.Count()} scores)..");
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MarkNonPreservedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MarkNonPreservedScoresCommand.cs
@@ -17,6 +17,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
     [Command("mark-non-preserved", Description = "Mark any scores which no longer need to be preserved.")]
     public class MarkNonPreservedScoresCommand : BaseCommand
     {
+        private readonly ElasticQueueProcessor elasticQueueProcessor = new ElasticQueueProcessor();
+
         [Option(CommandOptionType.SingleValue, Template = "-r|--ruleset", Description = "The ruleset to process.")]
         public int RulesetId { get; set; }
 
@@ -83,7 +85,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                     scoreId = score.id
                 });
 
-                // TODO: queue for de-indexing
+                elasticQueueProcessor.PushToQueue(new ElasticQueueProcessor.ElasticScoreItem
+                {
+                    ScoreId = (long?)score.id
+                });
             }
         }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MarkNonPreservedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MarkNonPreservedScoresCommand.cs
@@ -2,12 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Dapper;
 using McMaster.Extensions.CommandLineUtils;
 using MySqlConnector;
+using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
@@ -15,57 +17,103 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
     [Command("mark-non-preserved", Description = "Mark any scores which no longer need to be preserved.")]
     public class MarkNonPreservedScoresCommand : BaseCommand
     {
+        [Option(CommandOptionType.SingleValue, Template = "-r|--ruleset", Description = "The ruleset to process.")]
+        public int RulesetId { get; set; }
+
         public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
         {
-            using (var readConnection = Queue.GetDatabaseConnection())
-            using (var deleteConnection = Queue.GetDatabaseConnection())
-            using (var markCommand = deleteConnection.CreateCommand())
+            LegacyDatabaseHelper.RulesetDatabaseInfo databaseInfo = LegacyDatabaseHelper.GetRulesetSpecifics(RulesetId);
+
+            Console.WriteLine($"Running for ruleset {RulesetId}");
+
+            using (var db = Queue.GetDatabaseConnection())
             {
-                markCommand.CommandText = $"UPDATE {SoloScore.TABLE_NAME} SET preserve = 0 WHERE id = @id;";
-                MySqlParameter scoreId = markCommand.Parameters.Add("id", MySqlDbType.UInt64);
-                await markCommand.PrepareAsync(cancellationToken);
+                Console.WriteLine("Fetching all users...");
+                int[] userIds = (await db.QueryAsync<int>($"SELECT `user_id` FROM {databaseInfo.UserStatsTable}")).ToArray();
+                Console.WriteLine($"Fetched {userIds.Length} users");
 
-                // We are going to be processing a sheer motherload of scores.
-                // The best way to do this right now is per-user, as we have an index for that (and generally a single user will have 1-50,000 scores, making it a good amount to process at once).
-                // Or maybe we want a queue for it.
-                var scores = await readConnection.QueryAsync<SoloScore>(new CommandDefinition($"SELECT * FROM {SoloScore.TABLE_NAME} WHERE preserve = 1 ORDER BY user_id, ruleset_id", flags: CommandFlags.None, cancellationToken: cancellationToken));
-
-                foreach (var score in scores)
-                {
-                    if (cancellationToken.IsCancellationRequested)
-                        break;
-
-                    // TODO: check pinned state
-                    // TODO: check whether multiplayer score that needs saving
-
-                    // TODO: check whether other score is higher than this one for the user (we only need to keep the top)
-
-                    // TODO: fix mod equality check
-                    var maxPPUserScore = scores
-                                         .Where(s => s.beatmap_id == score.beatmap_id && s.ruleset_id == score.ruleset_id && s.ScoreInfo.Mods.SequenceEqual(score.ScoreInfo.Mods))
-                                         .MaxBy(s => s.ScoreInfo.PP);
-
-                    var maxScoreUserScore = scores
-                                            .Where(s => s.beatmap_id == score.beatmap_id && s.ruleset_id == score.ruleset_id && s.ScoreInfo.Mods.SequenceEqual(score.ScoreInfo.Mods))
-                                            .MaxBy(s => s.ScoreInfo.TotalScore);
-
-                    // Check whether this score is the user's highest
-                    if (maxPPUserScore?.id == score.id || maxScoreUserScore?.id == score.id)
-                    {
-                        Console.WriteLine($"Maintaining preservation for {score.id} (is user high)");
-                        continue;
-                    }
-
-                    Console.WriteLine($"Marking score {score.id} non-preserved...");
-                    scoreId.Value = score.id;
-
-                    // TODO: break production
-                    // await markCommand.ExecuteNonQueryAsync(cancellationToken);
-                    // TODO: queue for de-indexing
-                }
+                foreach (int userId in userIds)
+                    await processUser(db, userId, cancellationToken);
             }
 
             return 0;
         }
+
+        private async Task processUser(MySqlConnection db, int userId, CancellationToken cancellationToken)
+        {
+            var scores = await db.QueryAsync<SoloScore>(new CommandDefinition($"SELECT * FROM {SoloScore.TABLE_NAME} WHERE preserve = 1 AND user_id = @userId AND ruleset_id = @rulesetId", new
+            {
+                userId = userId,
+                rulesetId = RulesetId,
+            }, cancellationToken: cancellationToken));
+
+            if (!scores.Any())
+                return;
+
+            Console.WriteLine($"Processing user {userId} ({scores.Count()} scores)..");
+
+            foreach (var score in scores)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    break;
+
+                if (checkPinned(db, userId, score))
+                {
+                    Console.WriteLine($"Maintaining preservation for {score.id} (is pinned)");
+                    continue;
+                }
+
+                if (checkIsMultiplayerScore(db, score))
+                {
+                    Console.WriteLine($"Maintaining preservation for {score.id} (is multiplayer)");
+                    continue;
+                }
+
+                // check whether this score is a user high (either total_score or pp)
+                if (checkIsUserHigh(scores, score))
+                {
+                    Console.WriteLine($"Maintaining preservation for {score.id} (is user high)");
+                    continue;
+                }
+
+                Console.WriteLine($"Marking score {score.id} non-preserved...");
+
+                await db.ExecuteAsync($"UPDATE {SoloScore.TABLE_NAME} SET preserve = 0 WHERE id = @scoreId;", new
+                {
+                    scoreId = score.id
+                });
+
+                // TODO: queue for de-indexing
+            }
+        }
+
+        private bool checkIsMultiplayerScore(MySqlConnection db, SoloScore score)
+        {
+            // TODO: implement (once multiplayer scores are in solo_scores, is an ongoing effort in osu-web).
+            return false;
+        }
+
+        private static bool checkIsUserHigh(IEnumerable<SoloScore> userScores, SoloScore candidate)
+        {
+            // TODO: fix mod equality check (should not consider options; should not be ordered comparison)
+            var maxPPUserScore = userScores
+                                 .Where(s => s.beatmap_id == candidate.beatmap_id && s.ruleset_id == candidate.ruleset_id && s.ScoreInfo.Mods.SequenceEqual(candidate.ScoreInfo.Mods))
+                                 .MaxBy(s => s.ScoreInfo.PP);
+
+            var maxScoreUserScore = userScores
+                                    .Where(s => s.beatmap_id == candidate.beatmap_id && s.ruleset_id == candidate.ruleset_id && s.ScoreInfo.Mods.SequenceEqual(candidate.ScoreInfo.Mods))
+                                    .MaxBy(s => s.ScoreInfo.TotalScore);
+
+            // Check whether this score is the user's highest
+            return maxPPUserScore?.id == candidate.id || maxScoreUserScore?.id == candidate.id;
+        }
+
+        private bool checkPinned(MySqlConnection db, int userId, SoloScore score) =>
+            db.QuerySingle<int>("SELECT COUNT(*) FROM score_pins WHERE user_id = @userId AND score_id = @scoreId AND ruleset_id = @rulesetId AND score_type = 'solo_score'", new
+            {
+                userId = userId,
+                rulesetId = RulesetId,
+                scoreId = score.id
+            }) > 1;
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/MaintenanceCommands.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/MaintenanceCommands.cs
@@ -10,6 +10,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands
 {
     [Command(Name = "maintenance", Description = "General database maintenance commands which are usually run on a cron schedule.")]
     [Subcommand(typeof(DeleteNonPreservedScoresCommand))]
+    [Subcommand(typeof(MarkNonPreservedScoresCommand))]
     public sealed class MaintenanceCommands
     {
         public Task<int> OnExecuteAsync(CommandLineApplication app, CancellationToken cancellationToken)


### PR DESCRIPTION
This is a first step implementation which runs across all users.

The next step is making a queue for this, so that processes like score submission, pinning/unpinning etc. can notify us that we need to re-check a user. This should reduce the overhead involved in this process.

I've already structured this code in a way it can be extracted out for the next step, so this is mainly to get eyes on the process and have a fallback maintenance command for when shit-hits-fan.