### PR TITLE
Fix error code on unknown argument

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Program.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Program.cs
@@ -14,7 +14,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
     {
         private static readonly CancellationTokenSource cts = new CancellationTokenSource();
 
-        public static async Task Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
             Console.CancelKeyPress += (_, e) =>
             {
@@ -24,7 +24,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
                 e.Cancel = true;
             };
 
-            await CommandLineApplication.ExecuteAsync<Program>(args, cts.Token);
+            return await CommandLineApplication.ExecuteAsync<Program>(args, cts.Token);
         }
 
         public Task<int> OnExecuteAsync(CommandLineApplication app, CancellationToken cancellationToken)


### PR DESCRIPTION
I have a bash script with `set -e`, and I expect it to error out immediately if one of these commands fails. Currently it doesn't do so if the failure is as a result of a change of arguments. Or a non-zero return by commands, but we don't really do that I think (exceptions set error code to 134 - `SIGABRT`).

Master:
```
$ dotnet run -- wangs
Specify --help for a list of available options and commands.
Unrecognized command or argument 'wangs'

$ echo $?
0
```
PR:
```
$ dotnet run -- wangs
Specify --help for a list of available options and commands.
Unrecognized command or argument 'wangs'

$ echo $?
1
```