### PR TITLE
Add support for increasing rank counts

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -67,7 +67,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             Task.Run(() => Processor.Run(CancellationToken), CancellationToken);
         }
 
-        protected void SetScoreForBeatmap(int beatmapId, Action<ScoreItem>? scoreSetup = null)
+        protected ScoreItem SetScoreForBeatmap(int beatmapId, Action<ScoreItem>? scoreSetup = null)
         {
             using (MySqlConnection conn = Processor.GetDatabaseConnection())
             {
@@ -77,6 +77,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
                 conn.Insert(score.Score);
                 PushToQueueAndWaitForProcess(score);
+
+                return score;
             }
         }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -32,12 +32,16 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         protected const int TEST_BEATMAP_ID = 1;
         protected const int TEST_BEATMAP_SET_ID = 1;
 
-        private readonly CancellationTokenSource cancellationSource = new CancellationTokenSource(10000);
+        private readonly CancellationTokenSource cancellationSource;
 
         private Exception? firstError;
 
         protected DatabaseTest()
         {
+            cancellationSource = Debugger.IsAttached
+                ? new CancellationTokenSource()
+                : new CancellationTokenSource(10000);
+
             Environment.SetEnvironmentVariable("SCHEMA", "1");
             Environment.SetEnvironmentVariable("REALTIME_DIFFICULTY", "0");
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/UserRankCountProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/UserRankCountProcessorTests.cs
@@ -61,6 +61,21 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         }
 
         [Fact]
+        public void TestNonPassingScoreDoesNothing()
+        {
+            AddBeatmap();
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
+            {
+                item.Score.ScoreInfo.Passed = false;
+                item.Score.ScoreInfo.Rank = ScoreRank.A;
+            });
+
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+        }
+
+        [Fact]
         public void TestScoreWithRankBelowADoesNothing()
         {
             AddBeatmap();

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/UserRankCountProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/UserRankCountProcessorTests.cs
@@ -1,0 +1,317 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Scoring;
+using Xunit;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
+{
+    public class UserRankCountProcessorTests : DatabaseTest
+    {
+        [Fact]
+        public void TestScoresFromDifferentBeatmapsAreCountedSeparately()
+        {
+            var firstBeatmap = AddBeatmap(b => b.beatmap_id = 1001, s => s.beatmapset_id = 1);
+            var secondBeatmap = AddBeatmap(b => b.beatmap_id = 1002, s => s.beatmapset_id = 2);
+
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+
+            SetScoreForBeatmap(firstBeatmap.beatmap_id, item => item.Score.ScoreInfo.Rank = ScoreRank.X);
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.X] = 1,
+            });
+
+            SetScoreForBeatmap(secondBeatmap.beatmap_id, item => item.Score.ScoreInfo.Rank = ScoreRank.A);
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.X] = 1,
+                [ScoreRank.A] = 1,
+            });
+        }
+
+        [Fact]
+        public void TestScoresFromSameBeatmapInDifferentRulesetsAreCountedSeparately()
+        {
+            AddBeatmap();
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+            waitForRankCounts("osu_user_stats_mania", new Dictionary<ScoreRank, int>());
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item => item.Score.ScoreInfo.Rank = ScoreRank.X);
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.X] = 1,
+            });
+            waitForRankCounts("osu_user_stats_mania", new Dictionary<ScoreRank, int>());
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
+            {
+                item.Score.ruleset_id = item.Score.ScoreInfo.RulesetID = 3;
+                item.Score.ScoreInfo.Rank = ScoreRank.A;
+            });
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.X] = 1,
+            });
+            waitForRankCounts("osu_user_stats_mania", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.A] = 1,
+            });
+        }
+
+        [Fact]
+        public void TestScoreWithRankBelowADoesNothing()
+        {
+            AddBeatmap();
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item => item.Score.ScoreInfo.Rank = ScoreRank.B);
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+        }
+
+        [Fact]
+        public void TestScoreFromSameBeatmapAndHigherTotalChangesCountedRank()
+        {
+            AddBeatmap();
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
+            {
+                item.Score.ScoreInfo.Rank = ScoreRank.A;
+                item.Score.ScoreInfo.TotalScore = 600_000;
+            });
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.A] = 1,
+            });
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
+            {
+                item.Score.ScoreInfo.Rank = ScoreRank.X;
+                item.Score.ScoreInfo.TotalScore = 700_000;
+            });
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.X] = 1,
+            });
+        }
+
+        [Fact]
+        public void TestScoreFromSameBeatmapAndLowerTotalDoesNotChangeCountedRank()
+        {
+            AddBeatmap();
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
+            {
+                item.Score.ScoreInfo.Rank = ScoreRank.A;
+                item.Score.ScoreInfo.TotalScore = 600_000;
+            });
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.A] = 1,
+            });
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
+            {
+                item.Score.ScoreInfo.Rank = ScoreRank.X;
+                item.Score.ScoreInfo.TotalScore = 500_000;
+            });
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.A] = 1,
+            });
+        }
+
+        [Theory]
+        [InlineData(ScoreRank.A, ScoreRank.X)]
+        [InlineData(ScoreRank.X, ScoreRank.A)]
+        public void TestNewestScoreFromSameBeatmapAndWithSameTotalWins(ScoreRank firstRank, ScoreRank secondRank)
+        {
+            const int total_score = 600_000;
+
+            AddBeatmap();
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
+            {
+                item.Score.ScoreInfo.Rank = firstRank;
+                item.Score.ScoreInfo.TotalScore = total_score;
+            });
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [firstRank] = 1,
+            });
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
+            {
+                item.Score.ScoreInfo.Rank = secondRank;
+                item.Score.ScoreInfo.TotalScore = total_score;
+            });
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [secondRank] = 1,
+            });
+        }
+
+        [Fact]
+        public void TestReprocessWithSameVersionDoesntIncrease()
+        {
+            AddBeatmap();
+
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+
+            var score = CreateTestScore();
+            score.Score.ScoreInfo.Rank = ScoreRank.A;
+
+            PushToQueueAndWaitForProcess(score);
+
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.A] = 1,
+            });
+
+            // the score will be marked as processed (in the database) at this point, so should not increase the rank counts if processed a second time.
+            score.MarkProcessed();
+
+            PushToQueueAndWaitForProcess(score);
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.A] = 1,
+            });
+        }
+
+        [Fact]
+        public void TestReprocessNewHighScoreDoesntChangeCounts()
+        {
+            AddBeatmap();
+
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
+            {
+                item.Score.ScoreInfo.Rank = ScoreRank.A;
+                item.Score.ScoreInfo.TotalScore = 600_000;
+            });
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.A] = 1,
+            });
+
+            var secondScore = SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
+            {
+                item.Score.ScoreInfo.Rank = ScoreRank.X;
+                item.Score.ScoreInfo.TotalScore = 700_000;
+            });
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.X] = 1,
+            });
+
+            // the score will be marked as processed (in the database) at this point.
+            secondScore.MarkProcessed();
+            // artificially increase the `processed_version` so that the score undergoes a revert and reprocess.
+            secondScore.ProcessHistory!.processed_version++;
+
+            PushToQueueAndWaitForProcess(secondScore);
+
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.X] = 1,
+            });
+        }
+
+        [Fact]
+        public void TestReprocessNewerTiedScoreDoesntChangeCounts()
+        {
+            const int total_score = 600_000;
+
+            AddBeatmap();
+
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
+            {
+                item.Score.ScoreInfo.Rank = ScoreRank.A;
+                item.Score.ScoreInfo.TotalScore = total_score;
+            });
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.A] = 1,
+            });
+
+            var secondScore = SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
+            {
+                item.Score.ScoreInfo.Rank = ScoreRank.X;
+                item.Score.ScoreInfo.TotalScore = total_score;
+            });
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.X] = 1,
+            });
+
+            // the score will be marked as processed (in the database) at this point.
+            secondScore.MarkProcessed();
+            // artificially increase the `processed_version` so that the score undergoes a revert and reprocess.
+            secondScore.ProcessHistory!.processed_version++;
+
+            PushToQueueAndWaitForProcess(secondScore);
+
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.X] = 1,
+            });
+        }
+
+        [Fact]
+        public void TestReprocessNewNonHighScoreDoesntChangeCounts()
+        {
+            AddBeatmap();
+
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
+            {
+                item.Score.ScoreInfo.Rank = ScoreRank.A;
+                item.Score.ScoreInfo.TotalScore = 700_000;
+            });
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.A] = 1,
+            });
+
+            var secondScore = SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
+            {
+                item.Score.ScoreInfo.Rank = ScoreRank.X;
+                item.Score.ScoreInfo.TotalScore = 600_000;
+            });
+
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.A] = 1,
+            });
+
+            // the score will be marked as processed (in the database) at this point.
+            secondScore.MarkProcessed();
+            // artificially increase the `processed_version` so that the score undergoes a revert and reprocess.
+            secondScore.ProcessHistory!.processed_version++;
+
+            PushToQueueAndWaitForProcess(secondScore);
+
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.A] = 1,
+            });
+        }
+
+        private void waitForRankCounts(string tableName, Dictionary<ScoreRank, int> counts)
+        {
+            WaitForDatabaseState($"SELECT `xh_rank_count` from {tableName} WHERE `user_id` = 2", counts.GetValueOrDefault(ScoreRank.XH), CancellationToken);
+            WaitForDatabaseState($"SELECT `x_rank_count` from {tableName} WHERE `user_id` = 2", counts.GetValueOrDefault(ScoreRank.X), CancellationToken);
+            WaitForDatabaseState($"SELECT `sh_rank_count` from {tableName} WHERE `user_id` = 2", counts.GetValueOrDefault(ScoreRank.SH), CancellationToken);
+            WaitForDatabaseState($"SELECT `s_rank_count` from {tableName} WHERE `user_id` = 2", counts.GetValueOrDefault(ScoreRank.S), CancellationToken);
+            WaitForDatabaseState($"SELECT `a_rank_count` from {tableName} WHERE `user_id` = 2", counts.GetValueOrDefault(ScoreRank.A), CancellationToken);
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/UserRankCountProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/UserRankCountProcessorTests.cs
@@ -162,10 +162,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
 
-            var score = CreateTestScore();
-            score.Score.ScoreInfo.Rank = ScoreRank.A;
-
-            PushToQueueAndWaitForProcess(score);
+            var score = SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
+            {
+                item.Score.ScoreInfo.Rank = ScoreRank.A;
+                item.Score.ScoreInfo.TotalScore = 600_000;
+            });
 
             waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
             {
@@ -176,6 +177,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             score.MarkProcessed();
 
             PushToQueueAndWaitForProcess(score);
+
             waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
             {
                 [ScoreRank.A] = 1,

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
@@ -76,7 +76,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 + "AND `s`.`beatmap_id` = @BeatmapId "
                 + "AND `s`.`ruleset_id` = @RulesetId "
                 + "AND `s`.`preserve` = 1 "
-                + "ORDER BY JSON_EXTRACT(`s`.`data`, '$.total_score') DESC, `s`.`id` DESC", new
+                + "ORDER BY `s`.`data`->'$.total_score' DESC, `s`.`id` DESC", new
                 {
                     ExcludedScoreId = excludedScoreId,
                     UserId = userId,

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
@@ -77,7 +77,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 + "AND `ruleset_id` = @ruleset_id "
                 // preserve is not flagged on the newly arriving score until it has been completely processed (see logic in `ScoreStatisticsQueueProcessor.cs`)
                 // therefore we need to make an exception here to ensure it's included.
-                + "AND `preserve` = 1 OR `id` = @new_score_id "
+                + "AND (`preserve` = 1 OR `id` = @new_score_id) "
                 + "ORDER BY `data`->'$.total_score' DESC, `id` DESC "
                 + "LIMIT @offset, 1", new
                 {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
@@ -69,8 +69,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         {
             // purpose of join with `process_history` is to only look for already-processed scores
             var rankSource = conn.QueryFirstOrDefault<SoloScore?>(
-                $"SELECT * FROM {SoloScore.TABLE_NAME} `s`"
-                + $"JOIN {ProcessHistory.TABLE_NAME} `ph` ON `ph`.`score_id` = `s`.`id`"
+                "SELECT * FROM solo_scores `s`"
+                + "JOIN solo_scores_process_history `ph` ON `ph`.`score_id` = `s`.`id`"
                 + "WHERE (@ExcludedScoreId IS NULL OR `s`.`id` <> @ExcludedScoreId) "
                 + "AND `s`.`user_id` = @UserId "
                 + "AND `s`.`beatmap_id` = @BeatmapId "

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
@@ -76,7 +76,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 + "AND `s`.`beatmap_id` = @BeatmapId "
                 + "AND `s`.`ruleset_id` = @RulesetId "
                 + "AND `s`.`preserve` = 1 "
-                + "ORDER BY `s`.`data`->'$.total_score' DESC, `s`.`id` DESC", new
+                + "ORDER BY `s`.`data`->'$.total_score' DESC, `s`.`id` DESC "
+                + "LIMIT 1", new
                 {
                     ExcludedScoreId = excludedScoreId,
                     UserId = userId,

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
@@ -71,7 +71,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             var rankSource = conn.QueryFirstOrDefault<SoloScore?>(
                 "SELECT * FROM solo_scores `s`"
                 + "JOIN solo_scores_process_history `ph` ON `ph`.`score_id` = `s`.`id`"
-                + "WHERE (@ExcludedScoreId IS NULL OR `s`.`id` <> @ExcludedScoreId) "
+                + "WHERE (@ExcludedScoreId IS NULL OR `s`.`id` != @ExcludedScoreId) "
                 + "AND `s`.`user_id` = @UserId "
                 + "AND `s`.`beatmap_id` = @BeatmapId "
                 + "AND `s`.`ruleset_id` = @RulesetId "

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using JetBrains.Annotations;
+using MySqlConnector;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
+{
+    /// <summary>
+    /// Updates the rank achieved tallies for users.
+    /// </summary>
+    [UsedImplicitly]
+    public class UserRankCountProcessor : IProcessor
+    {
+        public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
+        {
+        }
+
+        public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
+        {
+        }
+
+        public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
+        {
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
@@ -69,8 +69,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         {
             // purpose of join with `process_history` is to only look for already-processed scores
             var rankSource = conn.QueryFirstOrDefault<SoloScore?>(
-                "SELECT * FROM solo_scores `s`"
-                + "JOIN solo_scores_process_history `ph` ON `ph`.`score_id` = `s`.`id`"
+                "SELECT * FROM solo_scores `s` "
+                + "JOIN solo_scores_process_history `ph` ON `ph`.`score_id` = `s`.`id` "
                 + "WHERE (@ExcludedScoreId IS NULL OR `s`.`id` != @ExcludedScoreId) "
                 + "AND `s`.`user_id` = @UserId "
                 + "AND `s`.`beatmap_id` = @BeatmapId "

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
@@ -1,9 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using Dapper;
 using JetBrains.Annotations;
 using MySqlConnector;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Scoring;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
@@ -16,14 +18,101 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
     {
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
+            if (previousVersion >= 7)
+            {
+                // note that this implementation is only supposed to be correct if a revert is immediately succeeded by a reprocessing of the same score.
+                // at the time of writing this is the only case where this method is called, but if that ever changes this will likely need reconsideration.
+
+                // first, see if the score we're reverting is the user's best (and as such included in the rank counts).
+                var bestScore = getBestScore(score.UserID, score.BeatmapID, score.RulesetID, excludedScoreId: null, conn, transaction);
+
+                if (bestScore?.ID != score.ID)
+                {
+                    // this score isn't the user's best on the beatmap, so nothing needs to be reverted.
+                    return;
+                }
+
+                updateRankCounts(userStats, score.Rank, revert: true);
+
+                // this score is the user's best, so fetch the next best (excluding it) so that we can apply the rank from that score.
+                var secondBestScore = getBestScore(score.UserID, score.BeatmapID, score.RulesetID, excludedScoreId: score.ID, conn, transaction);
+                if (secondBestScore != null)
+                    updateRankCounts(userStats, secondBestScore.Rank, revert: false);
+            }
         }
 
         public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
         {
+            // while looking for the best score, exclude the score being processed right now.
+            // this does nothing on the first process (as `getBestScore()` already only looks at scores processed at least once),
+            // but is important on subsequent reprocessings during `processed_version` bumps.
+            var bestScore = getBestScore(score.UserID, score.BeatmapID, score.RulesetID, excludedScoreId: score.ID, conn, transaction);
+
+            if (bestScore == null)
+            {
+                updateRankCounts(userStats, score.Rank, revert: false);
+                return;
+            }
+
+            if (score.TotalScore < bestScore.TotalScore) return;
+            if (score.TotalScore == bestScore.TotalScore && score.ID <= bestScore.ID) return;
+
+            updateRankCounts(userStats, bestScore.Rank, revert: true);
+            updateRankCounts(userStats, score.Rank, revert: false);
         }
 
         public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
         {
+        }
+
+        private static SoloScoreInfo? getBestScore(int userId, int beatmapId, int rulesetId, ulong? excludedScoreId, MySqlConnection conn, MySqlTransaction transaction)
+        {
+            // purpose of join with `process_history` is to only look for already-processed scores
+            var rankSource = conn.QueryFirstOrDefault<SoloScore?>(
+                $"SELECT * FROM {SoloScore.TABLE_NAME} `s`"
+                + $"JOIN {ProcessHistory.TABLE_NAME} `ph` ON `ph`.`score_id` = `s`.`id`"
+                + "WHERE (@ExcludedScoreId IS NULL OR `s`.`id` <> @ExcludedScoreId) "
+                + "AND `s`.`user_id` = @UserId "
+                + "AND `s`.`beatmap_id` = @BeatmapId "
+                + "AND `s`.`ruleset_id` = @RulesetId "
+                + "AND `s`.`preserve` = 1 "
+                + "ORDER BY JSON_EXTRACT(`s`.`data`, '$.total_score') DESC, `s`.`id` DESC", new
+                {
+                    ExcludedScoreId = excludedScoreId,
+                    UserId = userId,
+                    BeatmapId = beatmapId,
+                    RulesetId = rulesetId,
+                }, transaction);
+
+            return rankSource?.ScoreInfo;
+        }
+
+        private static void updateRankCounts(UserStats stats, ScoreRank rank, bool revert)
+        {
+            int delta = revert ? -1 : 1;
+
+            switch (rank)
+            {
+                case ScoreRank.XH:
+                    stats.xh_rank_count += delta;
+                    break;
+
+                case ScoreRank.X:
+                    stats.x_rank_count += delta;
+                    break;
+
+                case ScoreRank.SH:
+                    stats.sh_rank_count += delta;
+                    break;
+
+                case ScoreRank.S:
+                    stats.s_rank_count += delta;
+                    break;
+
+                case ScoreRank.A:
+                    stats.a_rank_count += delta;
+                    break;
+            }
         }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
@@ -27,8 +27,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         /// version 4: uses SoloScore"V2" (moving all content to json data block)
         /// version 5: added performance processor
         /// version 6: added play time processor
+        /// version 7: added user rank count processor
         /// </summary>
-        public const int VERSION = 6;
+        public const int VERSION = 7;
 
         public static readonly List<Ruleset> AVAILABLE_RULESETS = getRulesets();
 


### PR DESCRIPTION
Closes #133.

As per [discord conversation](https://discord.com/channels/188630481301012481/188630652340404224/1146035221628731423), basically written with zero regard for performance, only correctness of behaviour. There are probably places that are going to hurt in this implementation.

Notably, this implementation relies on there being an absolute ordering of scores from a given user on a given beatmap in a given ruleset, to determine which score to pick as the "source" of rank to tally. The criteria chosen are: total score descending, then ID descending (as a substitute for "newest") as a tie-breaker.

[I brought that up on discord too](https://discord.com/channels/188630481301012481/188630652340404224/1146055765107421254), and there were two alternatives offered for the tie-breaker: either highest rank, or newest score, whichever easiest. I wanted to do highest rank but for practical reasons this is more difficult than you'd think (tl;dr: can't query rank directly from SQL, have to reach into the `` `solo_scores`.`data` `` JSON to get it, wherein it's a string and not the enum, so I'd have to sort it...), therefore the choice of ID instead.

No idea if we want to be giving any considerations to mods here.

Do be careful with review on this one, it's the first time I'm touching this project to do anything serious.