### PR TITLE
Add new watch mode command

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -125,6 +125,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                 {
                     try
                     {
+                        if (highScore.score_id == 0)
+                        {
+                            // Something really bad probably happened, abort for safety.
+                            throw new InvalidOperationException("Score arrived with no ID");
+                        }
+
                         // At least one row in the old table have invalid dates.
                         // MySQL doesn't like empty dates, so let's ensure we have a valid one.
                         if (highScore.date < DateTimeOffset.UnixEpoch)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -125,6 +125,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                 {
                     try
                     {
+                        bool isDeletion = highScore.user_id == 0 && highScore.score == 0;
+
                         if (highScore.score_id == 0)
                         {
                             // Something really bad probably happened, abort for safety.
@@ -141,7 +143,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
                         string serialisedScore = string.Empty;
 
-                        if (!highScore.is_deletion)
+                        if (!isDeletion)
                         {
                             // At least one row in the old table have invalid dates.
                             // MySQL doesn't like empty dates, so let's ensure we have a valid one.
@@ -177,7 +179,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
                         if (existingMapping != null)
                         {
-                            if (highScore.is_deletion)
+                            if (isDeletion)
                             {
                                 deleteCommand.Transaction = transaction;
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -190,7 +190,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                                 await runCommand(deleteCommand);
                                 await enqueueForFurtherProcessing(existingMapping.score_id, db, transaction, true);
 
-                                // TODO: delete
                                 Interlocked.Increment(ref CurrentReportDeleteCount);
                                 Interlocked.Increment(ref TotalDeleteCount);
                             }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -135,7 +135,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
                         SoloScoreLegacyIDMap? existingMapping = existingIds.FirstOrDefault(e => e.old_score_id == highScore.score_id);
 
-                        if ((existingMapping != null && skipExisting) || (existingMapping == null && skipNew))
+                        if (!isDeletion && ((existingMapping != null && skipExisting) || (existingMapping == null && skipNew)))
                         {
                             Interlocked.Increment(ref TotalSkipCount);
                             continue;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -407,7 +407,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
         private async Task runCommand(MySqlCommand command)
         {
             if (dryRun)
+            {
+                Console.WriteLine($"Running: {command.CommandText}");
+                Console.WriteLine();
+
+                string paramString = string.Join(", ", command.Parameters.Select(p => $"{p.ParameterName}:{p.Value}"));
+                Console.WriteLine($"Params: {paramString}");
                 return;
+            }
 
             await command.ExecuteNonQueryAsync();
         }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -1,0 +1,389 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using MySqlConnector;
+using Newtonsoft.Json;
+using osu.Game.Beatmaps.Legacy;
+using osu.Game.Database;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Scoring.Legacy;
+using osu.Game.Scoring;
+using osu.Game.Scoring.Legacy;
+using osu.Server.QueueProcessor;
+using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
+{
+    /// <summary>
+    /// Handles one batch insertion of <see cref="HighScore"/>s. Can be used to parallelize work.
+    /// </summary>
+    /// <remarks>
+    /// Importantly, on a process-wide basis (with the requirement that only one import is happening at once from the same source),
+    /// scores for the same beatmap should always be inserted using the same <see cref="BatchInserter"/>. This is to ensure that the new
+    /// IDs given to inserted scores are still chronologically correct (we fallback to using IDs for tiebreaker cases where the stored timestamps
+    /// are equal to the max precision of mysql TIMESTAMP).
+    /// </remarks>
+    public class BatchInserter
+    {
+        public static int CurrentReportInsertCount;
+        public static int CurrentReportUpdateCount;
+        public static int TotalInsertCount;
+        public static int TotalUpdateCount;
+
+        public static int TotalSkipCount;
+
+        private readonly Ruleset ruleset;
+        private readonly bool importLegacyPP;
+        private readonly bool skipExisting;
+        private readonly bool skipNew;
+
+        public HighScore[] Scores { get; }
+
+        public Task Task { get; }
+
+        public List<ElasticQueuePusher.ElasticScoreItem> ElasticScoreItems { get; } = new List<ElasticQueuePusher.ElasticScoreItem>();
+
+        public List<ScoreItem> ScoreStatisticsItems { get; } = new List<ScoreItem>();
+
+        public BatchInserter(Ruleset ruleset, HighScore[] scores, bool importLegacyPP, bool skipExisting, bool skipNew)
+        {
+            this.ruleset = ruleset;
+            this.importLegacyPP = importLegacyPP;
+            this.skipExisting = skipExisting;
+            this.skipNew = skipNew;
+
+            Scores = scores;
+            Task = run(scores);
+        }
+
+        private async Task run(HighScore[] scores)
+        {
+            using (var db = DatabaseAccess.GetConnection())
+            using (var transaction = await db.BeginTransactionAsync())
+            using (var insertCommand = db.CreateCommand())
+            using (var updateCommand = db.CreateCommand())
+            {
+                // check for existing and skip
+                SoloScoreLegacyIDMap[] existingIds = (await db.QueryAsync<SoloScoreLegacyIDMap>(
+                    $"SELECT * FROM score_legacy_id_map WHERE `ruleset_id` = {ruleset.RulesetInfo.OnlineID} AND `old_score_id` IN @oldScoreIds",
+                    new
+                    {
+                        oldScoreIds = scores.Select(s => s.score_id)
+                    }, transaction)).ToArray();
+
+                insertCommand.CommandText =
+                    // main score insert
+                    "INSERT INTO scores (user_id, beatmap_id, ruleset_id, data, has_replay, preserve, created_at, unix_updated_at) "
+                    + $"VALUES (@userId, @beatmapId, {ruleset.RulesetInfo.OnlineID}, @data, @has_replay, 1, @date, UNIX_TIMESTAMP(@date));";
+
+                // pp insert
+                if (importLegacyPP)
+                    insertCommand.CommandText += "INSERT INTO score_performance (score_id, pp) VALUES (LAST_INSERT_ID(), @pp);";
+
+                // mapping insert
+                insertCommand.CommandText += $"INSERT INTO score_legacy_id_map (ruleset_id, old_score_id, score_id) VALUES ({ruleset.RulesetInfo.OnlineID}, @oldScoreId, LAST_INSERT_ID());";
+
+                updateCommand.CommandText =
+                    "UPDATE scores SET data = @data WHERE id = @id";
+
+                var userId = insertCommand.Parameters.Add("userId", MySqlDbType.UInt32);
+                var oldScoreId = insertCommand.Parameters.Add("oldScoreId", MySqlDbType.UInt64);
+                var beatmapId = insertCommand.Parameters.Add("beatmapId", MySqlDbType.UInt24);
+                var data = insertCommand.Parameters.Add("data", MySqlDbType.JSON);
+                var date = insertCommand.Parameters.Add("date", MySqlDbType.DateTime);
+                var hasReplay = insertCommand.Parameters.Add("has_replay", MySqlDbType.Bool);
+                var pp = insertCommand.Parameters.Add("pp", MySqlDbType.Float);
+
+                var updateData = updateCommand.Parameters.Add("data", MySqlDbType.JSON);
+                var updateId = updateCommand.Parameters.Add("id", MySqlDbType.UInt64);
+
+                foreach (var highScore in scores)
+                {
+                    try
+                    {
+                        // At least one row in the old table have invalid dates.
+                        // MySQL doesn't like empty dates, so let's ensure we have a valid one.
+                        if (highScore.date < DateTimeOffset.UnixEpoch)
+                        {
+                            Console.WriteLine($"Legacy score {highScore.score_id} has invalid date ({highScore.date}), fixing.");
+                            highScore.date = DateTimeOffset.UnixEpoch;
+                        }
+
+                        SoloScoreLegacyIDMap? existingMapping = existingIds.FirstOrDefault(e => e.old_score_id == highScore.score_id);
+
+                        if ((existingMapping != null && skipExisting) || (existingMapping == null && skipNew))
+                        {
+                            Interlocked.Increment(ref TotalSkipCount);
+                            continue;
+                        }
+
+                        ScoreInfo referenceScore = await createReferenceScore(ruleset, highScore, db, transaction);
+                        string serialisedScore = JsonConvert.SerializeObject(new SoloScoreInfo
+                        {
+                            // id will be written below in the UPDATE call.
+                            UserID = highScore.user_id,
+                            BeatmapID = highScore.beatmap_id,
+                            RulesetID = ruleset.RulesetInfo.OnlineID,
+                            Passed = true,
+                            TotalScore = (int)referenceScore.TotalScore,
+                            Accuracy = referenceScore.Accuracy,
+                            MaxCombo = highScore.maxcombo,
+                            Rank = Enum.TryParse(highScore.rank, out ScoreRank parsed) ? parsed : ScoreRank.D,
+                            Mods = referenceScore.Mods.Select(m => new APIMod(m)).ToArray(),
+                            Statistics = referenceScore.Statistics,
+                            MaximumStatistics = referenceScore.MaximumStatistics,
+                            EndedAt = highScore.date,
+                            LegacyTotalScore = highScore.score,
+                            LegacyScoreId = highScore.score_id
+                        }, new JsonSerializerSettings
+                        {
+                            DefaultValueHandling = DefaultValueHandling.Ignore
+                        });
+
+                        if (existingMapping != null)
+                        {
+                            // Note that this only updates the `data` field. We could add others in the future as required.
+                            updateCommand.Transaction = transaction;
+
+                            updateId.Value = existingMapping.score_id;
+                            updateData.Value = serialisedScore;
+
+                            if (!updateCommand.IsPrepared)
+                                await updateCommand.PrepareAsync();
+
+                            // This could potentially be batched further (ie. to run more SQL statements in a single NonQuery call), but in practice
+                            // this does not improve throughput.
+                            await updateCommand.ExecuteNonQueryAsync();
+                            await enqueueForFurtherProcessing(existingMapping.score_id, db, transaction);
+
+                            Interlocked.Increment(ref CurrentReportUpdateCount);
+                            Interlocked.Increment(ref TotalUpdateCount);
+                        }
+                        else
+                        {
+                            pp.Value = highScore.pp;
+                            userId.Value = highScore.user_id;
+                            oldScoreId.Value = highScore.score_id;
+                            beatmapId.Value = highScore.beatmap_id;
+                            date.Value = highScore.date;
+                            hasReplay.Value = highScore.replay;
+                            data.Value = serialisedScore;
+
+                            if (!insertCommand.IsPrepared)
+                                await insertCommand.PrepareAsync();
+                            insertCommand.Transaction = transaction;
+
+                            // This could potentially be batched further (ie. to run more SQL statements in a single NonQuery call), but in practice
+                            // this does not improve throughput.
+                            await insertCommand.ExecuteNonQueryAsync();
+                            await enqueueForFurtherProcessing((ulong)insertCommand.LastInsertedId, db, transaction);
+
+                            Interlocked.Increment(ref CurrentReportInsertCount);
+                            Interlocked.Increment(ref TotalInsertCount);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        throw new AggregateException($"Processing legacy score {highScore.score_id} failed.", e);
+                    }
+                }
+
+                await transaction.CommitAsync();
+            }
+        }
+
+        /// <summary>
+        /// Creates a partially-populated "reference" score that provides:
+        /// <list type="bullet">
+        /// <item><term><see cref="ScoreInfo.Ruleset"/></term></item>
+        /// <item><term><see cref="ScoreInfo.Accuracy"/></term></item>
+        /// <item><term><see cref="ScoreInfo.Mods"/></term></item>
+        /// <item><term><see cref="ScoreInfo.Statistics"/></term></item>
+        /// <item><term><see cref="ScoreInfo.MaximumStatistics"/></term></item>
+        /// </list>
+        /// </summary>
+        private async Task<ScoreInfo> createReferenceScore(Ruleset ruleset, HighScore highScore, MySqlConnection connection, MySqlTransaction transaction)
+        {
+            Mod? classicMod = ruleset.CreateMod<ModClassic>();
+            Debug.Assert(classicMod != null);
+
+            var scoreInfo = new ScoreInfo
+            {
+                Ruleset = ruleset.RulesetInfo,
+                Mods = ruleset.ConvertFromLegacyMods((LegacyMods)highScore.enabled_mods).Append(classicMod).ToArray(),
+                Statistics = new Dictionary<HitResult, int>(),
+                MaximumStatistics = new Dictionary<HitResult, int>(),
+                MaxCombo = highScore.maxcombo,
+                LegacyTotalScore = highScore.score,
+                IsLegacyScore = true
+            };
+
+            var scoreProcessor = ruleset.CreateScoreProcessor();
+
+            // Populate statistics and accuracy.
+            scoreInfo.SetCount50(highScore.count50);
+            scoreInfo.SetCount100(highScore.count100);
+            scoreInfo.SetCount300(highScore.count300);
+            scoreInfo.SetCountMiss(highScore.countmiss);
+            scoreInfo.SetCountGeki(highScore.countgeki);
+            scoreInfo.SetCountKatu(highScore.countkatu);
+            LegacyScoreDecoder.PopulateAccuracy(scoreInfo);
+
+            // Trim zero values from statistics.
+            scoreInfo.Statistics = scoreInfo.Statistics.Where(kvp => kvp.Value != 0).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+            // Populate the maximum statistics.
+            HitResult maxBasicResult = ruleset.GetHitResults().Select(h => h.result).Where(h => h.IsBasic()).MaxBy(scoreProcessor.GetBaseScoreForResult);
+
+            foreach ((HitResult result, int count) in scoreInfo.Statistics)
+            {
+                switch (result)
+                {
+                    case HitResult.LargeTickHit:
+                    case HitResult.LargeTickMiss:
+                        scoreInfo.MaximumStatistics[HitResult.LargeTickHit] = scoreInfo.MaximumStatistics.GetValueOrDefault(HitResult.LargeTickHit) + count;
+                        break;
+
+                    case HitResult.SmallTickHit:
+                    case HitResult.SmallTickMiss:
+                        scoreInfo.MaximumStatistics[HitResult.SmallTickHit] = scoreInfo.MaximumStatistics.GetValueOrDefault(HitResult.SmallTickHit) + count;
+                        break;
+
+                    case HitResult.IgnoreHit:
+                    case HitResult.IgnoreMiss:
+                    case HitResult.SmallBonus:
+                    case HitResult.LargeBonus:
+                        break;
+
+                    default:
+                        scoreInfo.MaximumStatistics[maxBasicResult] = scoreInfo.MaximumStatistics.GetValueOrDefault(maxBasicResult) + count;
+                        break;
+                }
+            }
+
+            // In osu! and osu!mania, some judgements affect combo but aren't stored to scores.
+            // A special hit result is used to pad out the combo value to match, based on the max combo from the beatmap attributes.
+            int maxComboFromStatistics = scoreInfo.MaximumStatistics.Where(kvp => kvp.Key.AffectsCombo()).Select(kvp => kvp.Value).DefaultIfEmpty(0).Sum();
+
+            BeatmapScoringAttributes? scoreAttributes = await connection.QuerySingleOrDefaultAsync<BeatmapScoringAttributes>(
+                "SELECT * FROM osu_beatmap_scoring_attribs WHERE beatmap_id = @BeatmapId AND mode = @RulesetId", new
+                {
+                    BeatmapId = highScore.beatmap_id,
+                    RulesetId = ruleset.RulesetInfo.OnlineID
+                }, transaction);
+
+            if (scoreAttributes == null)
+            {
+                // TODO: LOG
+                await Console.Error.WriteLineAsync($"{highScore.score_id}: Scoring attribs entry missing for beatmap {highScore.beatmap_id}.");
+                return scoreInfo;
+            }
+
+#pragma warning disable CS0618
+            // Pad the maximum combo.
+            // Special case here for osu!mania as it requires per-mod considerations (key mods).
+            if (ruleset.RulesetInfo.OnlineID == 3)
+            {
+                // Using the BeatmapStore class will fail if a particular difficulty attribute value doesn't exist in the database as a result of difficulty calculation not having been run yet.
+                // Additionally, to properly fill out attribute objects, the BeatmapStore class would require a beatmap object resulting in another database query.
+                // To get around both of these issues, we'll directly look up the attribute ourselves.
+
+                // The isConvertedBeatmap parameter only affects whether mania key mods are allowed.
+                // Since we're dealing with high scores, we assume that the database mod values have already been validated for mania-specific beatmaps that don't allow key mods.
+                int difficultyMods = (int)LegacyModsHelper.MaskRelevantMods((LegacyMods)highScore.enabled_mods, true, ruleset.RulesetInfo.OnlineID);
+
+                Dictionary<int, BeatmapDifficultyAttribute> dbAttributes = queryAttributes(
+                    new DifficultyAttributesLookup(highScore.beatmap_id, ruleset.RulesetInfo.OnlineID, difficultyMods), connection, transaction);
+
+                if (!dbAttributes.TryGetValue(9, out BeatmapDifficultyAttribute? maxComboAttribute))
+                {
+                    // TODO: LOG
+                    await Console.Error.WriteLineAsync($"{highScore.score_id}: Could not determine max combo from the difficulty attributes of beatmap {highScore.beatmap_id}.");
+                    return scoreInfo;
+                }
+
+                if ((int)maxComboAttribute.value > maxComboFromStatistics)
+                    scoreInfo.MaximumStatistics[HitResult.LegacyComboIncrease] = (int)maxComboAttribute.value - maxComboFromStatistics;
+            }
+            else
+            {
+                if (scoreAttributes.max_combo > maxComboFromStatistics)
+                    scoreInfo.MaximumStatistics[HitResult.LegacyComboIncrease] = scoreAttributes.max_combo - maxComboFromStatistics;
+            }
+
+#pragma warning restore CS0618
+
+            Beatmap beatmap = await connection.QuerySingleAsync<Beatmap>("SELECT * FROM osu_beatmaps WHERE `beatmap_id` = @BeatmapId", new
+            {
+                BeatmapId = highScore.beatmap_id
+            }, transaction);
+
+            LegacyBeatmapConversionDifficultyInfo difficulty = LegacyBeatmapConversionDifficultyInfo.FromAPIBeatmap(beatmap.ToAPIBeatmap());
+
+            StandardisedScoreMigrationTools.UpdateFromLegacy(scoreInfo, difficulty, scoreAttributes.ToAttributes());
+
+            return scoreInfo;
+        }
+
+        private static readonly ConcurrentDictionary<DifficultyAttributesLookup, Dictionary<int, BeatmapDifficultyAttribute>> attributes_cache =
+            new ConcurrentDictionary<DifficultyAttributesLookup, Dictionary<int, BeatmapDifficultyAttribute>>();
+
+        private static Dictionary<int, BeatmapDifficultyAttribute> queryAttributes(DifficultyAttributesLookup lookup, MySqlConnection connection, MySqlTransaction transaction)
+        {
+            if (attributes_cache.TryGetValue(lookup, out Dictionary<int, BeatmapDifficultyAttribute>? existing))
+                return existing;
+
+            IEnumerable<BeatmapDifficultyAttribute> dbAttributes =
+                connection.Query<BeatmapDifficultyAttribute>(
+                    "SELECT * FROM osu_beatmap_difficulty_attribs WHERE `beatmap_id` = @BeatmapId AND `mode` = @RulesetId AND `mods` = @Mods", lookup, transaction);
+
+            return attributes_cache[lookup] = dbAttributes.ToDictionary(a => (int)a.attrib_id, a => a);
+        }
+
+        private record DifficultyAttributesLookup(int BeatmapId, int RulesetId, int Mods)
+        {
+            public override string ToString()
+            {
+                return $"{{ BeatmapId = {BeatmapId}, RulesetId = {RulesetId}, Mods = {Mods} }}";
+            }
+        }
+
+        private async Task enqueueForFurtherProcessing(ulong scoreId, MySqlConnection connection, MySqlTransaction transaction)
+        {
+            if (importLegacyPP)
+            {
+                // we can proceed by pushing the score directly to ES for indexing.
+                ElasticScoreItems.Add(new ElasticQueuePusher.ElasticScoreItem
+                {
+                    ScoreId = (long)scoreId
+                });
+            }
+            else
+            {
+                // the legacy PP value was not imported.
+                // push the score to redis for PP processing.
+                // on completion of PP processing, the score will be pushed to ES for indexing.
+                // the score refetch here is wasteful, but convenient and reliable, as the actual updated/inserted `SoloScore` row
+                // is not constructed anywhere before this...
+                var score = await connection.QuerySingleAsync<SoloScore>("SELECT * FROM `scores` WHERE `id` = @id",
+                    new { id = scoreId }, transaction);
+                var history = await connection.QuerySingleOrDefaultAsync<ProcessHistory>("SELECT * FROM `score_process_history` WHERE `score_id` = @id",
+                    new { id = scoreId }, transaction);
+                ScoreStatisticsItems.Add(new ScoreItem(score, history));
+            }
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -105,7 +105,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                     "UPDATE scores SET data = @data WHERE id = @id";
 
                 deleteCommand.CommandText =
-                    "DELETE FROM scores WHERE id = @newId; DELETE FROM score_performance WHERE id = @newId; DELETE FROM solo_scores_legacy_id_map WHERE old_score_id = @oldId";
+                    "DELETE FROM scores WHERE id = @newId; DELETE FROM score_performance WHERE score_id = @newId; DELETE FROM solo_scores_legacy_id_map WHERE old_score_id = @oldId";
 
                 var userId = insertCommand.Parameters.Add("userId", MySqlDbType.UInt32);
                 var oldScoreId = insertCommand.Parameters.Add("oldScoreId", MySqlDbType.UInt64);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
+{
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [Serializable]
+    public class HighScore
+    {
+        public ulong score_id { get; set; }
+        public int beatmap_id { get; set; }
+        public int user_id { get; set; }
+        public int score { get; set; }
+        public ushort maxcombo { get; set; }
+        public string rank { get; set; } = null!; // Actually a ScoreRank, but reading as a string for manual parsing.
+        public ushort count50 { get; set; }
+        public ushort count100 { get; set; }
+        public ushort count300 { get; set; }
+        public ushort countmiss { get; set; }
+        public ushort countgeki { get; set; }
+        public ushort countkatu { get; set; }
+        public bool perfect { get; set; }
+        public int enabled_mods { get; set; }
+        public DateTimeOffset date { get; set; }
+        public float pp { get; set; }
+        public bool replay { get; set; }
+        public bool hidden { get; set; }
+        public string country_acronym { get; set; } = null!;
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
@@ -32,6 +32,5 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
         // This comes from score_process_queue. Used in join context.
         public uint queue_id { get; set; }
-        public bool is_deletion { get; set; }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
@@ -29,5 +29,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
         public bool replay { get; set; }
         public bool hidden { get; set; }
         public string country_acronym { get; set; } = null!;
+
+        // This comes from score_process_queue. Used in join context.
+        public uint queue_id { get; set; }
+        public bool is_deletion { get; set; }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
@@ -31,6 +31,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
         public string country_acronym { get; set; } = null!;
 
         // This comes from score_process_queue. Used in join context.
-        public uint queue_id { get; set; }
+        public uint? queue_id { get; set; }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -344,7 +344,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                         if (batch.Count == 0)
                             return;
 
-                        runningBatches.Add(new BatchInserter(ruleset, batch.ToArray(), importLegacyPP: !watchMode || SkipScoreProcessor, SkipExisting, SkipNew));
+                        runningBatches.Add(new BatchInserter(ruleset, batch.ToArray(), importLegacyPP: !watchMode || SkipScoreProcessor, skipExisting: SkipExisting, skipNew: SkipNew));
                         batch.Clear();
                     }
                 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -2,30 +2,17 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Dapper;
 using McMaster.Extensions.CommandLineUtils;
 using MySqlConnector;
-using Newtonsoft.Json;
-using osu.Game.Beatmaps.Legacy;
-using osu.Game.Database;
-using osu.Game.Online.API;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
-using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Scoring;
-using osu.Game.Rulesets.Scoring.Legacy;
-using osu.Game.Scoring;
-using osu.Game.Scoring.Legacy;
 using osu.Server.QueueProcessor;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
-using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 {
@@ -91,13 +78,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
         private ElasticQueuePusher? elasticQueueProcessor;
         private ScoreStatisticsQueueProcessor? scoreStatisticsQueueProcessor;
-
-        private static int currentReportInsertCount;
-        private static int currentReportUpdateCount;
-        private static int totalInsertCount;
-        private static int totalUpdateCount;
-
-        private static int totalSkipCount;
 
         /// <summary>
         /// The number of scores done in a single processing query. These scores are read in one go, then distributed to parallel insertion workers.
@@ -281,15 +261,15 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
                         if ((currentTimestamp - lastCommitTimestamp) / 1000f >= seconds_between_report)
                         {
-                            int inserted = Interlocked.Exchange(ref currentReportInsertCount, 0);
-                            int updated = Interlocked.Exchange(ref currentReportUpdateCount, 0);
+                            int inserted = Interlocked.Exchange(ref BatchInserter.CurrentReportInsertCount, 0);
+                            int updated = Interlocked.Exchange(ref BatchInserter.CurrentReportUpdateCount, 0);
 
                             // Only set startup timestamp after first insert actual insert/update run to avoid weighting during catch-up.
                             if (inserted + updated > 0 && startupTimestamp == 0)
                                 startupTimestamp = lastCommitTimestamp;
 
                             double secondsSinceStart = (double)(currentTimestamp - startupTimestamp) / 1000;
-                            double processingRate = (totalInsertCount + totalUpdateCount) / secondsSinceStart;
+                            double processingRate = (BatchInserter.TotalInsertCount + BatchInserter.TotalUpdateCount) / secondsSinceStart;
 
                             string eta = string.Empty;
 
@@ -304,7 +284,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
                             Console.WriteLine($"Inserting up to {lastId:N0} "
                                               + $"[{runningBatches.Count(t => t.Task.IsCompleted),-2}/{runningBatches.Count}] "
-                                              + $"{totalInsertCount:N0} inserted {totalUpdateCount:N0} updated {totalSkipCount:N0} skipped (+{inserted:N0} new +{updated:N0} upd) {processingRate:N0}/s {eta}");
+                                              + $"{BatchInserter.TotalInsertCount:N0} inserted {BatchInserter.TotalUpdateCount:N0} updated {BatchInserter.TotalSkipCount:N0} skipped (+{inserted:N0} new +{updated:N0} upd) {processingRate:N0}/s {eta}");
 
                             lastCommitTimestamp = currentTimestamp;
                         }
@@ -376,13 +356,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
             if (cancellationToken.IsCancellationRequested)
             {
                 Console.WriteLine($"Cancelled after {(DateTimeOffset.Now - start).TotalSeconds} seconds.");
-                Console.WriteLine($"Final stats: {totalInsertCount} inserted, {totalSkipCount} skipped");
+                Console.WriteLine($"Final stats: {BatchInserter.TotalInsertCount} inserted, {BatchInserter.TotalSkipCount} skipped");
                 Console.WriteLine($"Resume from start id {lastId}");
             }
             else
             {
                 Console.WriteLine($"Finished in {(DateTimeOffset.Now - start).TotalSeconds} seconds.");
-                Console.WriteLine($"Final stats: {totalInsertCount} inserted, {totalSkipCount} skipped");
+                Console.WriteLine($"Final stats: {BatchInserter.TotalInsertCount} inserted, {BatchInserter.TotalSkipCount} skipped");
             }
 
             Console.WriteLine();
@@ -446,384 +426,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                 scoresPerQuery = Math.Min(maximum_scores_per_query, scoresPerQuery + 100);
                 Console.WriteLine($"Increasing processing rate to {scoresPerQuery} due to latency of {latency}");
             }
-        }
-
-        /// <summary>
-        /// Handles one batch insertion of <see cref="HighScore"/>s. Can be used to parallelize work.
-        /// </summary>
-        /// <remarks>
-        /// Importantly, on a process-wide basis (with the requirement that only one import is happening at once from the same source),
-        /// scores for the same beatmap should always be inserted using the same <see cref="BatchInserter"/>. This is to ensure that the new
-        /// IDs given to inserted scores are still chronologically correct (we fallback to using IDs for tiebreaker cases where the stored timestamps
-        /// are equal to the max precision of mysql TIMESTAMP).
-        /// </remarks>
-        private class BatchInserter
-        {
-            private readonly Ruleset ruleset;
-            private readonly bool importLegacyPP;
-            private readonly bool skipExisting;
-            private readonly bool skipNew;
-
-            public HighScore[] Scores { get; }
-
-            public Task Task { get; }
-
-            public List<ElasticQueuePusher.ElasticScoreItem> ElasticScoreItems { get; } = new List<ElasticQueuePusher.ElasticScoreItem>();
-
-            public List<ScoreItem> ScoreStatisticsItems { get; } = new List<ScoreItem>();
-
-            public BatchInserter(Ruleset ruleset, HighScore[] scores, bool importLegacyPP, bool skipExisting, bool skipNew)
-            {
-                this.ruleset = ruleset;
-                this.importLegacyPP = importLegacyPP;
-                this.skipExisting = skipExisting;
-                this.skipNew = skipNew;
-
-                Scores = scores;
-                Task = run(scores);
-            }
-
-            private async Task run(HighScore[] scores)
-            {
-                using (var db = DatabaseAccess.GetConnection())
-                using (var transaction = await db.BeginTransactionAsync())
-                using (var insertCommand = db.CreateCommand())
-                using (var updateCommand = db.CreateCommand())
-                {
-                    // check for existing and skip
-                    SoloScoreLegacyIDMap[] existingIds = (await db.QueryAsync<SoloScoreLegacyIDMap>(
-                        $"SELECT * FROM score_legacy_id_map WHERE `ruleset_id` = {ruleset.RulesetInfo.OnlineID} AND `old_score_id` IN @oldScoreIds",
-                        new
-                        {
-                            oldScoreIds = scores.Select(s => s.score_id)
-                        }, transaction)).ToArray();
-
-                    insertCommand.CommandText =
-                        // main score insert
-                        "INSERT INTO scores (user_id, beatmap_id, ruleset_id, data, has_replay, preserve, created_at, unix_updated_at) "
-                        + $"VALUES (@userId, @beatmapId, {ruleset.RulesetInfo.OnlineID}, @data, @has_replay, 1, @date, UNIX_TIMESTAMP(@date));";
-
-                    // pp insert
-                    if (importLegacyPP)
-                        insertCommand.CommandText += "INSERT INTO score_performance (score_id, pp) VALUES (LAST_INSERT_ID(), @pp);";
-
-                    // mapping insert
-                    insertCommand.CommandText += $"INSERT INTO score_legacy_id_map (ruleset_id, old_score_id, score_id) VALUES ({ruleset.RulesetInfo.OnlineID}, @oldScoreId, LAST_INSERT_ID());";
-
-                    updateCommand.CommandText =
-                        "UPDATE scores SET data = @data WHERE id = @id";
-
-                    var userId = insertCommand.Parameters.Add("userId", MySqlDbType.UInt32);
-                    var oldScoreId = insertCommand.Parameters.Add("oldScoreId", MySqlDbType.UInt64);
-                    var beatmapId = insertCommand.Parameters.Add("beatmapId", MySqlDbType.UInt24);
-                    var data = insertCommand.Parameters.Add("data", MySqlDbType.JSON);
-                    var date = insertCommand.Parameters.Add("date", MySqlDbType.DateTime);
-                    var hasReplay = insertCommand.Parameters.Add("has_replay", MySqlDbType.Bool);
-                    var pp = insertCommand.Parameters.Add("pp", MySqlDbType.Float);
-
-                    var updateData = updateCommand.Parameters.Add("data", MySqlDbType.JSON);
-                    var updateId = updateCommand.Parameters.Add("id", MySqlDbType.UInt64);
-
-                    foreach (var highScore in scores)
-                    {
-                        try
-                        {
-                            // At least one row in the old table have invalid dates.
-                            // MySQL doesn't like empty dates, so let's ensure we have a valid one.
-                            if (highScore.date < DateTimeOffset.UnixEpoch)
-                            {
-                                Console.WriteLine($"Legacy score {highScore.score_id} has invalid date ({highScore.date}), fixing.");
-                                highScore.date = DateTimeOffset.UnixEpoch;
-                            }
-
-                            SoloScoreLegacyIDMap? existingMapping = existingIds.FirstOrDefault(e => e.old_score_id == highScore.score_id);
-
-                            if ((existingMapping != null && skipExisting) || (existingMapping == null && skipNew))
-                            {
-                                Interlocked.Increment(ref totalSkipCount);
-                                continue;
-                            }
-
-                            ScoreInfo referenceScore = await createReferenceScore(ruleset, highScore, db, transaction);
-                            string serialisedScore = JsonConvert.SerializeObject(new SoloScoreInfo
-                            {
-                                // id will be written below in the UPDATE call.
-                                UserID = highScore.user_id,
-                                BeatmapID = highScore.beatmap_id,
-                                RulesetID = ruleset.RulesetInfo.OnlineID,
-                                Passed = true,
-                                TotalScore = (int)referenceScore.TotalScore,
-                                Accuracy = referenceScore.Accuracy,
-                                MaxCombo = highScore.maxcombo,
-                                Rank = Enum.TryParse(highScore.rank, out ScoreRank parsed) ? parsed : ScoreRank.D,
-                                Mods = referenceScore.Mods.Select(m => new APIMod(m)).ToArray(),
-                                Statistics = referenceScore.Statistics,
-                                MaximumStatistics = referenceScore.MaximumStatistics,
-                                EndedAt = highScore.date,
-                                LegacyTotalScore = highScore.score,
-                                LegacyScoreId = highScore.score_id
-                            }, new JsonSerializerSettings
-                            {
-                                DefaultValueHandling = DefaultValueHandling.Ignore
-                            });
-
-                            if (existingMapping != null)
-                            {
-                                // Note that this only updates the `data` field. We could add others in the future as required.
-                                updateCommand.Transaction = transaction;
-
-                                updateId.Value = existingMapping.score_id;
-                                updateData.Value = serialisedScore;
-
-                                if (!updateCommand.IsPrepared)
-                                    await updateCommand.PrepareAsync();
-
-                                // This could potentially be batched further (ie. to run more SQL statements in a single NonQuery call), but in practice
-                                // this does not improve throughput.
-                                await updateCommand.ExecuteNonQueryAsync();
-                                await enqueueForFurtherProcessing(existingMapping.score_id, db, transaction);
-
-                                Interlocked.Increment(ref currentReportUpdateCount);
-                                Interlocked.Increment(ref totalUpdateCount);
-                            }
-                            else
-                            {
-                                pp.Value = highScore.pp;
-                                userId.Value = highScore.user_id;
-                                oldScoreId.Value = highScore.score_id;
-                                beatmapId.Value = highScore.beatmap_id;
-                                date.Value = highScore.date;
-                                hasReplay.Value = highScore.replay;
-                                data.Value = serialisedScore;
-
-                                if (!insertCommand.IsPrepared)
-                                    await insertCommand.PrepareAsync();
-                                insertCommand.Transaction = transaction;
-
-                                // This could potentially be batched further (ie. to run more SQL statements in a single NonQuery call), but in practice
-                                // this does not improve throughput.
-                                await insertCommand.ExecuteNonQueryAsync();
-                                await enqueueForFurtherProcessing((ulong)insertCommand.LastInsertedId, db, transaction);
-
-                                Interlocked.Increment(ref currentReportInsertCount);
-                                Interlocked.Increment(ref totalInsertCount);
-                            }
-                        }
-                        catch (Exception e)
-                        {
-                            throw new AggregateException($"Processing legacy score {highScore.score_id} failed.", e);
-                        }
-                    }
-
-                    await transaction.CommitAsync();
-                }
-            }
-
-            /// <summary>
-            /// Creates a partially-populated "reference" score that provides:
-            /// <list type="bullet">
-            /// <item><term><see cref="ScoreInfo.Ruleset"/></term></item>
-            /// <item><term><see cref="ScoreInfo.Accuracy"/></term></item>
-            /// <item><term><see cref="ScoreInfo.Mods"/></term></item>
-            /// <item><term><see cref="ScoreInfo.Statistics"/></term></item>
-            /// <item><term><see cref="ScoreInfo.MaximumStatistics"/></term></item>
-            /// </list>
-            /// </summary>
-            private async Task<ScoreInfo> createReferenceScore(Ruleset ruleset, HighScore highScore, MySqlConnection connection, MySqlTransaction transaction)
-            {
-                Mod? classicMod = ruleset.CreateMod<ModClassic>();
-                Debug.Assert(classicMod != null);
-
-                var scoreInfo = new ScoreInfo
-                {
-                    Ruleset = ruleset.RulesetInfo,
-                    Mods = ruleset.ConvertFromLegacyMods((LegacyMods)highScore.enabled_mods).Append(classicMod).ToArray(),
-                    Statistics = new Dictionary<HitResult, int>(),
-                    MaximumStatistics = new Dictionary<HitResult, int>(),
-                    MaxCombo = highScore.maxcombo,
-                    LegacyTotalScore = highScore.score,
-                    IsLegacyScore = true
-                };
-
-                var scoreProcessor = ruleset.CreateScoreProcessor();
-
-                // Populate statistics and accuracy.
-                scoreInfo.SetCount50(highScore.count50);
-                scoreInfo.SetCount100(highScore.count100);
-                scoreInfo.SetCount300(highScore.count300);
-                scoreInfo.SetCountMiss(highScore.countmiss);
-                scoreInfo.SetCountGeki(highScore.countgeki);
-                scoreInfo.SetCountKatu(highScore.countkatu);
-                LegacyScoreDecoder.PopulateAccuracy(scoreInfo);
-
-                // Trim zero values from statistics.
-                scoreInfo.Statistics = scoreInfo.Statistics.Where(kvp => kvp.Value != 0).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-
-                // Populate the maximum statistics.
-                HitResult maxBasicResult = ruleset.GetHitResults().Select(h => h.result).Where(h => h.IsBasic()).MaxBy(scoreProcessor.GetBaseScoreForResult);
-
-                foreach ((HitResult result, int count) in scoreInfo.Statistics)
-                {
-                    switch (result)
-                    {
-                        case HitResult.LargeTickHit:
-                        case HitResult.LargeTickMiss:
-                            scoreInfo.MaximumStatistics[HitResult.LargeTickHit] = scoreInfo.MaximumStatistics.GetValueOrDefault(HitResult.LargeTickHit) + count;
-                            break;
-
-                        case HitResult.SmallTickHit:
-                        case HitResult.SmallTickMiss:
-                            scoreInfo.MaximumStatistics[HitResult.SmallTickHit] = scoreInfo.MaximumStatistics.GetValueOrDefault(HitResult.SmallTickHit) + count;
-                            break;
-
-                        case HitResult.IgnoreHit:
-                        case HitResult.IgnoreMiss:
-                        case HitResult.SmallBonus:
-                        case HitResult.LargeBonus:
-                            break;
-
-                        default:
-                            scoreInfo.MaximumStatistics[maxBasicResult] = scoreInfo.MaximumStatistics.GetValueOrDefault(maxBasicResult) + count;
-                            break;
-                    }
-                }
-
-                // In osu! and osu!mania, some judgements affect combo but aren't stored to scores.
-                // A special hit result is used to pad out the combo value to match, based on the max combo from the beatmap attributes.
-                int maxComboFromStatistics = scoreInfo.MaximumStatistics.Where(kvp => kvp.Key.AffectsCombo()).Select(kvp => kvp.Value).DefaultIfEmpty(0).Sum();
-
-                BeatmapScoringAttributes? scoreAttributes = await connection.QuerySingleOrDefaultAsync<BeatmapScoringAttributes>(
-                    "SELECT * FROM osu_beatmap_scoring_attribs WHERE beatmap_id = @BeatmapId AND mode = @RulesetId", new
-                    {
-                        BeatmapId = highScore.beatmap_id,
-                        RulesetId = ruleset.RulesetInfo.OnlineID
-                    }, transaction);
-
-                if (scoreAttributes == null)
-                {
-                    // TODO: LOG
-                    await Console.Error.WriteLineAsync($"{highScore.score_id}: Scoring attribs entry missing for beatmap {highScore.beatmap_id}.");
-                    return scoreInfo;
-                }
-
-#pragma warning disable CS0618
-                // Pad the maximum combo.
-                // Special case here for osu!mania as it requires per-mod considerations (key mods).
-                if (ruleset.RulesetInfo.OnlineID == 3)
-                {
-                    // Using the BeatmapStore class will fail if a particular difficulty attribute value doesn't exist in the database as a result of difficulty calculation not having been run yet.
-                    // Additionally, to properly fill out attribute objects, the BeatmapStore class would require a beatmap object resulting in another database query.
-                    // To get around both of these issues, we'll directly look up the attribute ourselves.
-
-                    // The isConvertedBeatmap parameter only affects whether mania key mods are allowed.
-                    // Since we're dealing with high scores, we assume that the database mod values have already been validated for mania-specific beatmaps that don't allow key mods.
-                    int difficultyMods = (int)LegacyModsHelper.MaskRelevantMods((LegacyMods)highScore.enabled_mods, true, ruleset.RulesetInfo.OnlineID);
-
-                    Dictionary<int, BeatmapDifficultyAttribute> dbAttributes = queryAttributes(
-                        new DifficultyAttributesLookup(highScore.beatmap_id, ruleset.RulesetInfo.OnlineID, difficultyMods), connection, transaction);
-
-                    if (!dbAttributes.TryGetValue(9, out BeatmapDifficultyAttribute? maxComboAttribute))
-                    {
-                        // TODO: LOG
-                        await Console.Error.WriteLineAsync($"{highScore.score_id}: Could not determine max combo from the difficulty attributes of beatmap {highScore.beatmap_id}.");
-                        return scoreInfo;
-                    }
-
-                    if ((int)maxComboAttribute.value > maxComboFromStatistics)
-                        scoreInfo.MaximumStatistics[HitResult.LegacyComboIncrease] = (int)maxComboAttribute.value - maxComboFromStatistics;
-                }
-                else
-                {
-                    if (scoreAttributes.max_combo > maxComboFromStatistics)
-                        scoreInfo.MaximumStatistics[HitResult.LegacyComboIncrease] = scoreAttributes.max_combo - maxComboFromStatistics;
-                }
-
-#pragma warning restore CS0618
-
-                Beatmap beatmap = await connection.QuerySingleAsync<Beatmap>("SELECT * FROM osu_beatmaps WHERE `beatmap_id` = @BeatmapId", new
-                {
-                    BeatmapId = highScore.beatmap_id
-                }, transaction);
-
-                LegacyBeatmapConversionDifficultyInfo difficulty = LegacyBeatmapConversionDifficultyInfo.FromAPIBeatmap(beatmap.ToAPIBeatmap());
-
-                StandardisedScoreMigrationTools.UpdateFromLegacy(scoreInfo, difficulty, scoreAttributes.ToAttributes());
-
-                return scoreInfo;
-            }
-
-            private static readonly ConcurrentDictionary<DifficultyAttributesLookup, Dictionary<int, BeatmapDifficultyAttribute>> attributes_cache =
-                new ConcurrentDictionary<DifficultyAttributesLookup, Dictionary<int, BeatmapDifficultyAttribute>>();
-
-            private static Dictionary<int, BeatmapDifficultyAttribute> queryAttributes(DifficultyAttributesLookup lookup, MySqlConnection connection, MySqlTransaction transaction)
-            {
-                if (attributes_cache.TryGetValue(lookup, out Dictionary<int, BeatmapDifficultyAttribute>? existing))
-                    return existing;
-
-                IEnumerable<BeatmapDifficultyAttribute> dbAttributes =
-                    connection.Query<BeatmapDifficultyAttribute>(
-                        "SELECT * FROM osu_beatmap_difficulty_attribs WHERE `beatmap_id` = @BeatmapId AND `mode` = @RulesetId AND `mods` = @Mods", lookup, transaction);
-
-                return attributes_cache[lookup] = dbAttributes.ToDictionary(a => (int)a.attrib_id, a => a);
-            }
-
-            private record DifficultyAttributesLookup(int BeatmapId, int RulesetId, int Mods)
-            {
-                public override string ToString()
-                {
-                    return $"{{ BeatmapId = {BeatmapId}, RulesetId = {RulesetId}, Mods = {Mods} }}";
-                }
-            }
-
-            private async Task enqueueForFurtherProcessing(ulong scoreId, MySqlConnection connection, MySqlTransaction transaction)
-            {
-                if (importLegacyPP)
-                {
-                    // we can proceed by pushing the score directly to ES for indexing.
-                    ElasticScoreItems.Add(new ElasticQueuePusher.ElasticScoreItem
-                    {
-                        ScoreId = (long)scoreId
-                    });
-                }
-                else
-                {
-                    // the legacy PP value was not imported.
-                    // push the score to redis for PP processing.
-                    // on completion of PP processing, the score will be pushed to ES for indexing.
-                    // the score refetch here is wasteful, but convenient and reliable, as the actual updated/inserted `SoloScore` row
-                    // is not constructed anywhere before this...
-                    var score = await connection.QuerySingleAsync<SoloScore>("SELECT * FROM `scores` WHERE `id` = @id",
-                        new { id = scoreId }, transaction);
-                    var history = await connection.QuerySingleOrDefaultAsync<ProcessHistory>("SELECT * FROM `score_process_history` WHERE `score_id` = @id",
-                        new { id = scoreId }, transaction);
-                    ScoreStatisticsItems.Add(new ScoreItem(score, history));
-                }
-            }
-        }
-
-        [SuppressMessage("ReSharper", "InconsistentNaming")]
-        [Serializable]
-        private class HighScore
-        {
-            public ulong score_id { get; set; }
-            public int beatmap_id { get; set; }
-            public int user_id { get; set; }
-            public int score { get; set; }
-            public ushort maxcombo { get; set; }
-            public string rank { get; set; } = null!; // Actually a ScoreRank, but reading as a string for manual parsing.
-            public ushort count50 { get; set; }
-            public ushort count100 { get; set; }
-            public ushort count300 { get; set; }
-            public ushort countmiss { get; set; }
-            public ushort countgeki { get; set; }
-            public ushort countkatu { get; set; }
-            public bool perfect { get; set; }
-            public int enabled_mods { get; set; }
-            public DateTimeOffset date { get; set; }
-            public float pp { get; set; }
-            public bool replay { get; set; }
-            public bool hidden { get; set; }
-            public string country_acronym { get; set; } = null!;
         }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ScoreProcessQueue.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ScoreProcessQueue.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
+{
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [Serializable]
+    public class ScoreProcessQueue
+    {
+        public uint queue_id { get; set; }
+        public ulong score_id { get; set; }
+        public byte status { get; set; }
+        public bool is_deletion { get; set; }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
@@ -75,10 +75,20 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
             if (lastImportedLegacyScoreId >= firstEntry.score_id)
             {
-                var entry = db.QuerySingle<ScoreProcessQueue>($"SELECT * FROM score_process_queue WHERE mode = {RulesetId} AND score_id = {lastImportedLegacyScoreId + 1}");
+                var entry = db.QuerySingleOrDefault<ScoreProcessQueue>($"SELECT * FROM score_process_queue WHERE mode = {RulesetId} AND score_id = {lastImportedLegacyScoreId + 1}");
 
-                lastQueueId = entry.queue_id;
-                Console.WriteLine($"Continuing watch mode from last processed legacy score (score_id: {entry.score_id} queue_id: {entry.queue_id})");
+                if (entry != null)
+                {
+                    lastQueueId = entry.queue_id;
+                    Console.WriteLine($"Continuing watch mode from last processed legacy score (score_id: {entry.score_id} queue_id: {entry.queue_id})");
+                }
+                else
+                {
+                    // There may have been no new scores since the last run.
+                    entry = db.QuerySingle<ScoreProcessQueue>($"SELECT * FROM score_process_queue WHERE mode = {RulesetId} AND score_id = {lastImportedLegacyScoreId}");
+                    lastQueueId = entry.queue_id;
+                    Console.WriteLine($"Continuing watch mode from last processed legacy score (queue_id: {entry.queue_id})");
+                }
             }
             else
             {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
@@ -80,7 +80,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
             if (lastImportedLegacyScoreId >= firstEntry.score_id)
             {
-                var entry = db.QuerySingle<ScoreProcessQueue>($"SELECT * FROM score_process_queue WHERE mode = {RulesetId} AND score_id = {lastImportedLegacyScoreId}");
+                var entry = db.QuerySingle<ScoreProcessQueue>($"SELECT * FROM score_process_queue WHERE mode = {RulesetId} AND score_id = {lastImportedLegacyScoreId + 1}");
 
                 lastQueueId = entry.queue_id;
                 Console.WriteLine($"Continuing watch mode from last processed legacy score (score_id: {entry.score_id} queue_id: {entry.queue_id})");
@@ -94,9 +94,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                 Console.WriteLine("You have 10 seconds to decide if you really want to do this..");
                 await Task.Delay(10000, cancellationToken);
             }
-
-            Console.WriteLine();
-            Console.WriteLine($"Sourcing from {highScoreTable} for {ruleset.ShortName} starting from {lastQueueId}");
 
             if (SkipScoreProcessor)
             {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
@@ -61,11 +61,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
             Ruleset ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(RulesetId);
             string highScoreTable = LegacyDatabaseHelper.GetRulesetSpecifics(RulesetId).HighScoreTable;
 
-            // When running in watch mode, we need to ascertain a few things:
-            // - There is active ongoing processing in `score_process_queue` – if not, there will be nothing to watch and we will switch to full run mode.
-            // - Check whether the full run (non-watch) has caught up to recent scores (ie. processed up to a `score_id` contained in `score_process_queue`,
-            //   which generally keeps ~3 days of scores). If not, we should warn that there is a gap in processing, and an extra full run should be performed
-            //   to catch up.
             using var db = DatabaseAccess.GetConnection();
 
             ulong? lastImportedLegacyScoreId = db.QuerySingleOrDefault<ulong?>($"SELECT MAX(old_score_id) FROM score_legacy_id_map WHERE ruleset_id = {RulesetId}") ?? 0;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
@@ -143,9 +143,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                         Console.WriteLine($"Running batches were processing up to {lastQueueId}.");
                         Console.WriteLine();
 
-                        string status = inserter.Task.IsFaulted ? $"FAILED ({inserter.Task.Exception?.Message})" : "success";
-                        Console.WriteLine($"{inserter.Scores.First().score_id} - {inserter.Scores.Last().score_id}: {status}");
-                        return -1;
+                        throw inserter.Task.Exception!;
                     }
 
                     pushCompletedScoreToQueue(inserter);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
@@ -207,7 +207,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                 double secondsSinceStart = (double)(currentTimestamp - startupTimestamp) / 1000;
                 double processingRate = (BatchInserter.TotalInsertCount + BatchInserter.TotalUpdateCount) / secondsSinceStart;
 
-                Console.WriteLine($"Inserting up to {lastQueueId:N0} "
+                Console.WriteLine($"Inserting up to {lastQueueId:N0}: "
                                   + $"{BatchInserter.TotalInsertCount:N0} ins {BatchInserter.TotalUpdateCount:N0} upd {BatchInserter.TotalDeleteCount:N0} del {BatchInserter.TotalSkipCount:N0} skip (+{inserted:N0} new +{updated:N0} upd +{deleted:N0} del) {processingRate:N0}/s");
 
                 lastCommitTimestamp = currentTimestamp;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
@@ -145,7 +145,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
                     var lastScore = highScores.Last();
 
-                    lastQueueId = lastScore.queue_id;
+                    lastQueueId = lastScore.queue_id!.Value;
                     Console.WriteLine($"Workers processed up to (score_id: {lastScore.score_id} queue_id: {lastQueueId})");
                     lastQueueId++;
                 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
@@ -129,7 +129,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                         continue;
                     }
 
-                    var inserter = new BatchInserter(ruleset, highScores, importLegacyPP: !SkipScoreProcessor, skipExisting: true, skipNew: false, dryRun: DryRun);
+                    var inserter = new BatchInserter(ruleset, highScores, importLegacyPP: SkipScoreProcessor, skipExisting: true, skipNew: false, dryRun: DryRun);
 
                     while (!inserter.Task.IsCompleted)
                     {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
@@ -22,7 +22,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
     /// This is important to guarantee that scores are inserted in the same sequential order that they originally occured,
     /// which can be used for tie-breaker scenarios.
     /// </remarks>
-    [Command("watch-high-scores", Description = "Imports high scores from the osu_scores_*_high tables into the new scores table.")]
+    [Command("watch-high-scores", Description = "Watches for new high scores from the osu_scores_high tables and imports into the new scores table.")]
     public class WatchHighScoresCommand
     {
         /// <summary>
@@ -32,7 +32,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
         public int RulesetId { get; set; }
 
         /// <summary>
-        /// When set to <c>true</c> and in watch mode, scores will not be queued to the score statistics processor,
+        /// When set to <c>true</c>, scores will not be queued to the score statistics processor,
         /// instead being sent straight to the elasticsearch indexing queue.
         /// </summary>
         [Option(CommandOptionType.SingleOrNoValue, Template = "--skip-score-processor")]

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
@@ -1,0 +1,219 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using McMaster.Extensions.CommandLineUtils;
+using osu.Game.Rulesets;
+using osu.Server.QueueProcessor;
+using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
+{
+    /// <summary>
+    /// Watches for new high scores from the osu_scores_high tables and imports into the new scores table.
+    /// </summary>
+    /// <remarks>
+    /// This command is written under the assumption that only one importer instance is running concurrently.
+    /// This is important to guarantee that scores are inserted in the same sequential order that they originally occured,
+    /// which can be used for tie-breaker scenarios.
+    /// </remarks>
+    [Command("watch-high-scores", Description = "Imports high scores from the osu_scores_*_high tables into the new scores table.")]
+    public class WatchHighScoresCommand
+    {
+        /// <summary>
+        /// The ruleset to run this import job for.
+        /// </summary>
+        [Option(CommandOptionType.SingleValue, Template = "--ruleset-id")]
+        public int RulesetId { get; set; }
+
+        /// <summary>
+        /// When set to <c>true</c> and in watch mode, scores will not be queued to the score statistics processor,
+        /// instead being sent straight to the elasticsearch indexing queue.
+        /// </summary>
+        [Option(CommandOptionType.SingleOrNoValue, Template = "--skip-score-processor")]
+        public bool SkipScoreProcessor { get; set; }
+
+        private long lastCommitTimestamp;
+        private long startupTimestamp;
+
+        private ElasticQueuePusher? elasticQueueProcessor;
+        private ScoreStatisticsQueueProcessor? scoreStatisticsQueueProcessor;
+
+        /// <summary>
+        /// The number of seconds between console progress reports.
+        /// </summary>
+        private const double seconds_between_report = 2;
+
+        private ulong lastId;
+
+        private readonly DateTimeOffset startedAt = DateTimeOffset.Now;
+
+        public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
+        {
+            Ruleset ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(RulesetId);
+            string highScoreTable = LegacyDatabaseHelper.GetRulesetSpecifics(RulesetId).HighScoreTable;
+
+            // When running in watch mode, we need to ascertain a few things:
+            // - There is active ongoing processing in `score_process_queue` – if not, there will be nothing to watch and we will switch to full run mode.
+            // - Check whether the full run (non-watch) has caught up to recent scores (ie. processed up to a `score_id` contained in `score_process_queue`,
+            //   which generally keeps ~3 days of scores). If not, we should warn that there is a gap in processing, and an extra full run should be performed
+            //   to catch up.
+            using var db = DatabaseAccess.GetConnection();
+
+            ulong? lastImportedLegacyScore = db.QuerySingleOrDefault<ulong?>($"SELECT MAX(old_score_id) FROM score_legacy_id_map WHERE ruleset_id = {RulesetId}") ?? 0;
+            ulong? lowestProcessQueueEntry = db.QuerySingleOrDefault<ulong?>($"SELECT MIN(score_id) FROM score_process_queue WHERE is_deletion = 0 AND mode = {ruleset.RulesetInfo.OnlineID}") - 1;
+
+            if (lowestProcessQueueEntry == null)
+            {
+                Console.WriteLine("Couldn't find any scores to process");
+                return -1;
+            }
+
+            if (lastImportedLegacyScore >= lowestProcessQueueEntry)
+            {
+                lastId = lastImportedLegacyScore.Value + 1;
+                Console.WriteLine($"Continuing watch mode from last processed legacy score ({lastId})");
+            }
+            else
+            {
+                lastId = lowestProcessQueueEntry.Value;
+                Console.WriteLine($"WARNING: Continuing watch mode from start of score_process_queue ({lastId})");
+                Console.WriteLine("This implies that a full import hasn't been run yet, you might want to run another import first to catch up.");
+                Console.WriteLine();
+                Console.WriteLine("You have 10 seconds to decide if you really want to do this..");
+                await Task.Delay(10000, cancellationToken);
+            }
+
+            Console.WriteLine();
+            Console.WriteLine($"Sourcing from {highScoreTable} for {ruleset.ShortName} starting from {lastId}");
+
+            if (SkipScoreProcessor)
+            {
+                elasticQueueProcessor = new ElasticQueuePusher();
+                Console.WriteLine($"Indexing to elasticsearch queue(s) {elasticQueueProcessor.ActiveQueues}");
+            }
+            else
+            {
+                scoreStatisticsQueueProcessor = new ScoreStatisticsQueueProcessor();
+                Console.WriteLine($"Pushing imported scores to redis queue {scoreStatisticsQueueProcessor.QueueName}");
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("Starting processing in 5 seconds...");
+            await Task.Delay(5000, cancellationToken);
+
+            using (var dbMainQuery = DatabaseAccess.GetConnection())
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    HighScore[] highScores = (await dbMainQuery.QueryAsync<HighScore>($"SELECT * FROM {highScoreTable} h WHERE score_id >= @lastId ORDER BY score_id LIMIT 1000", new
+                    {
+                        lastId,
+                        rulesetId = ruleset.RulesetInfo.OnlineID,
+                    })).ToArray();
+
+                    if (highScores.Length == 0)
+                    {
+                        Thread.Sleep(500);
+                        continue;
+                    }
+
+                    var inserter = new BatchInserter(ruleset, highScores.ToArray(), importLegacyPP: !SkipScoreProcessor, true, false);
+
+                    while (!inserter.Task.IsCompleted)
+                    {
+                        outputProgress();
+                        Thread.Sleep(10);
+                    }
+
+                    if (inserter.Task.IsFaulted)
+                    {
+                        Console.WriteLine("ERROR: Inserter failed. Aborting for safety.");
+                        Console.WriteLine($"Running batches were processing up to {lastId}.");
+                        Console.WriteLine();
+
+                        string status = inserter.Task.IsFaulted ? $"FAILED ({inserter.Task.Exception?.Message})" : "success";
+                        Console.WriteLine($"{inserter.Scores.First().score_id} - {inserter.Scores.Last().score_id}: {status}");
+                        return -1;
+                    }
+
+                    pushCompletedScoreToQueue(inserter);
+
+                    lastId = highScores.Last().score_id;
+                    Console.WriteLine($"Workers processed up to score_id {lastId}");
+                    lastId++;
+                }
+            }
+
+            outputFinalStats();
+            return 0;
+        }
+
+        private void pushCompletedScoreToQueue(BatchInserter inserter)
+        {
+            if (scoreStatisticsQueueProcessor != null)
+            {
+                Debug.Assert(inserter.ElasticScoreItems.Any());
+
+                var scoreStatisticsItems = inserter.ScoreStatisticsItems.ToList();
+
+                if (scoreStatisticsItems.Any())
+                {
+                    scoreStatisticsQueueProcessor.PushToQueue(scoreStatisticsItems);
+                    Console.WriteLine($"Queued {scoreStatisticsItems.Count} item(s) for statistics processing");
+                }
+            }
+            else if (elasticQueueProcessor != null)
+            {
+                Debug.Assert(!inserter.ScoreStatisticsItems.Any());
+
+                var elasticItems = inserter.ElasticScoreItems.ToList();
+
+                if (elasticItems.Any())
+                {
+                    elasticQueueProcessor.PushToQueue(elasticItems);
+                    Console.WriteLine($"Queued {elasticItems.Count} item(s) for indexing");
+                }
+            }
+        }
+
+        private void outputProgress()
+        {
+            long currentTimestamp = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+
+            if ((currentTimestamp - lastCommitTimestamp) / 1000f >= seconds_between_report)
+            {
+                int inserted = Interlocked.Exchange(ref BatchInserter.CurrentReportInsertCount, 0);
+                int updated = Interlocked.Exchange(ref BatchInserter.CurrentReportUpdateCount, 0);
+
+                // Only set startup timestamp after first insert actual insert/update run to avoid weighting during catch-up.
+                if (inserted + updated > 0 && startupTimestamp == 0)
+                    startupTimestamp = lastCommitTimestamp;
+
+                double secondsSinceStart = (double)(currentTimestamp - startupTimestamp) / 1000;
+                double processingRate = (BatchInserter.TotalInsertCount + BatchInserter.TotalUpdateCount) / secondsSinceStart;
+
+                Console.WriteLine($"Inserting up to {lastId:N0} "
+                                  + $"{BatchInserter.TotalInsertCount:N0} inserted {BatchInserter.TotalUpdateCount:N0} updated {BatchInserter.TotalSkipCount:N0} skipped (+{inserted:N0} new +{updated:N0} upd) {processingRate:N0}/s");
+
+                lastCommitTimestamp = currentTimestamp;
+            }
+        }
+
+        private void outputFinalStats()
+        {
+            Console.WriteLine();
+            Console.WriteLine();
+            Console.WriteLine($"Cancelled after {(DateTimeOffset.Now - startedAt).TotalSeconds} seconds.");
+            Console.WriteLine($"Final stats: {BatchInserter.TotalInsertCount} inserted, {BatchInserter.TotalSkipCount} skipped");
+            Console.WriteLine($"Resume from start id {lastId}");
+            Console.WriteLine();
+            Console.WriteLine();
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/QueueCommands.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/QueueCommands.cs
@@ -14,6 +14,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands
     [Subcommand(typeof(ClearQueueCommand))]
     [Subcommand(typeof(WatchQueueCommand))]
     [Subcommand(typeof(ImportHighScoresCommand))]
+    [Subcommand(typeof(WatchHighScoresCommand))]
     [Subcommand(typeof(DeleteImportedHighScoresCommand))]
     public sealed class QueueCommands
     {


### PR DESCRIPTION
Posting this for review, but I'l be testing this live immediately.

Basically, this adds a new watch mode command. The old one still exists and can still watch, but the new one handles things in a slightly better way:

- The source of new scores is now tailing `score_process_queue` rather than `osu_scores_high`. This was done to make us aware of deletions performed by web-10 (which are inserted into the queue table with `is_deletion = true`.
- All batching is removed to simplify things as much as possible. For the watch mode we don't need any kind of insane performance, so I cut things back to the basics.
- All slave checks and rate adjusts are removed for the same reason.
- Deleting rows is now supported by `BatchInserter`. Note that this will only take effect with the new watch mode command, as it relies on the `is_deletion` flag to be included in the provided `HighScore`s.

If all goes well here, eventually I will remove the watch mode from the old command and make it specific to running a full import.