### PR TITLE
Use classic score in total score processor

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -132,6 +132,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                     { HitResult.Perfect, 5 },
                     { HitResult.LargeBonus, 0 }
                 },
+                MaximumStatistics =
+                {
+                    { HitResult.Perfect, 5 },
+                    { HitResult.LargeBonus, 2 }
+                },
                 Passed = true
             };
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/TotalScoreProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/TotalScoreProcessorTests.cs
@@ -12,10 +12,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             WaitForDatabaseState("SELECT total_score FROM osu_user_stats WHERE user_id = 2", (int?)null, CancellationToken);
 
             PushToQueueAndWaitForProcess(CreateTestScore());
-            WaitForDatabaseState("SELECT total_score FROM osu_user_stats WHERE user_id = 2", 100000, CancellationToken);
+            WaitForDatabaseState("SELECT total_score FROM osu_user_stats WHERE user_id = 2", 10081, CancellationToken);
 
             PushToQueueAndWaitForProcess(CreateTestScore());
-            WaitForDatabaseState("SELECT total_score FROM osu_user_stats WHERE user_id = 2", 200000, CancellationToken);
+            WaitForDatabaseState("SELECT total_score FROM osu_user_stats WHERE user_id = 2", 20162, CancellationToken);
         }
 
         [Fact]
@@ -45,12 +45,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             WaitForDatabaseState("SELECT total_score FROM osu_user_stats WHERE user_id = 2", (int?)null, CancellationToken);
 
             PushToQueueAndWaitForProcess(score);
-            WaitForDatabaseState("SELECT total_score FROM osu_user_stats WHERE user_id = 2", 100000, CancellationToken);
+            WaitForDatabaseState("SELECT total_score FROM osu_user_stats WHERE user_id = 2", 10081, CancellationToken);
 
             score.MarkProcessed();
 
             PushToQueueAndWaitForProcess(score);
-            WaitForDatabaseState("SELECT total_score FROM osu_user_stats WHERE user_id = 2", 100000, CancellationToken);
+            WaitForDatabaseState("SELECT total_score FROM osu_user_stats WHERE user_id = 2", 10081, CancellationToken);
         }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/TotalScoreProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/TotalScoreProcessor.cs
@@ -4,6 +4,8 @@
 using JetBrains.Annotations;
 using MySqlConnector;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring.Legacy;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
@@ -19,12 +21,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
             if (previousVersion >= 2)
-                userStats.total_score -= score.TotalScore;
+                userStats.total_score -= score.GetDisplayScore(ScoringMode.Classic);
         }
 
         public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
         {
-            userStats.total_score += score.TotalScore;
+            userStats.total_score += score.GetDisplayScore(ScoringMode.Classic);
         }
 
         public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BeatmapStore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BeatmapStore.cs
@@ -44,7 +44,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
         /// <param name="connection">The <see cref="MySqlConnection"/>.</param>
         /// <param name="transaction">An existing transaction.</param>
         /// <returns>The created <see cref="BeatmapStore"/>.</returns>
-        public static async Task<BeatmapStore> CreateAsync(MySqlConnection? connection, MySqlTransaction? transaction = null)
+        public static async Task<BeatmapStore> CreateAsync(MySqlConnection connection, MySqlTransaction? transaction = null)
         {
             var dbBlacklist = await connection.QueryAsync<PerformanceBlacklistEntry>("SELECT * FROM osu_beatmap_performance_blacklist", transaction: transaction);
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BuildStore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BuildStore.cs
@@ -28,7 +28,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
         /// <param name="connection">The <see cref="MySqlConnection"/>.</param>
         /// <param name="transaction">An existing transaction.</param>
         /// <returns>The created <see cref="BuildStore"/>.</returns>
-        public static async Task<BuildStore> CreateAsync(MySqlConnection? connection, MySqlTransaction? transaction = null)
+        public static async Task<BuildStore> CreateAsync(MySqlConnection connection, MySqlTransaction? transaction = null)
         {
             var dbBuilds = await connection.QueryAsync<Build>("SELECT * FROM osu_builds WHERE `allow_ranking` = TRUE OR `allow_performance` = TRUE", transaction: transaction);
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
@@ -9,14 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dapper" Version="2.0.151" />
+        <PackageReference Include="Dapper" Version="2.1.4" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.928.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.928.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.928.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.928.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.928.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.1004.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.1004.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.1004.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.1004.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.1004.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2023.822.0" />
     </ItemGroup>
 


### PR DESCRIPTION
As per https://github.com/ppy/osu-queue-score-statistics/issues/134#issuecomment-1686230928

- [x] Depends on https://github.com/ppy/osu/pull/24957
- [x] Depends on https://github.com/ppy/osu-queue-score-statistics/pull/155 for mergeability
- [x] Depends on https://github.com/ppy/osu/pull/24924 for adjusted test values to be correct (dependency can be removed if need be).
- [x] Depends on nuget release of `osu.Game`