### PR TITLE
Disallow classic mod from giving PP (for now)

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -32,6 +32,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
         protected const int TEST_BEATMAP_ID = 1;
         protected const int TEST_BEATMAP_SET_ID = 1;
+        protected int TestBuildID;
 
         private readonly CancellationTokenSource cancellationSource;
 
@@ -66,8 +67,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 db.Execute("TRUNCATE TABLE solo_scores");
                 db.Execute("TRUNCATE TABLE solo_scores_process_history");
                 db.Execute("TRUNCATE TABLE solo_scores_performance");
+                db.Execute("TRUNCATE TABLE osu_builds");
 
                 db.Execute("REPLACE INTO osu_counts (name, count) VALUES ('playcount', 0)");
+
+                TestBuildID = db.QuerySingle<int>("INSERT INTO osu_builds (version, allow_performance) VALUES ('1.0.0', 1); SELECT LAST_INSERT_ID();");
             }
 
             Task.Run(() => Processor.Run(CancellationToken), CancellationToken);

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
@@ -38,6 +38,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 score.Score.ScoreInfo.Statistics[HitResult.Great] = 100;
                 score.Score.ScoreInfo.MaxCombo = 100;
                 score.Score.ScoreInfo.Accuracy = 1;
+                score.Score.ScoreInfo.BuildID = TestBuildID;
                 score.Score.preserve = true;
             });
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
@@ -170,19 +170,15 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             {
                 // Osu
                 new OsuModMuted(),
-                new OsuModClassic(),
                 new OsuModDaycore(),
                 // Taiko
                 new TaikoModMuted(),
-                new TaikoModClassic(),
                 new TaikoModDaycore(),
                 // Catch
                 new CatchModMuted(),
-                new CatchModClassic(),
                 new CatchModDaycore(),
                 // Mania
                 new ManiaModMuted(),
-                new ManiaModClassic(),
                 new ManiaModDaycore(),
             };
 
@@ -193,13 +189,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         [Fact]
         public void ClassicAllowedOnLegacyScores()
         {
-            Assert.True(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScoreInfo(), new Mod[] { new OsuModClassic() }));
+            Assert.True(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScoreInfo { LegacyScoreId = 1 }, new Mod[] { new OsuModClassic() }));
         }
 
         [Fact]
         public void ClassicDisallowedOnNonLegacyScores()
         {
-            Assert.False(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScoreInfo { BuildID = 1 }, new Mod[] { new OsuModClassic() }));
+            Assert.False(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScoreInfo(), new Mod[] { new OsuModClassic() }));
         }
 
         [Fact]

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
@@ -3,6 +3,7 @@
 
 using Dapper;
 using osu.Framework.Extensions.TypeExtensions;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets.Catch.Mods;
 using osu.Game.Rulesets.Mania.Mods;
 using osu.Game.Rulesets.Mods;
@@ -98,7 +99,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             };
 
             foreach (var mod in mods)
-                Assert.True(ScorePerformanceProcessor.AllModsValidForPerformance(new[] { mod }), mod.GetType().ReadableName());
+                Assert.True(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScoreInfo(), new[] { mod }), mod.GetType().ReadableName());
         }
 
         [Fact]
@@ -130,7 +131,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             };
 
             foreach (var mod in mods)
-                Assert.False(ScorePerformanceProcessor.AllModsValidForPerformance(new[] { mod }), mod.GetType().ReadableName());
+                Assert.False(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScoreInfo(), new[] { mod }), mod.GetType().ReadableName());
         }
 
         [Fact]
@@ -158,7 +159,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             };
 
             foreach (var mod in mods)
-                Assert.False(ScorePerformanceProcessor.AllModsValidForPerformance(new[] { mod }), mod.GetType().ReadableName());
+                Assert.False(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScoreInfo(), new[] { mod }), mod.GetType().ReadableName());
         }
 
         [Fact]
@@ -186,7 +187,19 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             };
 
             foreach (var mod in mods)
-                Assert.True(ScorePerformanceProcessor.AllModsValidForPerformance(new[] { mod }), mod.GetType().ReadableName());
+                Assert.True(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScoreInfo(), new[] { mod }), mod.GetType().ReadableName());
+        }
+
+        [Fact]
+        public void ClassicAllowedOnLegacyScores()
+        {
+            Assert.True(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScoreInfo(), new Mod[] { new OsuModClassic() }));
+        }
+
+        [Fact]
+        public void ClassicDisallowedOnNonLegacyScores()
+        {
+            Assert.False(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScoreInfo { BuildID = 1 }, new Mod[] { new OsuModClassic() }));
         }
 
         [Fact]

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/DeleteImportedHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/DeleteImportedHighScoresCommand.cs
@@ -75,7 +75,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
                         foreach (var score in highScores)
                         {
-                            if (score.ScoreInfo.LegacyScoreId == null)
+                            if (!score.ScoreInfo.IsLegacyScore)
                                 continue;
 
                             Console.WriteLine($"Deleting {score.id}...");

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -192,7 +192,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                         continue;
 
                     case ModClassic:
-                        // Classic mod is only allowed if it's attached to legacy scores (null build ID).
+                        // Classic mod is only allowed if it's attached to legacy scores.
                         return score.IsLegacyScore;
 
                     // The mods which are allowed.

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -121,7 +121,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 Ruleset ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(score.RulesetID);
                 Mod[] mods = score.Mods.Select(m => m.ToMod(ruleset)).ToArray();
 
-                if (!AllModsValidForPerformance(mods))
+                if (!AllModsValidForPerformance(score, mods))
                     return;
 
                 APIBeatmap apiBeatmap = beatmap.ToAPIBeatmap();
@@ -149,7 +149,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         /// <summary>
         /// Checks whether all mods in a given array are valid to give PP for.
         /// </summary>
-        public static bool AllModsValidForPerformance(Mod[] mods)
+        public static bool AllModsValidForPerformance(SoloScoreInfo score, Mod[] mods)
         {
             foreach (var m in mods)
             {
@@ -191,6 +191,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
                         continue;
 
+                    case ModClassic:
+                        // Classic mod is only allowed if it's attached to legacy scores (null build ID).
+                        return score.BuildID == null;
+
                     // The mods which are allowed.
                     case ModEasy:
                     case ModNoFail:
@@ -200,7 +204,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                     case ModHidden:
                     case ModFlashlight:
                     case ModMuted:
-                    case ModClassic:
                     // osu!-specific:
                     case OsuModSpunOut:
                     case OsuModTouchDevice:

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -193,7 +193,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
                     case ModClassic:
                         // Classic mod is only allowed if it's attached to legacy scores (null build ID).
-                        return score.BuildID == null;
+                        return score.IsLegacyScore;
 
                     // The mods which are allowed.
                     case ModEasy:

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
@@ -120,9 +121,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 if (s.ScoreInfo.IsLegacyScore)
                     return false;
 
-                // This should never be the case, but just in-case let's disallow PP for non-legacy scores with no build.
-                if (s.ScoreInfo.BuildID == null)
-                    return true;
+                Debug.Assert(s.ScoreInfo.BuildID != null);
 
                 // Performance needs to be allowed for the build.
                 return buildStore.GetBuild(s.ScoreInfo.BuildID.Value)?.allow_performance != true;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -116,9 +116,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 if (!beatmapStore.IsBeatmapValidForPerformance(beatmap, s.ruleset_id))
                     return true;
 
-                // Scores with no build were imported from the legacy high scores tables and are always valid.
-                if (s.ScoreInfo.BuildID == null)
+                // Legacy scores are always valid.
+                if (s.ScoreInfo.IsLegacyScore)
                     return false;
+
+                // This should never be the case, but just in-case let's disallow PP for non-legacy scores with no build.
+                if (s.ScoreInfo.BuildID == null)
+                    return true;
 
                 // Performance needs to be allowed for the build.
                 return buildStore.GetBuild(s.ScoreInfo.BuildID.Value)?.allow_performance != true;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
@@ -98,7 +98,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
 
         protected override void ProcessResult(ScoreItem item)
         {
-            if (item.Score.ScoreInfo.LegacyScoreId != null)
+            if (item.Score.ScoreInfo.IsLegacyScore)
             {
                 item.Tags = new[] { "type:legacy" };
                 return;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
@@ -12,11 +12,11 @@
         <PackageReference Include="Dapper" Version="2.1.24" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2023.1127.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.1127.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.1127.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.1127.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.1127.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2023.1213.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.1213.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.1213.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.1213.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.1213.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2023.1207.0" />
     </ItemGroup>
 


### PR DESCRIPTION
Since we're not sure yet on the implementation of the mechanics of this mod (e.g. https://github.com/ppy/osu/issues/11769), it's easiest to just not allow it to be ranked for now. Scores coming from stable are still allowed to give PP.