### PR TITLE
Add support for increasing ranked score

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/RankedScoreProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/RankedScoreProcessorTests.cs
@@ -1,0 +1,200 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Scoring;
+using Xunit;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
+{
+    public class RankedScoreProcessorTests : DatabaseTest
+    {
+        [Fact]
+        public void TestNonPassingScoreDoesNothing()
+        {
+            AddBeatmap();
+            waitForRankedScore("osu_user_stats", 0);
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item => item.Score.ScoreInfo.Passed = false);
+            waitForRankedScore("osu_user_stats", 0);
+        }
+
+        [Theory]
+        [InlineData(BeatmapOnlineStatus.Graveyard)]
+        [InlineData(BeatmapOnlineStatus.WIP)]
+        [InlineData(BeatmapOnlineStatus.Pending)]
+        [InlineData(BeatmapOnlineStatus.Qualified)]
+        public void TestScoreOnUnrankedMapDoesNothing(BeatmapOnlineStatus status)
+        {
+            AddBeatmap(b => b.approved = status);
+            waitForRankedScore("osu_user_stats", 0);
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID);
+            waitForRankedScore("osu_user_stats", 0);
+        }
+
+        [Theory]
+        [InlineData(BeatmapOnlineStatus.Ranked)]
+        [InlineData(BeatmapOnlineStatus.Approved)]
+        [InlineData(BeatmapOnlineStatus.Loved)]
+        public void TestScoreOnRankedMapIncreasesRankedScore(BeatmapOnlineStatus status)
+        {
+            AddBeatmap(b => b.approved = status);
+            waitForRankedScore("osu_user_stats", 0);
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID);
+            waitForRankedScore("osu_user_stats", 10081);
+        }
+
+        [Fact]
+        public void TestScoresFromDifferentBeatmapsAreCountedSeparately()
+        {
+            var firstBeatmap = AddBeatmap(b => b.beatmap_id = 1001, s => s.beatmapset_id = 1);
+            var secondBeatmap = AddBeatmap(b => b.beatmap_id = 1002, s => s.beatmapset_id = 2);
+
+            waitForRankedScore("osu_user_stats", 0);
+
+            SetScoreForBeatmap(firstBeatmap.beatmap_id);
+            waitForRankedScore("osu_user_stats", 10081);
+
+            SetScoreForBeatmap(secondBeatmap.beatmap_id);
+            waitForRankedScore("osu_user_stats", 20162);
+        }
+
+        [Fact]
+        public void TestScoresFromSameBeatmapInDifferentRulesetsAreCountedSeparately()
+        {
+            AddBeatmap();
+            waitForRankedScore("osu_user_stats", 0);
+            waitForRankedScore("osu_user_stats_mania", 0);
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID);
+            waitForRankedScore("osu_user_stats", 10081);
+            waitForRankedScore("osu_user_stats_mania", 0);
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item => item.Score.ruleset_id = item.Score.ScoreInfo.RulesetID = 3);
+            waitForRankedScore("osu_user_stats", 10081);
+            waitForRankedScore("osu_user_stats_mania", 100000);
+        }
+
+        [Fact]
+        public void TestWorseScoreIsNotCounted()
+        {
+            AddBeatmap();
+            waitForRankedScore("osu_user_stats", 0);
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID);
+            waitForRankedScore("osu_user_stats", 10081);
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, score =>
+            {
+                var scoreInfo = score.Score.ScoreInfo;
+
+                scoreInfo.TotalScore = 50000;
+                scoreInfo.Statistics[HitResult.Perfect] = 0;
+                scoreInfo.Statistics[HitResult.Ok] = 5;
+            });
+            waitForRankedScore("osu_user_stats", 10081);
+        }
+
+        [Fact]
+        public void TestBetterScoreReplacesWorseScore()
+        {
+            AddBeatmap();
+            waitForRankedScore("osu_user_stats", 0);
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, score =>
+            {
+                var scoreInfo = score.Score.ScoreInfo;
+
+                scoreInfo.TotalScore = 50000;
+                scoreInfo.Statistics[HitResult.Perfect] = 0;
+                scoreInfo.Statistics[HitResult.Ok] = 5;
+            });
+            waitForRankedScore("osu_user_stats", 5041);
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID);
+            waitForRankedScore("osu_user_stats", 10081);
+        }
+
+        [Fact]
+        public void TestReprocessWithSameVersionDoesntIncrease()
+        {
+            AddBeatmap();
+
+            waitForRankedScore("osu_user_stats", 0);
+
+            var score = SetScoreForBeatmap(TEST_BEATMAP_ID);
+            waitForRankedScore("osu_user_stats", 10081);
+
+            // the score will be marked as processed (in the database) at this point, so should not increase ranked score if processed a second time.
+            score.MarkProcessed();
+
+            PushToQueueAndWaitForProcess(score);
+            waitForRankedScore("osu_user_stats", 10081);
+        }
+
+        [Fact]
+        public void TestReprocessNewHighScoreDoesNotChangeRankedTotal()
+        {
+            AddBeatmap();
+
+            waitForRankedScore("osu_user_stats", 0);
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, score =>
+            {
+                var scoreInfo = score.Score.ScoreInfo;
+
+                scoreInfo.TotalScore = 50000;
+                scoreInfo.Statistics[HitResult.Perfect] = 0;
+                scoreInfo.Statistics[HitResult.Ok] = 5;
+            });
+            waitForRankedScore("osu_user_stats", 5041);
+
+            var secondScore = SetScoreForBeatmap(TEST_BEATMAP_ID);
+            waitForRankedScore("osu_user_stats", 10081);
+
+            // the score will be marked as processed (in the database) at this point.
+            secondScore.MarkProcessed();
+            // artificially increase the `processed_version` so that the score undergoes a revert and reprocess.
+            secondScore.ProcessHistory!.processed_version++;
+
+            PushToQueueAndWaitForProcess(secondScore);
+
+            waitForRankedScore("osu_user_stats", 10081);
+        }
+
+        [Fact]
+        public void TestReprocessNewNonHighScoreDoesNotChangeRankedTotal()
+        {
+            AddBeatmap();
+
+            waitForRankedScore("osu_user_stats", 0);
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID);
+            waitForRankedScore("osu_user_stats", 10081);
+
+            var secondScore = SetScoreForBeatmap(TEST_BEATMAP_ID, score =>
+            {
+                var scoreInfo = score.Score.ScoreInfo;
+
+                scoreInfo.TotalScore = 50000;
+                scoreInfo.Statistics[HitResult.Perfect] = 0;
+                scoreInfo.Statistics[HitResult.Ok] = 5;
+            });
+            waitForRankedScore("osu_user_stats", 10081);
+
+            // the score will be marked as processed (in the database) at this point.
+            secondScore.MarkProcessed();
+            // artificially increase the `processed_version` so that the score undergoes a revert and reprocess.
+            secondScore.ProcessHistory!.processed_version++;
+
+            PushToQueueAndWaitForProcess(secondScore);
+
+            waitForRankedScore("osu_user_stats", 10081);
+        }
+
+        private void waitForRankedScore(string tableName, long expectedRankedScore)
+            => WaitForDatabaseState($"SELECT `ranked_score` FROM {tableName} WHERE `user_id` = 2", expectedRankedScore, CancellationToken);
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/UserRankCountProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/UserRankCountProcessorTests.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Game.Beatmaps;
 using osu.Game.Scoring;
 using Xunit;
 
@@ -83,6 +84,36 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             SetScoreForBeatmap(TEST_BEATMAP_ID, item => item.Score.ScoreInfo.Rank = ScoreRank.B);
             waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+        }
+
+        [Theory]
+        [InlineData(BeatmapOnlineStatus.Graveyard)]
+        [InlineData(BeatmapOnlineStatus.WIP)]
+        [InlineData(BeatmapOnlineStatus.Pending)]
+        [InlineData(BeatmapOnlineStatus.Qualified)]
+        public void TestScoreWithRankAOrAboveOnUnrankedMapDoesNothing(BeatmapOnlineStatus status)
+        {
+            AddBeatmap(b => b.approved = status);
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item => item.Score.ScoreInfo.Rank = ScoreRank.A);
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+        }
+
+        [Theory]
+        [InlineData(BeatmapOnlineStatus.Ranked)]
+        [InlineData(BeatmapOnlineStatus.Approved)]
+        [InlineData(BeatmapOnlineStatus.Loved)]
+        public void TestScoreWithRankAOrAboveOnRankedMapChangesRankCounts(BeatmapOnlineStatus status)
+        {
+            AddBeatmap(b => b.approved = status);
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item => item.Score.ScoreInfo.Rank = ScoreRank.A);
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.A] = 1
+            });
         }
 
         [Fact]

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/RankedScoreProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/RankedScoreProcessor.cs
@@ -2,13 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Diagnostics;
-using Dapper;
 using JetBrains.Annotations;
 using MySqlConnector;
-using osu.Game.Beatmaps;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring.Legacy;
+using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
@@ -23,7 +22,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             if (!score.Passed)
                 return;
 
-            if (!isBeatmapValidForRankedScore(score.BeatmapID, conn, transaction))
+            if (!DatabaseHelper.IsBeatmapValidForRankedCounts(score.BeatmapID, conn, transaction))
                 return;
 
             if (previousVersion >= 8)
@@ -31,7 +30,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 // It is assumed that in the case of a revert, either the score is deleted, or a reapplication will immediately follow.
 
                 // First, see if the score we're reverting is the user's best (and as such included in the total ranked score).
-                var bestScore = getBestScore(score, conn, transaction);
+                var bestScore = DatabaseHelper.GetUserBestScoreFor(score, conn, transaction);
 
                 // If this score isn't the user's best on the beatmap, nothing needs to be reverted.
                 if (bestScore?.ID != score.ID)
@@ -40,7 +39,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 // If it is, unapply from total ranked score before applying the next-best.
                 updateRankedScore(score, userStats, revert: true);
 
-                var secondBestScore = getSecondBestScore(score, conn, transaction);
+                var secondBestScore = DatabaseHelper.GetUserBestScoreFor(score, conn, transaction, offset: 1);
                 if (secondBestScore != null)
                     updateRankedScore(secondBestScore, userStats, revert: false);
             }
@@ -51,7 +50,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             if (!score.Passed)
                 return;
 
-            if (!isBeatmapValidForRankedScore(score.BeatmapID, conn, transaction))
+            if (!DatabaseHelper.IsBeatmapValidForRankedCounts(score.BeatmapID, conn, transaction))
                 return;
 
             // Note that most of the below code relies on the fact that classic scoring mode
@@ -60,7 +59,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             // where we increase the user's ranked score - at which point we will use classic
             // to meet past user expectations.
 
-            var bestScore = getBestScore(score, conn, transaction);
+            var bestScore = DatabaseHelper.GetUserBestScoreFor(score, conn, transaction);
 
             // If there's already another higher score than this one, nothing needs to be done.
             if (bestScore?.ID != score.ID)
@@ -69,7 +68,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             // If this score is the new best and there's a previous higher score,
             // that score's total should be unapplied from the user's ranked total
             // before we apply the new one.
-            var secondBestScore = getSecondBestScore(score, conn, transaction);
+            var secondBestScore = DatabaseHelper.GetUserBestScoreFor(score, conn, transaction, offset: 1);
             if (secondBestScore != null)
                 updateRankedScore(secondBestScore, userStats, revert: true);
 
@@ -80,43 +79,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
         {
         }
-
-        private static bool isBeatmapValidForRankedScore(int beatmapId, MySqlConnection conn, MySqlTransaction transaction)
-        {
-            var status = conn.QuerySingleOrDefault<BeatmapOnlineStatus>("SELECT `approved` FROM osu_beatmaps WHERE `beatmap_id` = @beatmap_id",
-                new { beatmap_id = beatmapId },
-                transaction);
-
-            // see https://osu.ppy.sh/wiki/en/Gameplay/Score/Ranked_score
-            return status == BeatmapOnlineStatus.Ranked
-                   || status == BeatmapOnlineStatus.Approved
-                   || status == BeatmapOnlineStatus.Loved;
-        }
-
-        private static SoloScoreInfo? getBestScore(SoloScoreInfo score, MySqlConnection conn, MySqlTransaction transaction, int offset = 0)
-        {
-            var rankSource = conn.QueryFirstOrDefault<SoloScore?>(
-                "SELECT * FROM solo_scores WHERE `user_id` = @user_id "
-                + "AND `beatmap_id` = @beatmap_id "
-                + "AND `ruleset_id` = @ruleset_id "
-                // preserve is not flagged on the newly arriving score until it has been completely processed (see logic in `ScoreStatisticsQueueProcessor.cs`)
-                // therefore we need to make an exception here to ensure it's included.
-                + "AND (`preserve` = 1 OR `id` = @new_score_id) "
-                + "ORDER BY `data`->'$.total_score' DESC, `id` DESC "
-                + "LIMIT @offset, 1", new
-                {
-                    user_id = score.UserID,
-                    beatmap_id = score.BeatmapID,
-                    ruleset_id = score.RulesetID,
-                    new_score_id = score.ID,
-                    offset = offset,
-                }, transaction);
-
-            return rankSource?.ScoreInfo;
-        }
-
-        private static SoloScoreInfo? getSecondBestScore(SoloScoreInfo score, MySqlConnection conn, MySqlTransaction transaction)
-            => getBestScore(score, conn, transaction, 1);
 
         private static void updateRankedScore(SoloScoreInfo soloScoreInfo, UserStats stats, bool revert)
         {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/RankedScoreProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/RankedScoreProcessor.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using JetBrains.Annotations;
+using MySqlConnector;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
+{
+    [UsedImplicitly]
+    public class RankedScoreProcessor : IProcessor
+    {
+        public bool RunOnFailedScores => false;
+
+        public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
+        {
+        }
+
+        public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
+        {
+        }
+
+        public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
+        {
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/RankedScoreProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/RankedScoreProcessor.cs
@@ -1,9 +1,14 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Diagnostics;
+using Dapper;
 using JetBrains.Annotations;
 using MySqlConnector;
+using osu.Game.Beatmaps;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring.Legacy;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
@@ -15,14 +20,108 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
+            if (!score.Passed)
+                return;
+
+            if (!isBeatmapValidForRankedScore(score.BeatmapID, conn, transaction))
+                return;
+
+            if (previousVersion >= 8)
+            {
+                // It is assumed that in the case of a revert, either the score is deleted, or a reapplication will immediately follow.
+
+                // First, see if the score we're reverting is the user's best (and as such included in the total ranked score).
+                var bestScore = getBestScore(score, conn, transaction);
+
+                // If this score isn't the user's best on the beatmap, nothing needs to be reverted.
+                if (bestScore?.ID != score.ID)
+                    return;
+
+                // If it is, unapply from total ranked score before applying the next-best.
+                updateRankedScore(score, userStats, revert: true);
+
+                var secondBestScore = getSecondBestScore(score, conn, transaction);
+                if (secondBestScore != null)
+                    updateRankedScore(secondBestScore, userStats, revert: false);
+            }
         }
 
         public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
         {
+            if (!score.Passed)
+                return;
+
+            if (!isBeatmapValidForRankedScore(score.BeatmapID, conn, transaction))
+                return;
+
+            // Note that most of the below code relies on the fact that classic scoring mode
+            // does not reorder scores.
+            // Therefore, we will be operating on standardised score right until the actual part
+            // where we increase the user's ranked score - at which point we will use classic
+            // to meet past user expectations.
+
+            var bestScore = getBestScore(score, conn, transaction);
+
+            // If there's already another higher score than this one, nothing needs to be done.
+            if (bestScore?.ID != score.ID)
+                return;
+
+            // If this score is the new best and there's a previous higher score,
+            // that score's total should be unapplied from the user's ranked total
+            // before we apply the new one.
+            var secondBestScore = getSecondBestScore(score, conn, transaction);
+            if (secondBestScore != null)
+                updateRankedScore(secondBestScore, userStats, revert: true);
+
+            Debug.Assert(bestScore != null);
+            updateRankedScore(bestScore, userStats, revert: false);
         }
 
         public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
         {
+        }
+
+        private static bool isBeatmapValidForRankedScore(int beatmapId, MySqlConnection conn, MySqlTransaction transaction)
+        {
+            var status = conn.QuerySingleOrDefault<BeatmapOnlineStatus>("SELECT `approved` FROM osu_beatmaps WHERE `beatmap_id` = @beatmap_id",
+                new { beatmap_id = beatmapId },
+                transaction);
+
+            // see https://osu.ppy.sh/wiki/en/Gameplay/Score/Ranked_score
+            return status == BeatmapOnlineStatus.Ranked
+                   || status == BeatmapOnlineStatus.Approved
+                   || status == BeatmapOnlineStatus.Loved;
+        }
+
+        private static SoloScoreInfo? getBestScore(SoloScoreInfo score, MySqlConnection conn, MySqlTransaction transaction, int offset = 0)
+        {
+            var rankSource = conn.QueryFirstOrDefault<SoloScore?>(
+                "SELECT * FROM solo_scores WHERE `user_id` = @user_id "
+                + "AND `beatmap_id` = @beatmap_id "
+                + "AND `ruleset_id` = @ruleset_id "
+                // preserve is not flagged on the newly arriving score until it has been completely processed (see logic in `ScoreStatisticsQueueProcessor.cs`)
+                // therefore we need to make an exception here to ensure it's included.
+                + "AND (`preserve` = 1 OR `id` = @new_score_id) "
+                + "ORDER BY `data`->'$.total_score' DESC, `id` DESC "
+                + "LIMIT @offset, 1", new
+                {
+                    user_id = score.UserID,
+                    beatmap_id = score.BeatmapID,
+                    ruleset_id = score.RulesetID,
+                    new_score_id = score.ID,
+                    offset = offset,
+                }, transaction);
+
+            return rankSource?.ScoreInfo;
+        }
+
+        private static SoloScoreInfo? getSecondBestScore(SoloScoreInfo score, MySqlConnection conn, MySqlTransaction transaction)
+            => getBestScore(score, conn, transaction, 1);
+
+        private static void updateRankedScore(SoloScoreInfo soloScoreInfo, UserStats stats, bool revert)
+        {
+            long delta = soloScoreInfo.GetDisplayScore(ScoringMode.Classic) * (revert ? -1 : 1);
+            stats.ranked_score += delta;
         }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
@@ -24,6 +24,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             if (!score.Passed)
                 return;
 
+            if (!DatabaseHelper.IsBeatmapValidForRankedCounts(score.BeatmapID, conn, transaction))
+                return;
+
             if (previousVersion >= 7)
             {
                 // It is assumed that in the case of a revert, either the score is deleted, or a reapplication will immediately follow.
@@ -47,6 +50,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
         {
             if (!score.Passed)
+                return;
+
+            if (!DatabaseHelper.IsBeatmapValidForRankedCounts(score.BeatmapID, conn, transaction))
                 return;
 
             var bestScore = DatabaseHelper.GetUserBestScoreFor(score, conn, transaction);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
@@ -29,8 +29,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         /// version 5: added performance processor
         /// version 6: added play time processor
         /// version 7: added user rank count processor
+        /// version 8: added ranked score processor
         /// </summary>
-        public const int VERSION = 7;
+        public const int VERSION = 8;
 
         public static readonly List<Ruleset> AVAILABLE_RULESETS = getRulesets();
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu-queue-score-statistics/issues/134
- [x] Depends on https://github.com/ppy/osu-queue-score-statistics/pull/157 (for mergeability, mostly - both pulls share prerequisites)
- [x] Depends on https://github.com/ppy/osu-queue-score-statistics/pull/160

Not much to say here really. A lot of this implementation is copy-paste from the rank count processor, with the exception of having to check the beatmap status. [Wiki says](https://osu.ppy.sh/wiki/en/Gameplay/Score/Ranked_score) ranked, loved, and approved count; that information comes from https://github.com/ppy/osu-wiki/pull/8488, which had @peppy reviewing, so seems legit.

The other part I wasn't 100% on here when querying the beatmap status, is whether to go for a local query or reuse `BeatmapStore` instead to leverage caching. Ended up doing a local query in the end as it seemed less overkill, but can switch back to the cache if you decide that's better.