### PR TITLE
Add command to delete imported high scores

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.sln.DotSettings
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.sln.DotSettings
@@ -250,6 +250,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_INTERNAL_MODIFIER/@EntryValue">Explicit</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/LOCAL_FUNCTION_BODY/@EntryValue">ExpressionBody</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/METHOD_OR_OPERATOR_BODY/@EntryValue">BlockBody</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/NAMESPACE_BODY/@EntryValue">BlockScoped</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/OBJECT_CREATION_WHEN_TYPE_EVIDENT/@EntryValue">ExplicitlyTyped</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/USE_HEURISTICS_FOR_BODY_STYLE/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ACCESSOR_DECLARATION_BRACES/@EntryValue">NEXT_LINE</s:String>

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/DeleteImportedHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/DeleteImportedHighScoresCommand.cs
@@ -1,0 +1,95 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using McMaster.Extensions.CommandLineUtils;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue;
+
+/// <summary>
+/// Deletes already-imported high scores from the solo_scores table.
+/// </summary>
+/// <remarks>
+/// Sometimes we need to delete already imported scores to fix an issue (or remove them for good).
+/// This command handles doing that correctly, including de-indexing, deleting related entities, etc.
+///
+/// If running this on a large batch, it is recommended to stop the import process first, and then re-run
+/// it from the earliest deleted `score_id`. This will ensure correctness of ordering.
+///
+/// For complete correctness, all scores from the earliest deletion to the latest score should be deleted.
+/// If not, scores will be out of order chronologically in their solo_score.id space.
+///
+/// Generally this isn't a huge issue, and the chance of it being seen in tiebreaker comparisons is as close to
+/// zero as it gets. But it does mean that we can no longer make the assertion that legacy imports are chronologically imported.
+/// I'm not sure how important this is in the first place, because they are never going to be perfectly chronological next to
+/// non-imported (lazer-first) scores anyway...
+/// </remarks>
+[Command("delete-high-scores", Description = $"Deletes already-imported high scores from the {SoloScore.TABLE_NAME} table.")]
+public class DeleteImportedHighScoresCommand : BaseCommand
+{
+    /// <summary>
+    /// The high score ID to start deleting imported high scores from.
+    /// </summary>
+    [Argument(0)]
+    public ulong StartId { get; set; }
+
+    private ElasticQueueProcessor? elasticQueueProcessor;
+
+    public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
+    {
+        ulong lastId = StartId;
+
+        Console.WriteLine();
+        Console.WriteLine($"Deleting from {SoloScore.TABLE_NAME} starting from {lastId}");
+
+        elasticQueueProcessor = new ElasticQueueProcessor();
+        Console.WriteLine($"Indexing to elasticsearch queue {elasticQueueProcessor.QueueName}");
+
+        Thread.Sleep(5000);
+
+        using (var conn = Queue.GetDatabaseConnection())
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                using (var transaction = await conn.BeginTransactionAsync(cancellationToken))
+                {
+                    var highScores = await conn.QueryAsync<SoloScore>("SELECT * FROM solo_scores WHERE id >= @lastId ORDER BY id LIMIT 500", new { lastId = lastId }, transaction);
+
+                    if (!highScores.Any())
+                    {
+                        Console.WriteLine("All done!");
+                        break;
+                    }
+
+                    foreach (var score in highScores)
+                    {
+                        await conn.ExecuteAsync("DELETE FROM solo_scores_performance WHERE score_id = @id; DELETE FROM solo_scores WHERE id = @id", score, transaction);
+                        await conn.ExecuteAsync("DELETE FROM solo_scores_legacy_id_map WHERE ruleset_id = @ruleset_id AND old_score_id = @legacy_score_id", new
+                        {
+                            ruleset_id = score.ruleset_id,
+                            legacy_score_id = score.ScoreInfo.LegacyScoreId
+                        }, transaction);
+                    }
+
+                    if (elasticQueueProcessor != null)
+                    {
+                        var elasticItems = highScores.Select(score => new ElasticQueueProcessor.ElasticScoreItem { ScoreId = (long?)score.id }).ToArray();
+
+                        elasticQueueProcessor.PushToQueue(elasticItems);
+                        Console.WriteLine($"Queued {elasticItems.Length} items for indexing");
+                    }
+
+                    lastId = highScores.Max(s => s.id);
+                    Console.WriteLine($"Deleted up to {lastId}");
+                }
+            }
+        }
+
+        return 0;
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/DeleteImportedHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/DeleteImportedHighScoresCommand.cs
@@ -10,97 +10,98 @@ using Dapper;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
-namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue;
-
-/// <summary>
-/// Deletes already-imported high scores from the solo_scores table.
-/// </summary>
-/// <remarks>
-/// Sometimes we need to delete already imported scores to fix an issue (or remove them for good).
-/// This command handles doing that correctly, including de-indexing, deleting related entities, etc.
-///
-/// If running this on a large batch, it is recommended to stop the import process first, and then re-run
-/// it from the earliest deleted `score_id`. This will ensure correctness of ordering.
-///
-/// For complete correctness, all scores from the earliest deletion to the latest score should be deleted.
-/// If not, scores will be out of order chronologically in their solo_score.id space.
-///
-/// Generally this isn't a huge issue, and the chance of it being seen in tiebreaker comparisons is as close to
-/// zero as it gets. But it does mean that we can no longer make the assertion that legacy imports are chronologically imported.
-/// I'm not sure how important this is in the first place, because they are never going to be perfectly chronological next to
-/// non-imported (lazer-first) scores anyway...
-/// </remarks>
-[Command("delete-high-scores", Description = $"Deletes already-imported high scores from the {SoloScore.TABLE_NAME} table.")]
-public class DeleteImportedHighScoresCommand : BaseCommand
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 {
     /// <summary>
-    /// The high score ID to start deleting imported high scores from.
+    /// Deletes already-imported high scores from the solo_scores table.
     /// </summary>
-    [Argument(0)]
-    public ulong StartId { get; set; }
-
-    private ElasticQueueProcessor? elasticQueueProcessor;
-
-    public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
+    /// <remarks>
+    /// Sometimes we need to delete already imported scores to fix an issue (or remove them for good).
+    /// This command handles doing that correctly, including de-indexing, deleting related entities, etc.
+    ///
+    /// If running this on a large batch, it is recommended to stop the import process first, and then re-run
+    /// it from the earliest deleted `score_id`. This will ensure correctness of ordering.
+    ///
+    /// For complete correctness, all scores from the earliest deletion to the latest score should be deleted.
+    /// If not, scores will be out of order chronologically in their solo_score.id space.
+    ///
+    /// Generally this isn't a huge issue, and the chance of it being seen in tiebreaker comparisons is as close to
+    /// zero as it gets. But it does mean that we can no longer make the assertion that legacy imports are chronologically imported.
+    /// I'm not sure how important this is in the first place, because they are never going to be perfectly chronological next to
+    /// non-imported (lazer-first) scores anyway...
+    /// </remarks>
+    [Command("delete-high-scores", Description = $"Deletes already-imported high scores from the {SoloScore.TABLE_NAME} table.")]
+    public class DeleteImportedHighScoresCommand : BaseCommand
     {
-        ulong lastId = StartId;
-        int deleted = 0;
+        /// <summary>
+        /// The high score ID to start deleting imported high scores from.
+        /// </summary>
+        [Argument(0)]
+        public ulong StartId { get; set; }
 
-        Console.WriteLine();
-        Console.WriteLine($"Deleting from {SoloScore.TABLE_NAME} starting from {lastId}");
+        private ElasticQueueProcessor? elasticQueueProcessor;
 
-        elasticQueueProcessor = new ElasticQueueProcessor();
-        Console.WriteLine($"Indexing to elasticsearch queue {elasticQueueProcessor.QueueName}");
-
-        Thread.Sleep(5000);
-
-        using (var conn = Queue.GetDatabaseConnection())
+        public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
         {
-            while (!cancellationToken.IsCancellationRequested)
+            ulong lastId = StartId;
+            int deleted = 0;
+
+            Console.WriteLine();
+            Console.WriteLine($"Deleting from {SoloScore.TABLE_NAME} starting from {lastId}");
+
+            elasticQueueProcessor = new ElasticQueueProcessor();
+            Console.WriteLine($"Indexing to elasticsearch queue {elasticQueueProcessor.QueueName}");
+
+            Thread.Sleep(5000);
+
+            using (var conn = Queue.GetDatabaseConnection())
             {
-                List<ElasticQueueProcessor.ElasticScoreItem> elasticItems = new List<ElasticQueueProcessor.ElasticScoreItem>();
-
-                using (var transaction = await conn.BeginTransactionAsync(cancellationToken))
+                while (!cancellationToken.IsCancellationRequested)
                 {
-                    var highScores = await conn.QueryAsync<SoloScore>("SELECT * FROM solo_scores WHERE id >= @lastId ORDER BY id LIMIT 500", new { lastId = lastId }, transaction);
+                    List<ElasticQueueProcessor.ElasticScoreItem> elasticItems = new List<ElasticQueueProcessor.ElasticScoreItem>();
 
-                    if (!highScores.Any())
+                    using (var transaction = await conn.BeginTransactionAsync(cancellationToken))
                     {
-                        Console.WriteLine("All done!");
-                        break;
-                    }
+                        var highScores = await conn.QueryAsync<SoloScore>("SELECT * FROM solo_scores WHERE id >= @lastId ORDER BY id LIMIT 500", new { lastId = lastId }, transaction);
 
-                    elasticItems.Clear();
-
-                    foreach (var score in highScores)
-                    {
-                        if (score.ScoreInfo.LegacyScoreId == null)
-                            continue;
-
-                        Console.WriteLine($"Deleting {score.id}...");
-                        await conn.ExecuteAsync("DELETE FROM solo_scores_performance WHERE score_id = @id; DELETE FROM solo_scores WHERE id = @id", score, transaction);
-                        await conn.ExecuteAsync("DELETE FROM solo_scores_legacy_id_map WHERE ruleset_id = @ruleset_id AND old_score_id = @legacy_score_id", new
+                        if (!highScores.Any())
                         {
-                            ruleset_id = score.ruleset_id,
-                            legacy_score_id = score.ScoreInfo.LegacyScoreId
-                        }, transaction);
+                            Console.WriteLine("All done!");
+                            break;
+                        }
 
-                        elasticItems.Add(new ElasticQueueProcessor.ElasticScoreItem { ScoreId = (long?)score.id });
-                        deleted++;
+                        elasticItems.Clear();
+
+                        foreach (var score in highScores)
+                        {
+                            if (score.ScoreInfo.LegacyScoreId == null)
+                                continue;
+
+                            Console.WriteLine($"Deleting {score.id}...");
+                            await conn.ExecuteAsync("DELETE FROM solo_scores_performance WHERE score_id = @id; DELETE FROM solo_scores WHERE id = @id", score, transaction);
+                            await conn.ExecuteAsync("DELETE FROM solo_scores_legacy_id_map WHERE ruleset_id = @ruleset_id AND old_score_id = @legacy_score_id", new
+                            {
+                                ruleset_id = score.ruleset_id,
+                                legacy_score_id = score.ScoreInfo.LegacyScoreId
+                            }, transaction);
+
+                            elasticItems.Add(new ElasticQueueProcessor.ElasticScoreItem { ScoreId = (long?)score.id });
+                            deleted++;
+                        }
+
+                        if (elasticItems.Count > 0)
+                        {
+                            elasticQueueProcessor.PushToQueue(elasticItems);
+                            Console.WriteLine($"Queued {elasticItems.Count} items for indexing");
+                        }
+
+                        lastId = highScores.Max(s => s.id);
+                        Console.WriteLine($"Processed up to {lastId} ({deleted} deleted)");
                     }
-
-                    if (elasticItems.Count > 0)
-                    {
-                        elasticQueueProcessor.PushToQueue(elasticItems);
-                        Console.WriteLine($"Queued {elasticItems.Count} items for indexing");
-                    }
-
-                    lastId = highScores.Max(s => s.id);
-                    Console.WriteLine($"Processed up to {lastId} ({deleted} deleted)");
                 }
             }
-        }
 
-        return 0;
+            return 0;
+        }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -29,6 +29,14 @@ using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 {
+    /// <summary>
+    /// Imports high scores from the osu_scores_high tables into the new solo_scores table.
+    /// </summary>
+    /// <remarks>
+    /// This command is written under the assumption that only one importer instance is running concurrently.
+    /// This is important to guarantee that scores are inserted in the same sequential order that they originally occured,
+    /// which can be used for tie-breaker scenarios.
+    /// </remarks>
     [Command("import-high-scores", Description = $"Imports high scores from the osu_scores_high tables into the new {SoloScore.TABLE_NAME} table.")]
     public class ImportHighScoresCommand : BaseCommand
     {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/QueueCommands.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/QueueCommands.cs
@@ -14,6 +14,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands
     [Subcommand(typeof(ClearQueueCommand))]
     [Subcommand(typeof(WatchQueueCommand))]
     [Subcommand(typeof(ImportHighScoresCommand))]
+    [Subcommand(typeof(DeleteImportedHighScoresCommand))]
     public sealed class QueueCommands
     {
         public Task<int> OnExecuteAsync(CommandLineApplication app, CancellationToken cancellationToken)


### PR DESCRIPTION
I wrote this, but realised we can probably benefit more from a command which re-imports "in-place", keeping the same ID mapping. So I'm going to make that now in addition to this.

But might as well have this one handy for that one rainy day when shit hits the fan?

Closes #146.

Note that this hasn't been heavily battle-tested.