### PR TITLE
Reduce maximum number of scores per query

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -100,7 +100,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
         /// The number of scores done in a single processing query. These scores are read in one go, then distributed to parallel insertion workers.
         /// May be adjusted at runtime based on the replication state.
         /// </summary>
-        private const int maximum_scores_per_query = 50000;
+        private const int maximum_scores_per_query = 40000;
 
         /// <summary>
         /// In cases of slave replication latency, this will be the minimum scores processed per top-level query.


### PR DESCRIPTION
Since https://github.com/ppy/osu-queue-score-statistics/pull/173, the importer uses the maximum number of scores per query if slave latency isn't checked. This just about reaches the default [maximum connection pool size](https://dev.mysql.com/doc/connector-net/en/connector-net-8-0-connection-options.html) (Ctrl+F 'MaximumPoolsize') and crashes: https://github.com/ppy/osu/actions/runs/7030178231/job/19129260473

By reducing this value to 40000, we have about 20 extra connections to play around with, without having to change the connection string.