### PR TITLE
Remove any chance of incorrect score handling due to missing entries in `score_process_queue`

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -170,7 +170,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                 using (var db = DatabaseAccess.GetConnection())
                     maxProcessableId = db.QuerySingle<ulong?>("SELECT MIN(score_id) FROM score_process_queue") - 1 ?? ulong.MaxValue;
 
-                where = "WHERE score_id >= @lastId AND score_id <= @";
+                where = "WHERE score_id >= @lastId AND score_id <= @maxProcessableId";
             }
             else
             {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -49,6 +49,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
         /// <summary>
         /// The high score ID to start the import process from. This can be used to perform batch reimporting for special cases.
+        /// When a value is specified, execution will end after all available items are processed.
         /// </summary>
         [Option(CommandOptionType.SingleValue, Template = "--start-id")]
         public ulong? StartId { get; set; }
@@ -77,12 +78,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
         /// </summary>
         [Option(CommandOptionType.SingleOrNoValue, Template = "--skip-indexing")]
         public bool SkipIndexing { get; set; }
-
-        /// <summary>
-        /// Whether to exit when there are no scores left at the tail end of the import. Defaults to <c>false</c>.
-        /// </summary>
-        [Option(CommandOptionType.SingleOrNoValue, Template = "--exit-on-completion")]
-        public bool ExitOnCompletion { get; set; }
 
         private long lastCommitTimestamp;
         private long lastLatencyCheckTimestamp;
@@ -141,8 +136,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
             ulong lastId;
 
-            if (StartId.HasValue)
-                lastId = StartId.Value;
+            bool singleRun = StartId.HasValue;
+
+            if (singleRun)
+                lastId = StartId!.Value;
             else
             {
                 using (var db = DatabaseAccess.GetConnection())
@@ -153,7 +150,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
             Console.WriteLine();
             Console.WriteLine($"Sourcing from {highScoreTable} for {ruleset.ShortName} starting from {lastId}");
-            Console.WriteLine($"Inserting into solo_scores and processing {(ExitOnCompletion ? "as single run" : "indefinitely")}");
+            Console.WriteLine($"Inserting into solo_scores and processing {(singleRun ? "as single run" : "indefinitely")}");
 
             if (!SkipIndexing)
             {
@@ -183,7 +180,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
                     if (!highScores.Any())
                     {
-                        if (ExitOnCompletion)
+                        if (singleRun)
                         {
                             Console.WriteLine("No scores found, all done!");
                             break;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -189,7 +189,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                         checkSlaveLatency(dbMainQuery);
 
                     var highScores = await dbMainQuery.QueryAsync<HighScore>($"SELECT * FROM {highScoreTable} {where}" +
-                                                                             "ORDER BY score_id LIMIT @scoresPerQuery", new
+                                                                             " ORDER BY score_id LIMIT @scoresPerQuery", new
                     {
                         lastId,
                         maxProcessableId,


### PR DESCRIPTION
While working through the import process today to ensure we have everything covered, I realised that the previous fix I made for  ensuring scores are processed was insufficient due to the `null` allowance. Because score submission in web-10 is not done within a transaction, there's a window of time where rows are in `osu_scores_high` but not in `score_process_queue`.

To resolve this, we need to assume two modes of operation:

- Batch processing, when `StartId` is non-null, which will now process from the specified ID up to the last entry in `osu_scores_high` which doesn't have a `score_process_queue` entry (generally two days before current time, due to partition cycling).
- Live mode, when `StartId` is null, which will now process only entries with a `score_process_queue` entry.

I haven't tested this yet, PRing for feedback in the mean time.