### PR TITLE
Always query maximum amount when not checking slave latency

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -131,6 +131,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
         public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
         {
+            if (!CheckSlaveLatency)
+                scoresPerQuery = maximum_scores_per_query;
+
             Ruleset ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(RulesetId);
             string highScoreTable = LegacyDatabaseHelper.GetRulesetSpecifics(RulesetId).HighScoreTable;
 


### PR DESCRIPTION
When running the diffcalc sheet generator (e.g. https://github.com/ppy/osu/actions/runs/7019346258/job/19096638966), I noticed that it would get stuck querying only 1000 scores / sec, which is the default amount when not checking slave latency.