### PR TITLE
Only increment playcount & play time if score is considered valid for it

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PlayCountProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PlayCountProcessorTests.cs
@@ -1,18 +1,25 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using osu.Game.Rulesets.Scoring;
 using Xunit;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 {
     public class PlayCountProcessorTests : DatabaseTest
     {
+        private const int beatmap_length = 158;
+
+        public PlayCountProcessorTests()
+        {
+            AddBeatmap(b => b.total_length = beatmap_length);
+        }
+
         [Fact]
         public void TestPlaycountIncreaseMania()
         {
-            AddBeatmap();
-
             WaitForDatabaseState("SELECT playcount FROM osu_user_stats_mania WHERE user_id = 2", (int?)null, CancellationToken);
 
             PushToQueueAndWaitForProcess(CreateTestScore(3));
@@ -26,8 +33,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         public Task TestGlobalPlaycountsIncrement()
         {
             const int attempt_count = 100;
-
-            AddBeatmap();
 
             var cts = new CancellationTokenSource();
 
@@ -55,8 +60,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         [Fact]
         public void TestPlaycountIncrease()
         {
-            AddBeatmap();
-
             WaitForDatabaseState("SELECT playcount FROM osu_user_stats WHERE user_id = 2", (int?)null, CancellationToken);
 
             PushToQueueAndWaitForProcess(CreateTestScore());
@@ -67,10 +70,49 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         }
 
         [Fact]
+        public void TestPlaycountDoesNotIncreaseIfPlayTooShort()
+        {
+            WaitForDatabaseState("SELECT playcount FROM osu_user_stats WHERE user_id = 2", (int?)null, CancellationToken);
+
+            var score = CreateTestScore();
+            score.Score.ScoreInfo.EndedAt = score.Score.ScoreInfo.StartedAt!.Value + TimeSpan.FromSeconds(4);
+
+            PushToQueueAndWaitForProcess(score);
+            WaitForDatabaseState("SELECT playcount FROM osu_user_stats WHERE user_id = 2", 0, CancellationToken);
+        }
+
+        [Fact]
+        public void TestPlaycountDoesNotIncreaseIfScoreTooLow()
+        {
+            WaitForDatabaseState("SELECT playcount FROM osu_user_stats WHERE user_id = 2", (int?)null, CancellationToken);
+
+            var score = CreateTestScore();
+            score.Score.ScoreInfo.TotalScore = 20;
+
+            PushToQueueAndWaitForProcess(score);
+            WaitForDatabaseState("SELECT playcount FROM osu_user_stats WHERE user_id = 2", 0, CancellationToken);
+        }
+
+        [Theory]
+        [InlineData(3, 40)]
+        [InlineData(9, 100)]
+        [InlineData(19, 200)]
+        [InlineData(19, 500)]
+        public void TestPlaycountDoesNotIncreaseIfTooFewObjectsHit(int hitCount, int totalCount)
+        {
+            WaitForDatabaseState("SELECT playcount FROM osu_user_stats WHERE user_id = 2", (int?)null, CancellationToken);
+
+            var score = CreateTestScore();
+            score.Score.ScoreInfo.Statistics = new Dictionary<HitResult, int> { [HitResult.Great] = hitCount };
+            score.Score.ScoreInfo.MaximumStatistics = new Dictionary<HitResult, int> { [HitResult.Great] = totalCount };
+
+            PushToQueueAndWaitForProcess(score);
+            WaitForDatabaseState("SELECT playcount FROM osu_user_stats WHERE user_id = 2", 0, CancellationToken);
+        }
+
+        [Fact]
         public void TestProcessingSameScoreTwiceRaceCondition()
         {
-            AddBeatmap();
-
             IgnoreProcessorExceptions();
 
             WaitForDatabaseState("SELECT playcount FROM osu_user_stats WHERE user_id = 2", (int?)null, CancellationToken);
@@ -94,8 +136,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         [Fact]
         public void TestPlaycountReprocessDoesntIncrease()
         {
-            AddBeatmap();
-
             var score = CreateTestScore();
 
             WaitForDatabaseState("SELECT playcount FROM osu_user_stats WHERE user_id = 2", (int?)null, CancellationToken);
@@ -113,8 +153,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         [Fact]
         public void TestRapidPlaysHasLimitedIncrease()
         {
-            AddBeatmap();
-
             WaitForDatabaseState($"SELECT playcount FROM osu_user_beatmap_playcount WHERE user_id = 2 and beatmap_id = {TEST_BEATMAP_ID}", (int?)null, CancellationToken);
 
             for (int i = 0; i < 30; i++)
@@ -127,8 +165,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         [Fact]
         public void TestUserBeatmapPlaycountIncrease()
         {
-            AddBeatmap();
-
             WaitForDatabaseState($"SELECT playcount FROM osu_user_beatmap_playcount WHERE user_id = 2 and beatmap_id = {TEST_BEATMAP_ID}", (int?)null, CancellationToken);
 
             SetScoreForBeatmap(TEST_BEATMAP_ID);
@@ -141,8 +177,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         [Fact]
         public void TestUserBeatmapPlaycountReprocessDoesntIncrease()
         {
-            AddBeatmap();
-
             var score = CreateTestScore();
 
             WaitForDatabaseState($"SELECT playcount FROM osu_user_beatmap_playcount WHERE user_id = 2 and beatmap_id = {TEST_BEATMAP_ID}", (int?)null, CancellationToken);
@@ -160,8 +194,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         [Fact]
         public void TestMonthlyPlaycountIncrease()
         {
-            AddBeatmap();
-
             WaitForDatabaseState("SELECT playcount FROM osu_user_month_playcount WHERE user_id = 2", (int?)null, CancellationToken);
 
             PushToQueueAndWaitForProcess(CreateTestScore());
@@ -177,8 +209,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         [InlineData(2)]
         public void TestMonthlyPlaycountReprocessOldVersionIncrease(int version)
         {
-            AddBeatmap();
-
             var score = CreateTestScore();
 
             WaitForDatabaseState("SELECT playcount FROM osu_user_month_playcount WHERE user_id = 2", (int?)null, CancellationToken);
@@ -197,8 +227,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         [Fact]
         public void TestMonthlyPlaycountReprocessDoesntIncrease()
         {
-            AddBeatmap();
-
             var score = CreateTestScore();
 
             WaitForDatabaseState("SELECT playcount FROM osu_user_month_playcount WHERE user_id = 2", (int?)null, CancellationToken);

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PlayTimeProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PlayTimeProcessorTests.cs
@@ -2,8 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Game.Online.API;
 using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Scoring;
 using Xunit;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
@@ -87,6 +89,47 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             PushToQueueAndWaitForProcess(testScore);
             WaitForDatabaseState("SELECT total_seconds_played FROM osu_user_stats WHERE user_id = 2", (int)(beatmap_length / custom_rate), CancellationToken);
+        }
+
+        [Fact]
+        public void TestPlayTimeDoesNotIncreaseIfPlayTooShort()
+        {
+            WaitForDatabaseState("SELECT total_seconds_played FROM osu_user_stats WHERE user_id = 2", (int?)null, CancellationToken);
+
+            var score = CreateTestScore();
+            score.Score.ScoreInfo.EndedAt = score.Score.ScoreInfo.StartedAt!.Value + TimeSpan.FromSeconds(4);
+
+            PushToQueueAndWaitForProcess(score);
+            WaitForDatabaseState("SELECT total_seconds_played FROM osu_user_stats WHERE user_id = 2", 0, CancellationToken);
+        }
+
+        [Fact]
+        public void TestPlayTimeDoesNotIncreaseIfScoreTooLow()
+        {
+            WaitForDatabaseState("SELECT total_seconds_played FROM osu_user_stats WHERE user_id = 2", (int?)null, CancellationToken);
+
+            var score = CreateTestScore();
+            score.Score.ScoreInfo.TotalScore = 20;
+
+            PushToQueueAndWaitForProcess(score);
+            WaitForDatabaseState("SELECT total_seconds_played FROM osu_user_stats WHERE user_id = 2", 0, CancellationToken);
+        }
+
+        [Theory]
+        [InlineData(3, 40)]
+        [InlineData(9, 100)]
+        [InlineData(19, 200)]
+        [InlineData(19, 500)]
+        public void TestPlayTimeDoesNotIncreaseIfTooFewObjectsHit(int hitCount, int totalCount)
+        {
+            WaitForDatabaseState("SELECT total_seconds_played FROM osu_user_stats WHERE user_id = 2", (int?)null, CancellationToken);
+
+            var score = CreateTestScore();
+            score.Score.ScoreInfo.Statistics = new Dictionary<HitResult, int> { [HitResult.Great] = hitCount };
+            score.Score.ScoreInfo.MaximumStatistics = new Dictionary<HitResult, int> { [HitResult.Great] = totalCount };
+
+            PushToQueueAndWaitForProcess(score);
+            WaitForDatabaseState("SELECT total_seconds_played FROM osu_user_stats WHERE user_id = 2", 0, CancellationToken);
         }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/PlayValidityHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/PlayValidityHelper.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
+{
+    public class PlayValidityHelper
+    {
+        public static int GetPlayLength(SoloScoreInfo score)
+        {
+            // to ensure sanity, first get the maximum time feasible from the beatmap's length
+            double totalLengthSeconds = score.Beatmap!.Length;
+
+            Ruleset ruleset = ScoreStatisticsQueueProcessor.AVAILABLE_RULESETS.Single(r => r.RulesetInfo.OnlineID == score.RulesetID);
+
+            var rateAdjustMods = score.Mods.Select(m => m.ToMod(ruleset)).OfType<ModRateAdjust>().ToArray();
+
+            foreach (var mod in rateAdjustMods)
+                totalLengthSeconds /= mod.SpeedChange.Value;
+
+            if (score.StartedAt == null)
+                return (int)totalLengthSeconds;
+
+            // TODO: better handle failed plays once we have incoming data.
+
+            TimeSpan realTimePassed = score.EndedAt - score.StartedAt.Value;
+            return (int)Math.Min(totalLengthSeconds, realTimePassed.TotalSeconds);
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/PlayValidityHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/PlayValidityHelper.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
@@ -44,8 +45,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
             foreach (var mod in rateAdjustMods)
                 totalLengthSeconds /= mod.SpeedChange.Value;
 
-            if (score.StartedAt == null)
-                return (int)totalLengthSeconds;
+            Debug.Assert(score.StartedAt != null);
 
             // TODO: better handle failed plays once we have incoming data.
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/PlayValidityHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/PlayValidityHelper.cs
@@ -28,9 +28,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
             int totalObjectsJudged = score.Statistics.Where(kv => kv.Key.IsScorable()).Sum(kv => kv.Value);
             int totalObjects = score.MaximumStatistics.Where(kv => kv.Key.IsScorable()).Sum(kv => kv.Value);
 
-            return lengthInSeconds >= 8
-                   && score.TotalScore >= 5000
-                   && totalObjectsJudged >= Math.Min(0.1f * totalObjects, 20);
+            return score.Passed
+                   || (lengthInSeconds >= 8
+                       && score.TotalScore >= 5000
+                       && totalObjectsJudged >= Math.Min(0.1f * totalObjects, 20));
         }
 
         public static int GetPlayLength(SoloScoreInfo score)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
@@ -26,6 +26,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
+            if (!score.IsValidForPlayTracking(out _) && previousVersion >= 10)
+                return;
+
             if (previousVersion >= 1)
                 userStats.playcount--;
 
@@ -38,6 +41,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
         {
+            if (!score.IsValidForPlayTracking(out _))
+                return;
+
             const int beatmap_count = 12;
             const int over_time = 120;
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
@@ -1,13 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Linq;
 using JetBrains.Annotations;
 using MySqlConnector;
 using osu.Game.Online.API.Requests.Responses;
-using osu.Game.Rulesets;
-using osu.Game.Rulesets.Mods;
+using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
@@ -25,37 +22,16 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
             if (previousVersion >= 6)
-                userStats.total_seconds_played -= getPlayLength(score);
+                userStats.total_seconds_played -= PlayValidityHelper.GetPlayLength(score);
         }
 
         public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
         {
-            userStats.total_seconds_played += getPlayLength(score);
+            userStats.total_seconds_played += PlayValidityHelper.GetPlayLength(score);
         }
 
         public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
         {
-        }
-
-        private static int getPlayLength(SoloScoreInfo score)
-        {
-            // to ensure sanity, first get the maximum time feasible from the beatmap's length
-            double totalLengthSeconds = score.Beatmap!.Length;
-
-            Ruleset ruleset = ScoreStatisticsQueueProcessor.AVAILABLE_RULESETS.Single(r => r.RulesetInfo.OnlineID == score.RulesetID);
-
-            var rateAdjustMods = score.Mods.Select(m => m.ToMod(ruleset)).OfType<ModRateAdjust>().ToArray();
-
-            foreach (var mod in rateAdjustMods)
-                totalLengthSeconds /= mod.SpeedChange.Value;
-
-            if (score.StartedAt == null)
-                return (int)totalLengthSeconds;
-
-            // TODO: better handle failed plays once we have incoming data.
-
-            TimeSpan realTimePassed = score.EndedAt - score.StartedAt.Value;
-            return (int)Math.Min(totalLengthSeconds, realTimePassed.TotalSeconds);
         }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
@@ -21,13 +21,19 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
+            if (!score.IsValidForPlayTracking(out int lengthInSeconds) && previousVersion >= 10)
+                return;
+
             if (previousVersion >= 6)
-                userStats.total_seconds_played -= PlayValidityHelper.GetPlayLength(score);
+                userStats.total_seconds_played -= lengthInSeconds;
         }
 
         public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
         {
-            userStats.total_seconds_played += PlayValidityHelper.GetPlayLength(score);
+            if (!score.IsValidForPlayTracking(out int lengthInSeconds))
+                return;
+
+            userStats.total_seconds_played += lengthInSeconds;
         }
 
         public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
@@ -25,19 +25,19 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
             if (previousVersion >= 6)
-                userStats.total_seconds_played -= getPlayLength(score, conn, transaction);
+                userStats.total_seconds_played -= getPlayLength(score);
         }
 
         public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
         {
-            userStats.total_seconds_played += getPlayLength(score, conn, transaction);
+            userStats.total_seconds_played += getPlayLength(score);
         }
 
         public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
         {
         }
 
-        private static int getPlayLength(SoloScoreInfo score, MySqlConnection conn, MySqlTransaction transaction)
+        private static int getPlayLength(SoloScoreInfo score)
         {
             // to ensure sanity, first get the maximum time feasible from the beatmap's length
             double totalLengthSeconds = score.Beatmap!.Length;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
@@ -32,8 +32,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         /// version 7: added user rank count processor
         /// version 8: switched total score processor from standardised score to classic score
         /// version 9: added ranked score processor
+        /// version 10: modified play count and time processors to only track valid scores
         /// </summary>
-        public const int VERSION = 9;
+        public const int VERSION = 10;
 
         public static readonly List<Ruleset> AVAILABLE_RULESETS = getRulesets();
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu-queue-score-statistics/issues/63.

- The length of play condition was taken directly from https://github.com/ppy/osu-queue-score-statistics/issues/63#issuecomment-1202043145.
- The total score condition was adapted from the above but reduced, as it will be operating on standardised score rather than score V1, so 10k would be generally more punishing than in stable.
- There is also a total hit count condition as suggested in https://github.com/ppy/osu-queue-score-statistics/issues/63#issuecomment-1202040431. Potentially removable, I'm up for discussing the validity of it.

  For reference:
  ![1703108891](https://github.com/ppy/osu-queue-score-statistics/assets/20418176/36a58735-b0ed-45d1-a215-765b8e43af0b)
