### PR TITLE
Allow limited processing of imported high scores

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
@@ -218,5 +218,26 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 ScoreId = score.Score.id
             });
         }
+
+        [Fact]
+        public void LegacyScoreDoesProcess()
+        {
+            AddBeatmap();
+            AddBeatmapAttributes<OsuDifficultyAttributes>();
+
+            ScoreItem score = SetScoreForBeatmap(TEST_BEATMAP_ID, score =>
+            {
+                score.Score.ScoreInfo.Statistics[HitResult.Great] = 100;
+                score.Score.ScoreInfo.MaxCombo = 100;
+                score.Score.ScoreInfo.Accuracy = 1;
+                score.Score.ScoreInfo.LegacyScoreId = 1;
+                score.Score.preserve = true;
+            });
+
+            WaitForDatabaseState("SELECT COUNT(*) FROM solo_scores_performance WHERE score_id = @ScoreId", 1, CancellationToken, new
+            {
+                ScoreId = score.Score.id
+            });
+        }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/TotalScoreProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/TotalScoreProcessorTests.cs
@@ -60,7 +60,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             Processor.PushToQueue(score);
             WaitForTotalProcessed(1, CancellationToken);
 
-            WaitForDatabaseState("SELECT total_score FROM osu_user_stats WHERE user_id = 2", (int?)null, CancellationToken);
+            // partial processing is actually expected to happen here (for pp), but the user's total should still be zero.
+            WaitForDatabaseState("SELECT total_score FROM osu_user_stats WHERE user_id = 2", 0, CancellationToken);
         }
 
         [Fact]

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -151,7 +151,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                 using var db = DatabaseAccess.GetConnection();
 
                 ulong? lastImportedLegacyScore = db.QuerySingleOrDefault<ulong?>($"SELECT MAX(old_score_id) FROM score_legacy_id_map WHERE ruleset_id = {RulesetId}") ?? 0;
-                ulong? lowestProcessQueueEntry = db.QuerySingleOrDefault<ulong?>($"SELECT MIN(score_id) FROM score_process_queue WHERE is_deletion = 0 AND mode = {ruleset.RulesetInfo.OnlineID}") - 1 ?? ulong.MaxValue;
+                ulong? lowestProcessQueueEntry = db.QuerySingleOrDefault<ulong?>($"SELECT MIN(score_id) FROM score_process_queue WHERE is_deletion = 0 AND mode = {ruleset.RulesetInfo.OnlineID}") - 1;
 
                 if (lowestProcessQueueEntry == null)
                 {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -324,6 +324,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
                     if (scoreStatisticsQueueProcessor != null)
                     {
+                        Debug.Assert(!runningBatches.SelectMany(b => b.ElasticScoreItems).Any());
+
                         var scoreStatisticsItems = runningBatches.SelectMany(b => b.ScoreStatisticsItems).ToList();
 
                         if (scoreStatisticsItems.Any())
@@ -332,9 +334,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                             Console.WriteLine($"Queued {scoreStatisticsItems.Count} item(s) for statistics processing");
                         }
                     }
-
-                    if (elasticQueueProcessor != null)
+                    else if (elasticQueueProcessor != null)
                     {
+                        Debug.Assert(!runningBatches.SelectMany(b => b.ScoreStatisticsItems).Any());
+
                         var elasticItems = runningBatches.SelectMany(b => b.ElasticScoreItems).ToList();
 
                         if (elasticItems.Any())

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -355,7 +355,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                         if (batch.Count == 0)
                             return;
 
-                        runningBatches.Add(new BatchInserter(ruleset, batch.ToArray(), importLegacyPP: watchMode, SkipExisting, SkipNew));
+                        runningBatches.Add(new BatchInserter(ruleset, batch.ToArray(), importLegacyPP: !watchMode, SkipExisting, SkipNew));
                         batch.Clear();
                     }
                 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -141,6 +141,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
             bool watchMode = !StartId.HasValue;
             ulong maxProcessableId;
 
+            // When running in watch mode, we need to ascertain a few things:
+            // - There is active ongoing processing in `score_process_queue` – if not, there will be nothing to watch and we will switch to full run mode.
+            // - Check whether the full run (non-watch) has caught up to recent scores (ie. processed up to a `score_id` contained in `score_process_queue`,
+            //   which generally keeps ~3 days of scores). If not, we should warn that there is a gap in processing, and an extra full run should be performed
+            //   to catch up.
             if (watchMode)
             {
                 using var db = DatabaseAccess.GetConnection();

--- a/osu.Server.Queues.ScoreStatisticsProcessor/IProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/IProcessor.cs
@@ -23,6 +23,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         /// </summary>
         bool RunOnFailedScores { get; }
 
+        /// <summary>
+        /// Whether this processor should be run on imported legacy scores.
+        /// </summary>
+        bool RunOnLegacyScores { get; }
+
         void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction);
 
         void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/HitStatisticsProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/HitStatisticsProcessor.cs
@@ -17,6 +17,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
     {
         public bool RunOnFailedScores => true;
 
+        public bool RunOnLegacyScores => false;
+
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
             if (previousVersion >= 2)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MaxComboProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MaxComboProcessor.cs
@@ -21,6 +21,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
     {
         public bool RunOnFailedScores => false;
 
+        public bool RunOnLegacyScores => false;
+
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
             // TODO: this will require access to stable scores to be implemented correctly.

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
@@ -41,6 +41,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnFailedScores => true; // This is handled by each awarder.
 
+        public bool RunOnLegacyScores => false;
+
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
         }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
@@ -22,6 +22,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
     {
         public bool RunOnFailedScores => true;
 
+        public bool RunOnLegacyScores => false;
+
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
             if (previousVersion >= 1)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
@@ -20,6 +20,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
     {
         public bool RunOnFailedScores => true;
 
+        public bool RunOnLegacyScores => false;
+
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
             if (previousVersion >= 6)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/RankedScoreProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/RankedScoreProcessor.cs
@@ -17,6 +17,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
     {
         public bool RunOnFailedScores => false;
 
+        public bool RunOnLegacyScores => false;
+
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
             if (!score.Passed)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -32,6 +32,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnFailedScores => false;
 
+        public bool RunOnLegacyScores => true;
+
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
         }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/TotalScoreProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/TotalScoreProcessor.cs
@@ -19,6 +19,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
     {
         public bool RunOnFailedScores => true;
 
+        public bool RunOnLegacyScores => false;
+
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
             if (previousVersion < 2)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
@@ -19,6 +19,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
     {
         public bool RunOnFailedScores => false;
 
+        public bool RunOnLegacyScores => false;
+
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
             if (!score.Passed)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -31,6 +31,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnFailedScores => false;
 
+        public bool RunOnLegacyScores => true;
+
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
         }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
@@ -98,15 +98,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
 
         protected override void ProcessResult(ScoreItem item)
         {
+            var tags = new List<string>();
+
             if (item.Score.ScoreInfo.IsLegacyScore)
-            {
-                item.Tags = new[] { "type:legacy" };
-                return;
-            }
+                tags.Add("type:legacy");
 
             if (item.ProcessHistory?.processed_version == VERSION)
             {
-                item.Tags = new[] { "type:skipped" };
+                item.Tags = tags.Append("type:skipped").ToArray();
                 return;
             }
 
@@ -130,14 +129,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
                         {
                             // ruleset could be invalid
                             // TODO: add check in client and server to not submit unsupported rulesets
-                            item.Tags = new[] { "type:no-stats" };
+                            item.Tags = tags.Append("type:no-stats").ToArray();
                             return;
                         }
 
                         // if required, we can rollback any previous version of processing then reapply with the latest.
                         if (item.ProcessHistory != null)
                         {
-                            item.Tags = new[] { "type:upgraded" };
+                            item.Tags = tags.Append("type:upgraded").ToArray();
                             byte version = item.ProcessHistory.processed_version;
 
                             foreach (var p in enumerateValidProcessors(score))
@@ -145,7 +144,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
                         }
                         else
                         {
-                            item.Tags = new[] { "type:new" };
+                            item.Tags = tags.Append("type:new").ToArray();
                         }
 
                         foreach (var p in enumerateValidProcessors(score))

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
@@ -181,7 +181,18 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
             }
         }
 
-        private IEnumerable<IProcessor> enumerateValidProcessors(SoloScoreInfo score) => score.Passed ? processors : processors.Where(p => p.RunOnFailedScores);
+        private IEnumerable<IProcessor> enumerateValidProcessors(SoloScoreInfo score)
+        {
+            IEnumerable<IProcessor> result = processors;
+
+            if (!score.Passed)
+                result = result.Where(p => p.RunOnFailedScores);
+
+            if (score.IsLegacyScore)
+                result = result.Where(p => p.RunOnLegacyScores);
+
+            return result;
+        }
 
         private static void updateHistoryEntry(ScoreItem item, MySqlConnection db, MySqlTransaction transaction)
         {


### PR DESCRIPTION
Aims to resolve https://github.com/ppy/osu-infrastructure/issues/25.

This PR allows a limited subset of PP-related processors to run for legacy scores, and changes the score import job to push imported scores for aforementioned processing when running in watch/indefinite mode.

I am very intentionally opening this as draft to first ensure that I am in the correct wheelhouse when it comes to what the issue above intended to convey. **Therefore, this is extremely untested code. It passes tests, but that means nothing for the import job. I have not attempted to run the import job. It only works in my head. Please give this a quick general review, but please do not merge this until I have tested it.**

I **will** attempt to run it and test it, to the best of my ability, using ad-hoc means, namely manual database inserts - these are the only means I have, given that stable and surrounding infra is a closed-off system - when I receive confirmation that this looks roughly correct when it comes to the general shape and meets the general expectations. I'll also add extended test coverage for the pp processors, ensuring that they do in fact process legacy scores.