### PR TITLE
Replace all usage of `TABLE_NAME` constants with direct table names

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -57,11 +57,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 db.Execute("TRUNCATE TABLE osu_user_stats_mania");
                 db.Execute("TRUNCATE TABLE osu_user_beatmap_playcount");
                 db.Execute("TRUNCATE TABLE osu_user_month_playcount");
-                db.Execute($"TRUNCATE TABLE {Beatmap.TABLE_NAME}");
-                db.Execute($"TRUNCATE TABLE {BeatmapSet.TABLE_NAME}");
-                db.Execute($"TRUNCATE TABLE {SoloScore.TABLE_NAME}");
-                db.Execute($"TRUNCATE TABLE {ProcessHistory.TABLE_NAME}");
-                db.Execute($"TRUNCATE TABLE {SoloScorePerformance.TABLE_NAME}");
+                db.Execute("TRUNCATE TABLE osu_beatmaps");
+                db.Execute("TRUNCATE TABLE osu_beatmapsets");
+                db.Execute("TRUNCATE TABLE solo_scores");
+                db.Execute("TRUNCATE TABLE solo_scores_process_history");
+                db.Execute("TRUNCATE TABLE solo_scores_performance");
             }
 
             Task.Run(() => Processor.Run(CancellationToken), CancellationToken);
@@ -92,7 +92,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             Processor.PushToQueue(item);
 
-            WaitForDatabaseState($"SELECT score_id FROM {ProcessHistory.TABLE_NAME} WHERE score_id = {item.Score.id}", item.Score.id, CancellationToken);
+            WaitForDatabaseState($"SELECT score_id FROM solo_scores_process_history WHERE score_id = {item.Score.id}", item.Score.id, CancellationToken);
             WaitForTotalProcessed(processedBefore + 1, CancellationToken);
         }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
@@ -24,7 +24,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         {
             using (var db = Processor.GetDatabaseConnection())
             {
-                db.Execute($"TRUNCATE TABLE {BeatmapDifficultyAttribute.TABLE_NAME}");
+                db.Execute("TRUNCATE TABLE osu_beatmap_difficulty_attribs");
             }
         }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/SerialisationTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/SerialisationTests.cs
@@ -21,7 +21,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
                 db.Insert(score.ProcessHistory);
 
-                db.QueryFirst<ProcessHistory>($"SELECT * FROM {ProcessHistory.TABLE_NAME}").ShouldDeepEqual(score.ProcessHistory);
+                db.QueryFirst<ProcessHistory>("SELECT * FROM solo_scores_process_history").ShouldDeepEqual(score.ProcessHistory);
             }
         }
 
@@ -51,7 +51,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
                 db.Insert(score);
 
-                var retrieved = db.QueryFirst<SoloScore>($"SELECT * FROM {SoloScore.TABLE_NAME}");
+                var retrieved = db.QueryFirst<SoloScore>("SELECT * FROM solo_scores");
 
                 // ignore time values for now until we can figure how to test without precision issues.
                 retrieved.created_at = score.created_at;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/DeleteNonPreservedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/DeleteNonPreservedScoresCommand.cs
@@ -26,15 +26,15 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
             using (var deleteCommand = deleteConnection.CreateCommand())
             {
                 deleteCommand.CommandText =
-                    $"DELETE FROM {SoloScorePerformance.TABLE_NAME} WHERE score_id = @id;" +
-                    $"DELETE FROM {ProcessHistory.TABLE_NAME} WHERE score_id = @id;" +
-                    $"DELETE FROM {SoloScore.TABLE_NAME} WHERE id = @id;";
+                    $"DELETE FROM solo_scores_performance WHERE score_id = @id;" +
+                    $"DELETE FROM solo_scores_process_history WHERE score_id = @id;" +
+                    $"DELETE FROM solo_scores WHERE id = @id;";
 
                 MySqlParameter scoreId = deleteCommand.Parameters.Add("id", MySqlDbType.UInt64);
 
                 await deleteCommand.PrepareAsync(cancellationToken);
 
-                var scores = await readConnection.QueryAsync<SoloScore>(new CommandDefinition($"SELECT * FROM {SoloScore.TABLE_NAME} WHERE preserve = 0 AND updated_at < DATE_SUB(NOW(), INTERVAL {preserve_hours} HOUR)", flags: CommandFlags.None, cancellationToken: cancellationToken));
+                var scores = await readConnection.QueryAsync<SoloScore>(new CommandDefinition($"SELECT * FROM solo_scores WHERE preserve = 0 AND updated_at < DATE_SUB(NOW(), INTERVAL {preserve_hours} HOUR)", flags: CommandFlags.None, cancellationToken: cancellationToken));
 
                 foreach (var score in scores)
                 {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/DeleteNonPreservedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/DeleteNonPreservedScoresCommand.cs
@@ -26,9 +26,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
             using (var deleteCommand = deleteConnection.CreateCommand())
             {
                 deleteCommand.CommandText =
-                    $"DELETE FROM solo_scores_performance WHERE score_id = @id;" +
-                    $"DELETE FROM solo_scores_process_history WHERE score_id = @id;" +
-                    $"DELETE FROM solo_scores WHERE id = @id;";
+                    "DELETE FROM solo_scores_performance WHERE score_id = @id;" +
+                    "DELETE FROM solo_scores_process_history WHERE score_id = @id;" +
+                    "DELETE FROM solo_scores WHERE id = @id;";
 
                 MySqlParameter scoreId = deleteCommand.Parameters.Add("id", MySqlDbType.UInt64);
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MarkNonPreservedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MarkNonPreservedScoresCommand.cs
@@ -45,11 +45,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
         {
             var parameters = new
             {
-                userId = userId,
+                userId,
                 rulesetId = RulesetId,
             };
 
-            IEnumerable<SoloScore> scores = await db.QueryAsync<SoloScore>(new CommandDefinition($"SELECT * FROM {SoloScore.TABLE_NAME} WHERE preserve = 1 AND user_id = @userId AND ruleset_id = @rulesetId", parameters, cancellationToken: cancellationToken));
+            IEnumerable<SoloScore> scores = await db.QueryAsync<SoloScore>(new CommandDefinition("SELECT * FROM solo_scores WHERE preserve = 1 AND user_id = @userId AND ruleset_id = @rulesetId", parameters, cancellationToken: cancellationToken));
 
             if (!scores.Any())
                 return;
@@ -84,7 +84,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
                 Console.WriteLine($"Marking score {score.id} non-preserved...");
 
-                await db.ExecuteAsync($"UPDATE {SoloScore.TABLE_NAME} SET preserve = 0 WHERE id = @scoreId;", new
+                await db.ExecuteAsync("UPDATE solo_scores SET preserve = 0 WHERE id = @scoreId;", new
                 {
                     scoreId = score.id
                 });

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/DeleteImportedHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/DeleteImportedHighScoresCommand.cs
@@ -30,7 +30,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
     /// I'm not sure how important this is in the first place, because they are never going to be perfectly chronological next to
     /// non-imported (lazer-first) scores anyway...
     /// </remarks>
-    [Command("delete-high-scores", Description = $"Deletes already-imported high scores from the {SoloScore.TABLE_NAME} table.")]
+    [Command("delete-high-scores", Description = "Deletes already-imported high scores from the solo_scores table.")]
     public class DeleteImportedHighScoresCommand : BaseCommand
     {
         /// <summary>
@@ -47,7 +47,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
             int deleted = 0;
 
             Console.WriteLine();
-            Console.WriteLine($"Deleting from {SoloScore.TABLE_NAME} starting from {lastId}");
+            Console.WriteLine($"Deleting from solo_scores starting from {lastId}");
 
             elasticQueueProcessor = new ElasticQueueProcessor();
             Console.WriteLine($"Indexing to elasticsearch queue {elasticQueueProcessor.QueueName}");
@@ -62,7 +62,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
                     using (var transaction = await conn.BeginTransactionAsync(cancellationToken))
                     {
-                        var highScores = await conn.QueryAsync<SoloScore>("SELECT * FROM solo_scores WHERE id >= @lastId ORDER BY id LIMIT 500", new { lastId = lastId }, transaction);
+                        var highScores = await conn.QueryAsync<SoloScore>("SELECT * FROM solo_scores WHERE id >= @lastId ORDER BY id LIMIT 500", new { lastId }, transaction);
 
                         if (!highScores.Any())
                         {
@@ -81,7 +81,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                             await conn.ExecuteAsync("DELETE FROM solo_scores_performance WHERE score_id = @id; DELETE FROM solo_scores WHERE id = @id", score, transaction);
                             await conn.ExecuteAsync("DELETE FROM solo_scores_legacy_id_map WHERE ruleset_id = @ruleset_id AND old_score_id = @legacy_score_id", new
                             {
-                                ruleset_id = score.ruleset_id,
+                                score.ruleset_id,
                                 legacy_score_id = score.ScoreInfo.LegacyScoreId
                             }, transaction);
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -37,7 +37,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
     /// This is important to guarantee that scores are inserted in the same sequential order that they originally occured,
     /// which can be used for tie-breaker scenarios.
     /// </remarks>
-    [Command("import-high-scores", Description = $"Imports high scores from the osu_scores_high tables into the new {SoloScore.TABLE_NAME} table.")]
+    [Command("import-high-scores", Description = "Imports high scores from the osu_scores_high tables into the new solo_scores table.")]
     public class ImportHighScoresCommand : BaseCommand
     {
         /// <summary>
@@ -381,10 +381,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
                     insertCommand.CommandText =
                         // main score insert
-                        $"INSERT INTO solo_scores (user_id, beatmap_id, ruleset_id, data, has_replay, preserve, created_at, updated_at) "
+                        "INSERT INTO solo_scores (user_id, beatmap_id, ruleset_id, data, has_replay, preserve, created_at, updated_at) "
                         + $"VALUES (@userId, @beatmapId, {ruleset.RulesetInfo.OnlineID}, @data, @has_replay, 1, @date, @date);"
                         // pp insert
-                        + $"INSERT INTO solo_scores_performance (score_id, pp) VALUES (LAST_INSERT_ID(), @pp);"
+                        + "INSERT INTO solo_scores_performance (score_id, pp) VALUES (LAST_INSERT_ID(), @pp);"
                         // mapping insert
                         + $"INSERT INTO solo_scores_legacy_id_map (ruleset_id, old_score_id, score_id) VALUES ({ruleset.RulesetInfo.OnlineID}, @oldScoreId, LAST_INSERT_ID());";
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -29,7 +29,7 @@ using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 {
-    [Command("import-high-scores", Description = $"Imports high scores from the osu_scores_high tables into the new {SoloScore.TABLE_NAME} table.")]
+    [Command("import-high-scores", Description = "Imports high scores from the osu_scores_high tables into the new solo_scores table.")]
     public class ImportHighScoresCommand : BaseCommand
     {
         /// <summary>
@@ -134,14 +134,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
             else
             {
                 using (var db = Queue.GetDatabaseConnection())
-                    lastId = db.QuerySingleOrDefault<ulong?>($"SELECT MAX(old_score_id) FROM {SoloScoreLegacyIDMap.TABLE_NAME} WHERE ruleset_id = {RulesetId}") ?? 0;
+                    lastId = db.QuerySingleOrDefault<ulong?>($"SELECT MAX(old_score_id) FROM solo_scores_legacy_id_map WHERE ruleset_id = {RulesetId}") ?? 0;
 
                 Console.WriteLine($"StartId not provided, using last legacy ID map entry ({lastId})");
             }
 
             Console.WriteLine();
             Console.WriteLine($"Sourcing from {highScoreTable} for {ruleset.ShortName} starting from {lastId}");
-            Console.WriteLine($"Inserting into {SoloScore.TABLE_NAME} and processing {(ExitOnCompletion ? "as single run" : "indefinitely")}");
+            Console.WriteLine($"Inserting into solo_scores and processing {(ExitOnCompletion ? "as single run" : "indefinitely")}");
 
             if (!SkipIndexing)
             {
@@ -159,7 +159,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                         checkSlaveLatency(dbMainQuery);
 
                     var highScores = await dbMainQuery.QueryAsync<HighScore>($"SELECT * FROM {highScoreTable} WHERE score_id >= @lastId ORDER BY score_id LIMIT {scoresPerQuery}",
-                        new { lastId = lastId });
+                        new { lastId });
 
                     if (!highScores.Any())
                     {
@@ -366,22 +366,22 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                 using (var updateCommand = db.CreateCommand())
                 {
                     // check for existing and skip
-                    (ulong oldId, ulong newId)[] existingIds = db.Query($"SELECT `old_score_id`, `score_id` FROM {SoloScoreLegacyIDMap.TABLE_NAME} WHERE `ruleset_id` = {ruleset.RulesetInfo.OnlineID} AND `old_score_id` IN @oldScoreIds", new
+                    (ulong oldId, ulong newId)[] existingIds = db.Query($"SELECT `old_score_id`, `score_id` FROM solo_scores_legacy_id_map WHERE `ruleset_id` = {ruleset.RulesetInfo.OnlineID} AND `old_score_id` IN @oldScoreIds", new
                     {
                         oldScoreIds = scores.Select(s => s.score_id)
                     }, transaction).Select(s => ((ulong)s.old_score_id, (ulong)s.score_id)).ToArray();
 
                     insertCommand.CommandText =
                         // main score insert
-                        $"INSERT INTO {SoloScore.TABLE_NAME} (user_id, beatmap_id, ruleset_id, data, has_replay, preserve, created_at, updated_at) "
+                        $"INSERT INTO solo_scores (user_id, beatmap_id, ruleset_id, data, has_replay, preserve, created_at, updated_at) "
                         + $"VALUES (@userId, @beatmapId, {ruleset.RulesetInfo.OnlineID}, @data, @has_replay, 1, @date, @date);"
                         // pp insert
-                        + $"INSERT INTO {SoloScorePerformance.TABLE_NAME} (score_id, pp) VALUES (LAST_INSERT_ID(), @pp);"
+                        + $"INSERT INTO solo_scores_performance (score_id, pp) VALUES (LAST_INSERT_ID(), @pp);"
                         // mapping insert
-                        + $"INSERT INTO {SoloScoreLegacyIDMap.TABLE_NAME} (ruleset_id, old_score_id, score_id) VALUES ({ruleset.RulesetInfo.OnlineID}, @oldScoreId, LAST_INSERT_ID());";
+                        + $"INSERT INTO solo_scores_legacy_id_map (ruleset_id, old_score_id, score_id) VALUES ({ruleset.RulesetInfo.OnlineID}, @oldScoreId, LAST_INSERT_ID());";
 
                     updateCommand.CommandText =
-                        $"UPDATE {SoloScore.TABLE_NAME} SET data = @data WHERE id = @id";
+                        "UPDATE solo_scores SET data = @data WHERE id = @id";
 
                     var userId = insertCommand.Parameters.Add("userId", MySqlDbType.UInt32);
                     var oldScoreId = insertCommand.Parameters.Add("oldScoreId", MySqlDbType.UInt64);
@@ -615,7 +615,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
                 IEnumerable<BeatmapDifficultyAttribute> dbAttributes =
                     connection.Query<BeatmapDifficultyAttribute>(
-                        $"SELECT * FROM {BeatmapDifficultyAttribute.TABLE_NAME} WHERE `beatmap_id` = @BeatmapId AND `mode` = @RulesetId AND `mods` = @Mods", lookup, transaction);
+                        "SELECT * FROM osu_beatmap_difficulty_attribs WHERE `beatmap_id` = @BeatmapId AND `mode` = @RulesetId AND `mods` = @Mods", lookup, transaction);
 
                 return attributes_cache[lookup] = dbAttributes.ToDictionary(a => (int)a.attrib_id, a => a);
             }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/PumpAllScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/PumpAllScoresCommand.cs
@@ -27,7 +27,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
             using (var dbMainQuery = Queue.GetDatabaseConnection())
             using (var db = Queue.GetDatabaseConnection())
             {
-                string query = $"SELECT * FROM {SoloScore.TABLE_NAME} WHERE id >= @StartId";
+                string query = "SELECT * FROM solo_scores WHERE id >= @StartId";
 
                 if (!string.IsNullOrEmpty(CustomQuery))
                     query += $" AND {CustomQuery}";
@@ -41,7 +41,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                         break;
 
                     // attach any previous processing information
-                    var history = db.QuerySingleOrDefault<ProcessHistory>($"SELECT * FROM {ProcessHistory.TABLE_NAME} WHERE score_id = @id", score);
+                    var history = db.QuerySingleOrDefault<ProcessHistory>("SELECT * FROM solo_scores_process_history WHERE score_id = @id", score);
 
                     Console.WriteLine($"Pumping {score}");
                     Queue.PushToQueue(new ScoreItem(score, history));

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/Beatmap.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/Beatmap.cs
@@ -11,11 +11,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [Serializable]
-    [Table(TABLE_NAME)]
+    [Table("osu_beatmaps")]
     public class Beatmap
     {
-        public const string TABLE_NAME = "osu_beatmaps";
-
         [ExplicitKey]
         public int beatmap_id { get; set; }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/BeatmapDifficultyAttribute.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/BeatmapDifficultyAttribute.cs
@@ -9,11 +9,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [Serializable]
-    [Table(TABLE_NAME)]
+    [Table("osu_beatmap_difficulty_attribs")]
     public class BeatmapDifficultyAttribute
     {
-        public const string TABLE_NAME = "osu_beatmap_difficulty_attribs";
-
         [ExplicitKey]
         public uint beatmap_id { get; set; }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/BeatmapSet.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/BeatmapSet.cs
@@ -10,11 +10,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [Serializable]
-    [Table(TABLE_NAME)]
+    [Table("osu_beatmapsets")]
     public class BeatmapSet
     {
-        public const string TABLE_NAME = "osu_beatmapsets";
-
         [ExplicitKey]
         public int beatmapset_id { get; set; }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/Build.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/Build.cs
@@ -9,11 +9,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [Serializable]
-    [Table(TABLE_NAME)]
+    [Table("osu_builds")]
     public class Build
     {
-        public const string TABLE_NAME = "osu_builds";
-
         public int build_id { get; set; }
         public bool allow_ranking { get; set; }
         public bool allow_performance { get; set; }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/PerformanceBlacklistEntry.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/PerformanceBlacklistEntry.cs
@@ -9,11 +9,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [Serializable]
-    [Table(TABLE_NAME)]
+    [Table("osu_beatmap_performance_blacklist")]
     public class PerformanceBlacklistEntry
     {
-        public const string TABLE_NAME = "osu_beatmap_performance_blacklist";
-
         public int beatmap_id { get; set; }
         public int mode { get; set; }
     }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/ProcessHistory.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/ProcessHistory.cs
@@ -7,11 +7,9 @@ using Dapper.Contrib.Extensions;
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
-    [Table(TABLE_NAME)]
+    [Table("solo_scores_process_history")]
     public class ProcessHistory
     {
-        public const string TABLE_NAME = $"{SoloScore.TABLE_NAME}_process_history";
-
         [ExplicitKey]
         public long score_id { get; set; }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs
@@ -11,11 +11,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [Serializable]
-    [Table(TABLE_NAME)]
+    [Table("solo_scores")]
     public class SoloScore
     {
-        public const string TABLE_NAME = "solo_scores";
-
         [ExplicitKey]
         public ulong id { get; set; }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScoreLegacyIDMap.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScoreLegacyIDMap.cs
@@ -9,11 +9,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [Serializable]
-    [Table(TABLE_NAME)]
+    [Table("solo_scores_legacy_id_map")]
     public class SoloScoreLegacyIDMap
     {
-        public const string TABLE_NAME = $"{SoloScore.TABLE_NAME}_legacy_id_map";
-
         [ExplicitKey]
         public ushort ruleset_id { get; set; }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScorePerformance.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScorePerformance.cs
@@ -9,11 +9,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [Serializable]
-    [Table(TABLE_NAME)]
+    [Table("solo_scores_performance")]
     public class SoloScorePerformance
     {
-        public const string TABLE_NAME = $"{SoloScore.TABLE_NAME}_performance";
-
         [ExplicitKey]
         public ulong score_id { get; set; }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MaxComboProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MaxComboProcessor.cs
@@ -34,7 +34,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             if (score.Mods.Select(m => m.ToMod(ruleset)).Any(m => m.Type == ModType.Automation))
                 return;
 
-            var beatmap = conn.QuerySingleOrDefault<Beatmap?>($"SELECT * FROM {Beatmap.TABLE_NAME} WHERE `beatmap_id` = @BeatmapId", new
+            var beatmap = conn.QuerySingleOrDefault<Beatmap?>("SELECT * FROM osu_beatmaps WHERE `beatmap_id` = @BeatmapId", new
             {
                 BeatmapId = score.BeatmapID
             }, transaction: transaction);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
@@ -24,7 +24,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
             // Do a global check to see if this beatmapset is contained in *any* pack.
             var validPacksForBeatmapSet = conn.Query<int>("SELECT pack_id FROM osu_beatmappacks_items WHERE beatmapset_id = @beatmapSetId LIMIT 1", new
             {
-                beatmapSetId = beatmapSetId,
+                beatmapSetId,
             }, transaction: transaction);
 
             foreach (var medal in medals)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -52,7 +52,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         /// <param name="transaction">An existing transaction.</param>
         public async Task ProcessUserScoresAsync(int userId, int rulesetId, MySqlConnection connection, MySqlTransaction? transaction = null)
         {
-            var scores = (await connection.QueryAsync<SoloScore>($"SELECT * FROM {SoloScore.TABLE_NAME} WHERE `user_id` = @UserId AND `ruleset_id` = @RulesetId", new
+            var scores = (await connection.QueryAsync<SoloScore>("SELECT * FROM solo_scores WHERE `user_id` = @UserId AND `ruleset_id` = @RulesetId", new
             {
                 UserId = userId,
                 RulesetId = rulesetId
@@ -70,7 +70,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         /// <param name="transaction">An existing transaction.</param>
         public async Task ProcessScoreAsync(ulong scoreId, MySqlConnection connection, MySqlTransaction? transaction = null)
         {
-            var score = await connection.QuerySingleOrDefaultAsync<SoloScore>($"SELECT * FROM {SoloScore.TABLE_NAME} WHERE `id` = @ScoreId", new
+            var score = await connection.QuerySingleOrDefaultAsync<SoloScore>("SELECT * FROM solo_scores WHERE `id` = @ScoreId", new
             {
                 ScoreId = scoreId
             }, transaction: transaction);
@@ -128,7 +128,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 if (performanceAttributes == null)
                     return;
 
-                await connection.ExecuteAsync($"INSERT INTO {SoloScorePerformance.TABLE_NAME} (`score_id`, `pp`) VALUES (@ScoreId, @Pp) ON DUPLICATE KEY UPDATE `pp` = @Pp", new
+                await connection.ExecuteAsync("INSERT INTO solo_scores_performance (`score_id`, `pp`) VALUES (@ScoreId, @Pp) ON DUPLICATE KEY UPDATE `pp` = @Pp", new
                 {
                     ScoreId = score.ID,
                     Pp = performanceAttributes.Total

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -80,8 +80,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             }
 
             List<SoloScoreWithPerformance> scores = (await connection.QueryAsync<SoloScoreWithPerformance>(
-                $"SELECT `s`.*, `p`.`pp` FROM solo_scores `s` "
-                + $"JOIN solo_scores_performance `p` ON `s`.`id` = `p`.`score_id` "
+                "SELECT `s`.*, `p`.`pp` FROM solo_scores `s` "
+                + "JOIN solo_scores_performance `p` ON `s`.`id` = `p`.`score_id` "
                 + "WHERE `s`.`user_id` = @UserId "
                 + "AND `s`.`ruleset_id` = @RulesetId "
                 + "AND `s`.`preserve` = 1", new

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -80,8 +80,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             }
 
             List<SoloScoreWithPerformance> scores = (await connection.QueryAsync<SoloScoreWithPerformance>(
-                $"SELECT `s`.*, `p`.`pp` FROM {SoloScore.TABLE_NAME} `s` "
-                + $"JOIN {SoloScorePerformance.TABLE_NAME} `p` ON `s`.`id` = `p`.`score_id` "
+                $"SELECT `s`.*, `p`.`pp` FROM solo_scores `s` "
+                + $"JOIN solo_scores_performance `p` ON `s`.`id` = `p`.`score_id` "
                 + "WHERE `s`.`user_id` = @UserId "
                 + "AND `s`.`ruleset_id` = @RulesetId "
                 + "AND `s`.`preserve` = 1", new

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
@@ -108,7 +108,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
                         if (score.Passed)
                         {
                             // For now, just assume all passing scores are to be preserved.
-                            conn.Execute($"UPDATE {SoloScore.TABLE_NAME} SET preserve = 1 WHERE id = @Id", new { Id = score.ID }, transaction);
+                            conn.Execute("UPDATE solo_scores SET preserve = 1 WHERE id = @Id", new { Id = score.ID }, transaction);
                         }
 
                         transaction.Commit();

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BeatmapStore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BeatmapStore.cs
@@ -22,7 +22,7 @@ using Beatmap = osu.Server.Queues.ScoreStatisticsProcessor.Models.Beatmap;
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
 {
     /// <summary>
-    /// A store for retrieving <see cref="Beatmap"/>s.
+    /// A store for retrieving <see cref="Models.Beatmap"/>s.
     /// </summary>
     public class BeatmapStore
     {
@@ -46,7 +46,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
         /// <returns>The created <see cref="BeatmapStore"/>.</returns>
         public static async Task<BeatmapStore> CreateAsync(MySqlConnection? connection, MySqlTransaction? transaction = null)
         {
-            var dbBlacklist = await connection.QueryAsync<PerformanceBlacklistEntry>($"SELECT * FROM {PerformanceBlacklistEntry.TABLE_NAME}", transaction: transaction);
+            var dbBlacklist = await connection.QueryAsync<PerformanceBlacklistEntry>("SELECT * FROM osu_beatmap_performance_blacklist", transaction: transaction);
 
             return new BeatmapStore
             (
@@ -92,7 +92,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
             if (!attributeCache.TryGetValue(key, out rawDifficultyAttributes))
             {
                 rawDifficultyAttributes = attributeCache[key] = (await connection.QueryAsync<BeatmapDifficultyAttribute>(
-                    $"SELECT * FROM {BeatmapDifficultyAttribute.TABLE_NAME} WHERE `beatmap_id` = @BeatmapId AND `mode` = @RulesetId AND `mods` = @ModValue", new
+                    "SELECT * FROM osu_beatmap_difficulty_attribs WHERE `beatmap_id` = @BeatmapId AND `mode` = @RulesetId AND `mods` = @ModValue", new
                     {
                         key.BeatmapId,
                         key.RulesetId,
@@ -121,7 +121,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
             if (beatmapCache.TryGetValue(beatmapId, out var beatmap))
                 return beatmap;
 
-            return beatmapCache[beatmapId] = await connection.QuerySingleOrDefaultAsync<Beatmap?>($"SELECT * FROM {Beatmap.TABLE_NAME} WHERE `beatmap_id` = @BeatmapId", new
+            return beatmapCache[beatmapId] = await connection.QuerySingleOrDefaultAsync<Beatmap?>("SELECT * FROM osu_beatmaps WHERE `beatmap_id` = @BeatmapId", new
             {
                 BeatmapId = beatmapId
             }, transaction: transaction);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BuildStore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BuildStore.cs
@@ -30,7 +30,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
         /// <returns>The created <see cref="BuildStore"/>.</returns>
         public static async Task<BuildStore> CreateAsync(MySqlConnection? connection, MySqlTransaction? transaction = null)
         {
-            var dbBuilds = await connection.QueryAsync<Build>($"SELECT * FROM {Build.TABLE_NAME} WHERE `allow_ranking` = TRUE OR `allow_performance` = TRUE", transaction: transaction);
+            var dbBuilds = await connection.QueryAsync<Build>("SELECT * FROM osu_builds WHERE `allow_ranking` = TRUE OR `allow_performance` = TRUE", transaction: transaction);
 
             return new BuildStore
             (

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Stores/StreamedWorkingBeatmap.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Stores/StreamedWorkingBeatmap.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.IO;
 using osu.Framework.Audio.Track;
 using osu.Framework.Graphics.Textures;
@@ -57,9 +58,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
         }
 
         protected override IBeatmap GetBeatmap() => beatmap;
-        public override Texture GetBackground() => throw new System.NotImplementedException();
-        protected override Track GetBeatmapTrack() => throw new System.NotImplementedException();
-        protected override ISkin GetSkin() => throw new System.NotImplementedException();
-        public override Stream GetStream(string storagePath) => throw new System.NotImplementedException();
+        public override Texture GetBackground() => throw new NotImplementedException();
+        protected override Track GetBeatmapTrack() => throw new NotImplementedException();
+        protected override ISkin GetSkin() => throw new NotImplementedException();
+        public override Stream GetStream(string storagePath) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
Rider can't understand these constants, which makes database introspection quite useless. Also I don't think it's making things any clearer having the constants.