### PR TITLE
Ensure `pp` is populated before attempting to import a legacy score

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -167,11 +167,15 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                         checkSlaveLatency(dbMainQuery);
 
                     var highScores = await dbMainQuery.QueryAsync<HighScore>($"SELECT * FROM {highScoreTable} " +
-                                                                             $"LEFT JOIN score_process_queue USING (score_id) " +
+                                                                             "LEFT JOIN score_process_queue USING (score_id) " +
                                                                              // Either the score is so old the process queue entry is deleted, or it has finished pp processing.
                                                                              // Without this we could insert scores before pp processing is completed.
-                                                                             $"WHERE score_id >= @lastId AND (status IS NULL OR status > 0) " +
-                                                                             $"ORDER BY score_id LIMIT {scoresPerQuery}", new { lastId });
+                                                                             "WHERE score_id >= @lastId AND (status IS NULL OR status > 0) " +
+                                                                             "ORDER BY score_id LIMIT @scoresPerQuery", new
+                    {
+                        lastId,
+                        scoresPerQuery
+                    });
 
                     if (!highScores.Any())
                     {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -166,8 +166,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                     if (CheckSlaveLatency)
                         checkSlaveLatency(dbMainQuery);
 
-                    var highScores = await dbMainQuery.QueryAsync<HighScore>($"SELECT * FROM {highScoreTable} WHERE score_id >= @lastId ORDER BY score_id LIMIT {scoresPerQuery}",
-                        new { lastId });
+                    var highScores = await dbMainQuery.QueryAsync<HighScore>($"SELECT * FROM {highScoreTable} " +
+                                                                             $"LEFT JOIN score_process_queue USING (score_id) " +
+                                                                             // Either the score is so old the process queue entry is deleted, or it has finished pp processing.
+                                                                             // Without this we could insert scores before pp processing is completed.
+                                                                             $"WHERE score_id >= @lastId AND (status IS NULL OR status > 0) " +
+                                                                             $"ORDER BY score_id LIMIT {scoresPerQuery}", new { lastId });
 
                     if (!highScores.Any())
                     {


### PR DESCRIPTION
Should address https://github.com/ppy/osu/discussions/25397 (going forward, not existing scores; they will need to be manually fixed or we should just wait until re-importing everything).

Of note, this only works if we assume there is one single instance of `osu-performance` running (so processing is in a consistent incrementing fashion), else we may skip ahead with the `lastId = Max()` logic. But we haven't run multiple `osu-performance` instances in years so it's probably okay?

If we want to support the above case better, the checks would need to be moved out of the SQL query and into actual logic, incrementing `lastId` only to the last processed row, and reprocessing that batch until all are satisfied. Personally don't think it's worth it.

Note that I haven't tested this yet, but it's roughly based off existing logic in `osu-performance` (https://github.com/ppy/osu-performance/blob/3d403354321c5e0cd0cd9c9cf587d5b88a0ba78f/src/performance/Processor.cpp#L706-L710).