### PR TITLE
Fix some entries not waiting for performance population before importing

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
@@ -30,7 +30,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
         public bool hidden { get; set; }
         public string country_acronym { get; set; } = null!;
 
-        // This comes from score_process_queue. Used in join context.
+        // These comes from score_process_queue. Used in join context.
         public uint? queue_id { get; set; }
+        public byte? status { get; set; }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
@@ -30,7 +30,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
         public bool hidden { get; set; }
         public string country_acronym { get; set; } = null!;
 
-        // These comes from score_process_queue. Used in join context.
+        // These come from score_process_queue. Used in join context.
         public uint? queue_id { get; set; }
         public byte? status { get; set; }
     }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
@@ -132,6 +132,15 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                                              .OrderBy(s => s.queue_id)
                                              .ToArray();
 
+                    var pendingProcessing = highScores.FirstOrDefault(s => s.status == 0);
+
+                    if (pendingProcessing != null)
+                    {
+                        Console.WriteLine($"Waiting on processing of (score_id: {pendingProcessing.score_id} queue_id: {pendingProcessing.queue_id})");
+                        Thread.Sleep(500);
+                        continue;
+                    }
+
                     if (highScores.Length == 0)
                     {
                         Thread.Sleep(500);


### PR DESCRIPTION
Simplest fix for now. Has been deployed a couple of days and is running well.