### PR TITLE
Add more PP safeguards

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
@@ -123,7 +122,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 if (s.ScoreInfo.IsLegacyScore)
                     return false;
 
-                Debug.Assert(s.ScoreInfo.BuildID != null);
+                // Some older lazer scores don't have build IDs.
+                if (s.ScoreInfo.BuildID == null)
+                    return true;
 
                 // Performance needs to be allowed for the build.
                 return buildStore.GetBuild(s.ScoreInfo.BuildID.Value)?.allow_performance != true;


### PR DESCRIPTION
- We noticed there are already scores in the database that have been set with lazer that don't have a `build_id`. I previously had a condition for this, that was changed to an assert following discussion, that actually cannot be asserted.
- Some scores present in the database may already have PP values from before we had per-mod filtering for PP (e.g. RX scores or such). These should not be considered towards the user total.