### PR TITLE
Add command to migrate playlist scores from `multiplayer_scores` to `solo_scores`

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
@@ -1,0 +1,190 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using Dapper.Contrib.Extensions;
+using McMaster.Extensions.CommandLineUtils;
+using Newtonsoft.Json;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
+{
+    [Command("migrate-playlist-scores", Description = "Migrate scores from `multiplayer_scores` to `solo_scores`.")]
+    public class MigratePlaylistScoresToSoloScoresCommand : BaseCommand
+    {
+        /// <summary>
+        /// The playlist room ID to reprocess.
+        /// </summary>
+        [Required]
+        [Argument(0, Description = "Command separated list of playlist room IDs to reprocess.")]
+        public string PlaylistIds { get; set; } = string.Empty;
+
+        public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
+        {
+            foreach (string id in PlaylistIds.Split(','))
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    break;
+
+                using (var db = Queue.GetDatabaseConnection())
+                {
+                    var playlistItems = await db.QueryAsync<MultiplayerPlaylistItem>("SELECT * FROM multiplayer_playlist_items WHERE room_id = @PlaylistId", new
+                    {
+                        PlaylistId = int.Parse(id),
+                    });
+
+                    foreach (var item in playlistItems)
+                    {
+                        if (cancellationToken.IsCancellationRequested)
+                            break;
+
+                        MultiplayerScore[] scores = (await db.QueryAsync<MultiplayerScore>($"SELECT * FROM multiplayer_scores WHERE playlist_item_id = {item.id}")).ToArray();
+
+                        foreach (var score in scores)
+                        {
+                            Console.WriteLine($"Reprocessing score {score.id} from playlist {item.id}");
+
+                            Ruleset ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(item.ruleset_id);
+                            HitResult maxRulesetJudgement = ruleset.GetHitResults().First().result;
+                            Dictionary<HitResult, int> statistics = JsonConvert.DeserializeObject<Dictionary<HitResult, int>>(score.statistics)!;
+                            List<HitResult> allHits = statistics
+                                                      .SelectMany(kvp => Enumerable.Repeat(kvp.Key, kvp.Value))
+                                                      .ToList();
+                            var maximumStatistics = new Dictionary<HitResult, int>();
+
+                            foreach (var groupedStats in allHits
+                                                         .Select(r => getMaxJudgementFor(r, maxRulesetJudgement))
+                                                         .GroupBy(r => r))
+                            {
+                                maximumStatistics[groupedStats.Key] = groupedStats.Count();
+                            }
+
+                            APIMod[] roomMods = JsonConvert.DeserializeObject<APIMod[]>(item.required_mods)!;
+                            APIMod[] scoreMods = JsonConvert.DeserializeObject<APIMod[]>(score.mods)!;
+
+                            foreach (var m in roomMods)
+                                Debug.Assert(scoreMods.Contains(m));
+
+                            Console.WriteLine($"Mods: {string.Join(',', scoreMods.Select(m => m.ToString()))}");
+
+                            int insertId = await db.InsertAsync(new SoloScore
+                            {
+                                user_id = (int)score.userId,
+                                beatmap_id = (int)score.beatmapId,
+                                ruleset_id = item.ruleset_id,
+                                preserve = true,
+                                ScoreInfo = SoloScoreInfo.ForSubmission(new ScoreInfo
+                                {
+                                    Statistics = statistics,
+                                    MaximumStatistics = maximumStatistics,
+                                    Ruleset = ruleset.RulesetInfo,
+                                    MaxCombo = score.max_combo,
+                                    APIMods = scoreMods,
+                                    Accuracy = (double)score.accuracy!,
+                                    TotalScore = (long)score.total_score!,
+                                    Rank = Enum.Parse<ScoreRank>(score.rank),
+                                    Passed = score.passed,
+                                }),
+                                created_at = (DateTimeOffset)score.created_at!,
+                                updated_at = (DateTimeOffset)score.updated_at!,
+                            });
+
+                            await db.ExecuteAsync("INSERT INTO multiplayer_score_links (user_id, room_id, beatmap_id, playlist_item_id, score_id, created_at, updated_at) VALUES (@userId, @roomId, @beatmapId, @playlistItemId, @scoreId, @createdAt, @updatedAt)", new
+                            {
+                                score.userId,
+                                score.roomId,
+                                score.beatmapId,
+                                score.playlistItemId,
+                                scoreId = insertId,
+                                createdAt = score.started_at,
+                                updatedAt = score.ended_at
+                            });
+
+                            Console.WriteLine();
+                        }
+                    }
+                }
+            }
+
+            Console.WriteLine("Finished.");
+            return 0;
+        }
+
+        private static HitResult getMaxJudgementFor(HitResult hitResult, HitResult max)
+        {
+            switch (hitResult)
+            {
+                case HitResult.Miss:
+                case HitResult.Meh:
+                case HitResult.Ok:
+                case HitResult.Good:
+                case HitResult.Great:
+                case HitResult.Perfect:
+                    return max;
+
+                case HitResult.SmallTickMiss:
+                case HitResult.SmallTickHit:
+                    return HitResult.SmallTickHit;
+
+                case HitResult.LargeTickMiss:
+                case HitResult.LargeTickHit:
+                    return HitResult.LargeTickHit;
+            }
+
+            return HitResult.IgnoreHit;
+        }
+
+        // ReSharper disable InconsistentNaming
+        public class MultiplayerScore
+        {
+            public long id { get; set; }
+            public uint userId { get; set; }
+            public long roomId { get; set; }
+            public long playlistItemId { get; set; }
+            public long beatmapId { get; set; }
+            public string rank { get; set; } = string.Empty;
+            public long? total_score { get; set; }
+            public double? accuracy { get; set; }
+            public double? pp { get; set; }
+            public int max_combo { get; set; }
+            public string mods { get; set; } = string.Empty;
+            public string statistics { get; set; } = string.Empty;
+            public DateTime started_at { get; set; }
+            public DateTime? ended_at { get; set; }
+            public bool passed { get; set; }
+            public DateTime? created_at { get; set; }
+            public DateTime? updated_at { get; set; }
+            public DateTime? deleted_at { get; set; }
+        }
+
+        public class MultiplayerPlaylistItem
+        {
+            public long id { get; set; }
+            public long room_id { get; set; }
+            public uint owner_id { get; set; }
+            public uint beatmap_id { get; set; }
+            public ushort ruleset_id { get; set; }
+            public ushort? playlist_order { get; set; }
+            public string allowed_mods { get; set; } = string.Empty;
+            public string required_mods { get; set; } = string.Empty;
+            public byte? max_attempts { get; set; }
+            public DateTime? created_at { get; set; }
+            public DateTime? updated_at { get; set; }
+            public bool expired { get; set; }
+            public DateTime? played_at { get; set; }
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
@@ -80,7 +80,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
                             int? insertId = null;
 
-                            if (score.total_score != null)
+                            if (score.total_score != null || score.ended_at != null)
                             {
                                 var soloScoreInfo = SoloScoreInfo.ForSubmission(new ScoreInfo
                                 {
@@ -90,13 +90,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                                     MaxCombo = (int)score.max_combo!,
                                     APIMods = scoreMods,
                                     Accuracy = (double)score.accuracy!,
-                                    TotalScore = (long)score.total_score,
+                                    TotalScore = (long)score.total_score!,
                                     Rank = Enum.Parse<ScoreRank>(score.rank),
                                     Passed = score.passed,
                                 });
 
-                                soloScoreInfo.StartedAt = score.started_at;
-                                soloScoreInfo.EndedAt = score.ended_at ?? default;
+                                soloScoreInfo.StartedAt = DateTime.SpecifyKind(score.started_at, DateTimeKind.Utc);
+                                soloScoreInfo.EndedAt = DateTime.SpecifyKind(score.ended_at!.Value, DateTimeKind.Utc);
                                 soloScoreInfo.BeatmapID = (int)score.beatmapId;
 
                                 insertId = await db.InsertAsync(new SoloScore
@@ -106,8 +106,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                                     ruleset_id = item.ruleset_id,
                                     preserve = true,
                                     ScoreInfo = soloScoreInfo,
-                                    created_at = (DateTimeOffset)score.created_at!,
-                                    updated_at = (DateTimeOffset)score.updated_at!,
+                                    created_at = DateTime.SpecifyKind(score.created_at!.Value, DateTimeKind.Utc),
+                                    updated_at = DateTime.SpecifyKind(score.updated_at!.Value, DateTimeKind.Utc),
                                 });
                             }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
@@ -78,8 +78,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                             foreach (var m in roomMods)
                                 Debug.Assert(scoreMods.Contains(m));
 
-                            Console.WriteLine($"Mods: {string.Join(',', scoreMods.Select(m => m.ToString()))}");
-
                             int insertId = await db.InsertAsync(new SoloScore
                             {
                                 user_id = (int)score.userId,

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
@@ -91,7 +91,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                                     Statistics = statistics,
                                     MaximumStatistics = maximumStatistics,
                                     Ruleset = ruleset.RulesetInfo,
-                                    MaxCombo = score.max_combo,
+                                    MaxCombo = (int)score.max_combo!,
                                     APIMods = scoreMods,
                                     Accuracy = (double)score.accuracy!,
                                     TotalScore = (long)score.total_score!,
@@ -150,16 +150,16 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
         // ReSharper disable InconsistentNaming
         public class MultiplayerScore
         {
-            public long id { get; set; }
+            public ulong id { get; set; }
             public uint userId { get; set; }
-            public long roomId { get; set; }
-            public long playlistItemId { get; set; }
-            public long beatmapId { get; set; }
+            public ulong roomId { get; set; }
+            public ulong playlistItemId { get; set; }
+            public uint beatmapId { get; set; }
             public string rank { get; set; } = string.Empty;
             public long? total_score { get; set; }
             public double? accuracy { get; set; }
             public double? pp { get; set; }
-            public int max_combo { get; set; }
+            public uint? max_combo { get; set; }
             public string mods { get; set; } = string.Empty;
             public string statistics { get; set; } = string.Empty;
             public DateTime started_at { get; set; }
@@ -172,8 +172,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
         public class MultiplayerPlaylistItem
         {
-            public long id { get; set; }
-            public long room_id { get; set; }
+            public ulong id { get; set; }
+            public ulong room_id { get; set; }
             public uint owner_id { get; set; }
             public uint beatmap_id { get; set; }
             public ushort ruleset_id { get; set; }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
@@ -59,7 +59,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
                             Ruleset ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(item.ruleset_id);
                             HitResult maxRulesetJudgement = ruleset.GetHitResults().First().result;
-                            Dictionary<HitResult, int> statistics = JsonConvert.DeserializeObject<Dictionary<HitResult, int>>(score.statistics)!;
+
+                            Dictionary<HitResult, int> statistics = JsonConvert.DeserializeObject<Dictionary<HitResult, int>>(score.statistics)
+                                                                    ?? new Dictionary<HitResult, int>();
+
                             List<HitResult> allHits = statistics
                                                       .SelectMany(kvp => Enumerable.Repeat(kvp.Key, kvp.Value))
                                                       .ToList();

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
@@ -78,33 +78,38 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                             foreach (var m in roomMods)
                                 Debug.Assert(scoreMods.Contains(m));
 
-                            var soloScoreInfo = SoloScoreInfo.ForSubmission(new ScoreInfo
-                            {
-                                Statistics = statistics,
-                                MaximumStatistics = maximumStatistics,
-                                Ruleset = ruleset.RulesetInfo,
-                                MaxCombo = (int)score.max_combo!,
-                                APIMods = scoreMods,
-                                Accuracy = (double)score.accuracy!,
-                                TotalScore = (long)score.total_score!,
-                                Rank = Enum.Parse<ScoreRank>(score.rank),
-                                Passed = score.passed,
-                            });
+                            int? insertId = null;
 
-                            soloScoreInfo.StartedAt = score.started_at;
-                            soloScoreInfo.EndedAt = score.started_at;
-                            soloScoreInfo.BeatmapID = (int)score.beatmapId;
-
-                            int insertId = await db.InsertAsync(new SoloScore
+                            if (score.total_score != null)
                             {
-                                user_id = (int)score.userId,
-                                beatmap_id = (int)score.beatmapId,
-                                ruleset_id = item.ruleset_id,
-                                preserve = true,
-                                ScoreInfo = soloScoreInfo,
-                                created_at = (DateTimeOffset)score.created_at!,
-                                updated_at = (DateTimeOffset)score.updated_at!,
-                            });
+                                var soloScoreInfo = SoloScoreInfo.ForSubmission(new ScoreInfo
+                                {
+                                    Statistics = statistics,
+                                    MaximumStatistics = maximumStatistics,
+                                    Ruleset = ruleset.RulesetInfo,
+                                    MaxCombo = (int)score.max_combo!,
+                                    APIMods = scoreMods,
+                                    Accuracy = (double)score.accuracy!,
+                                    TotalScore = (long)score.total_score,
+                                    Rank = Enum.Parse<ScoreRank>(score.rank),
+                                    Passed = score.passed,
+                                });
+
+                                soloScoreInfo.StartedAt = score.started_at;
+                                soloScoreInfo.EndedAt = score.started_at;
+                                soloScoreInfo.BeatmapID = (int)score.beatmapId;
+
+                                insertId = await db.InsertAsync(new SoloScore
+                                {
+                                    user_id = (int)score.userId,
+                                    beatmap_id = (int)score.beatmapId,
+                                    ruleset_id = item.ruleset_id,
+                                    preserve = true,
+                                    ScoreInfo = soloScoreInfo,
+                                    created_at = (DateTimeOffset)score.created_at!,
+                                    updated_at = (DateTimeOffset)score.updated_at!,
+                                });
+                            }
 
                             await db.ExecuteAsync("INSERT INTO multiplayer_score_links (user_id, room_id, beatmap_id, playlist_item_id, score_id, created_at, updated_at) VALUES (@userId, @roomId, @beatmapId, @playlistItemId, @scoreId, @createdAt, @updatedAt)", new
                             {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
@@ -97,12 +97,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
                                 soloScoreInfo.StartedAt = DateTime.SpecifyKind(score.started_at, DateTimeKind.Utc);
                                 soloScoreInfo.EndedAt = DateTime.SpecifyKind(score.ended_at!.Value, DateTimeKind.Utc);
-                                soloScoreInfo.BeatmapID = (int)score.beatmapId;
+                                soloScoreInfo.BeatmapID = (int)score.beatmap_id;
 
                                 insertId = await db.InsertAsync(new SoloScore
                                 {
-                                    user_id = (int)score.userId,
-                                    beatmap_id = (int)score.beatmapId,
+                                    user_id = (int)score.user_id,
+                                    beatmap_id = (int)score.beatmap_id,
                                     ruleset_id = item.ruleset_id,
                                     preserve = true,
                                     ScoreInfo = soloScoreInfo,
@@ -113,10 +113,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
                             await db.ExecuteAsync("INSERT INTO multiplayer_score_links (user_id, room_id, beatmap_id, playlist_item_id, score_id, created_at, updated_at) VALUES (@userId, @roomId, @beatmapId, @playlistItemId, @scoreId, @createdAt, @updatedAt)", new
                             {
-                                score.userId,
-                                score.roomId,
-                                score.beatmapId,
-                                score.playlistItemId,
+                                userId = score.user_id,
+                                roomId = score.room_id,
+                                beatmapId = score.beatmap_id,
+                                playlistItemId = score.playlist_item_id,
                                 scoreId = insertId,
                                 createdAt = score.ended_at,
                                 updatedAt = score.ended_at
@@ -160,10 +160,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
         public class MultiplayerScore
         {
             public ulong id { get; set; }
-            public uint userId { get; set; }
-            public ulong roomId { get; set; }
-            public ulong playlistItemId { get; set; }
-            public uint beatmapId { get; set; }
+            public uint user_id { get; set; }
+            public ulong room_id { get; set; }
+            public ulong playlist_item_id { get; set; }
+            public uint beatmap_id { get; set; }
             public string rank { get; set; } = string.Empty;
             public long? total_score { get; set; }
             public double? accuracy { get; set; }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
@@ -121,7 +121,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                                 beatmapId = score.beatmap_id,
                                 playlistItemId = score.playlist_item_id,
                                 scoreId = insertId,
-                                createdAt = score.ended_at,
+                                createdAt = score.created_at,
                                 updatedAt = score.ended_at
                             });
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
@@ -78,24 +78,30 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                             foreach (var m in roomMods)
                                 Debug.Assert(scoreMods.Contains(m));
 
+                            var soloScoreInfo = SoloScoreInfo.ForSubmission(new ScoreInfo
+                            {
+                                Statistics = statistics,
+                                MaximumStatistics = maximumStatistics,
+                                Ruleset = ruleset.RulesetInfo,
+                                MaxCombo = (int)score.max_combo!,
+                                APIMods = scoreMods,
+                                Accuracy = (double)score.accuracy!,
+                                TotalScore = (long)score.total_score!,
+                                Rank = Enum.Parse<ScoreRank>(score.rank),
+                                Passed = score.passed,
+                            });
+
+                            soloScoreInfo.StartedAt = score.started_at;
+                            soloScoreInfo.EndedAt = score.started_at;
+                            soloScoreInfo.BeatmapID = (int)score.beatmapId;
+
                             int insertId = await db.InsertAsync(new SoloScore
                             {
                                 user_id = (int)score.userId,
                                 beatmap_id = (int)score.beatmapId,
                                 ruleset_id = item.ruleset_id,
                                 preserve = true,
-                                ScoreInfo = SoloScoreInfo.ForSubmission(new ScoreInfo
-                                {
-                                    Statistics = statistics,
-                                    MaximumStatistics = maximumStatistics,
-                                    Ruleset = ruleset.RulesetInfo,
-                                    MaxCombo = (int)score.max_combo!,
-                                    APIMods = scoreMods,
-                                    Accuracy = (double)score.accuracy!,
-                                    TotalScore = (long)score.total_score!,
-                                    Rank = Enum.Parse<ScoreRank>(score.rank),
-                                    Passed = score.passed,
-                                }),
+                                ScoreInfo = soloScoreInfo,
                                 created_at = (DateTimeOffset)score.created_at!,
                                 updated_at = (DateTimeOffset)score.updated_at!,
                             });
@@ -107,7 +113,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                                 score.beatmapId,
                                 score.playlistItemId,
                                 scoreId = insertId,
-                                createdAt = score.started_at,
+                                createdAt = score.ended_at,
                                 updatedAt = score.ended_at
                             });
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MigratePlaylistScoresToSoloScoresCommand.cs
@@ -96,7 +96,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                                 });
 
                                 soloScoreInfo.StartedAt = score.started_at;
-                                soloScoreInfo.EndedAt = score.started_at;
+                                soloScoreInfo.EndedAt = score.ended_at ?? default;
                                 soloScoreInfo.BeatmapID = (int)score.beatmapId;
 
                                 insertId = await db.InsertAsync(new SoloScore

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/MaintenanceCommands.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/MaintenanceCommands.cs
@@ -11,6 +11,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands
     [Command(Name = "maintenance", Description = "General database maintenance commands which are usually run on a cron schedule.")]
     [Subcommand(typeof(DeleteNonPreservedScoresCommand))]
     [Subcommand(typeof(MarkNonPreservedScoresCommand))]
+    [Subcommand(typeof(MigratePlaylistScoresToSoloScoresCommand))]
     public sealed class MaintenanceCommands
     {
         public Task<int> OnExecuteAsync(CommandLineApplication app, CancellationToken cancellationToken)


### PR DESCRIPTION
This is to be used to preserve ongoing featured artist / spotlight room's scores as we migrate scores to the new table.

It means we can continue to move forward without worrying about breaking things, basically.

It's made to only run for playlists, and not migrate *all* scores, but could be expanded in the future if we want to have more coverage.