### PR TITLE
Explicitly specify NC/DC as mods valid for PP

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -163,9 +163,23 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                     case ManiaModKey10:
                         return false;
 
+                    case ModNightcore nc:
+                        // Disallow non-default rate adjustments for now.
+                        if (!nc.SpeedChange.IsDefault)
+                            return false;
+
+                        continue;
+
                     case ModDoubleTime dt:
                         // Disallow non-default rate adjustments for now.
                         if (!dt.SpeedChange.IsDefault)
+                            return false;
+
+                        continue;
+
+                    case ModDaycore dc:
+                        // Disallow non-default rate adjustments for now.
+                        if (!dc.SpeedChange.IsDefault)
                             return false;
 
                         continue;


### PR DESCRIPTION
As of https://github.com/ppy/osu/pull/24640, NC no longer inherits DT and DC no longer inherits HT.

This can be merged as is without an update to nuget packages.