### PR TITLE
Add support for incrementing global and beatmap playcounts

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -67,6 +67,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 db.Execute("TRUNCATE TABLE solo_scores");
                 db.Execute("TRUNCATE TABLE solo_scores_process_history");
                 db.Execute("TRUNCATE TABLE solo_scores_performance");
+
+                db.Execute("REPLACE INTO osu_counts (name, count) VALUES ('playcount', 0)");
             }
 
             Task.Run(() => Processor.Run(CancellationToken), CancellationToken);

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PlayCountProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PlayCountProcessorTests.cs
@@ -22,9 +22,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         }
 
         [Fact]
-        public void TestGlobalPlaycountIncrement()
+        public void TestGlobalPlaycountsIncrement()
         {
-            const int attempt_count = 5000;
+            const int attempt_count = 100;
 
             AddBeatmap();
 
@@ -35,11 +35,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                     int offset = i - attempt_count;
                     SetScoreForBeatmap(TEST_BEATMAP_ID, s => s.Score.created_at = DateTimeOffset.Now.AddMinutes(offset));
                 }
-
-                PushToQueueAndWaitForProcess(CreateTestScore());
             });
 
             WaitForDatabaseState("SELECT IF(count > 0, 1, 0) FROM osu_counts WHERE name = 'playcount'", 1, CancellationToken);
+            WaitForDatabaseState($"SELECT IF(playcount > 0, 1, 0) FROM osu_beatmaps WHERE beatmap_id = {TEST_BEATMAP_ID}", 1, CancellationToken);
+            WaitForDatabaseState($"SELECT IF(play_count > 0, 1, 0) FROM osu_beatmapsets WHERE beatmapset_id = {TEST_BEATMAP_SET_ID}", 1, CancellationToken);
         }
 
         [Fact]

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using Dapper;
 using JetBrains.Annotations;
 using MySqlConnector;
+using osu.Framework.Development;
 using osu.Framework.Utils;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
@@ -65,7 +66,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         {
             // We want to reduce database overhead here, so we only update the global playcount every n plays.
             // Note that we use a non-round number to make the display more natural.
-            const int increment = 99;
+            int increment = DebugUtils.IsNUnitRunning ? 5 : 99;
 
             if (RNG.Next(0, increment) == 0)
             {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
@@ -6,7 +6,9 @@ using System.Diagnostics;
 using Dapper;
 using JetBrains.Annotations;
 using MySqlConnector;
+using osu.Framework.Utils;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
@@ -49,11 +51,55 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
                 adjustUserMonthlyPlaycount(score, conn, transaction);
                 adjustUserBeatmapPlaycount(score, conn, transaction);
+
+                adjustGlobalPlaycount(conn, transaction);
+                adjustGlobalBeatmapPlaycount(score, conn, transaction);
             }
         }
 
         public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
         {
+        }
+
+        private static void adjustGlobalPlaycount(MySqlConnection conn, MySqlTransaction transaction)
+        {
+            // We want to reduce database overhead here, so we only update the global playcount every n plays.
+            // Note that we use a non-round number to make the display more natural.
+            const int increment = 99;
+
+            if (RNG.Next(0, increment) == 0)
+            {
+                conn.Execute("UPDATE osu_counts SET count = count + @increment WHERE name = 'playcount'", new
+                {
+                    increment
+                }, transaction);
+            }
+        }
+
+        private static void adjustGlobalBeatmapPlaycount(SoloScoreInfo score, MySqlConnection conn, MySqlTransaction transaction)
+        {
+            // We want to reduce database overhead here, so we only update the global beatmap playcount every n plays.
+            // Note that we use a non-round number to make the display more natural.
+            int increment = score.Beatmap!.PlayCount < 1000 ? 1 : 9;
+
+            if (RNG.Next(0, increment) == 0)
+            {
+                conn.Execute("UPDATE osu_beatmaps SET playcount = playcount + @increment WHERE beatmap_id = @beatmapId; UPDATE osu_beatmapsets SET play_count = play_count + @increment WHERE beatmapset_id = @beatmapSetId", new
+                {
+                    increment,
+                    beatmapId = score.BeatmapID,
+                    beatmapSetId = score.Beatmap.OnlineBeatmapSetID
+                }, transaction);
+
+                // Reindex beatmap occasionally.
+                if (RNG.Next(0, 10) == 0)
+                    LegacyDatabaseHelper.RunLegacyIO("indexing/bulk", "POST", $"beatmapset[]={score.Beatmap.OnlineBeatmapSetID}");
+
+                // TODO: announce playcount milestones
+                // const int notify_amount = 1000000;
+                // if (score.Beatmap.PlayCount > 0 && Math.Abs((incrementedPlaycount % notify_amount) - (score.Beatmap.PlayCount % notify_amount)) > increment)
+                //     throw new NotImplementedException("addEvent");
+            }
         }
 
         private static void adjustUserBeatmapPlaycount(SoloScoreInfo score, MySqlConnection conn, MySqlTransaction transaction, bool revert = false)


### PR DESCRIPTION
Covers `osu_counts` playcount, as well as beatmap and beatmap set level playcounts. All implemented using the same logic that as web-10.

- [x] Depends on https://github.com/ppy/osu-queue-score-statistics/pull/164

personal reminder: consider backfilling these fields from solo_scores when deploying.