### PR TITLE
Refactor to avoid fragmentation

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -157,6 +157,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
                 using var cmd = db.CreateCommand();
                 cmd.CommandText = insertCommand.ToString().Trim(',', ' ');
+                cmd.CommandTimeout = 120;
 
                 try
                 {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -64,7 +64,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
             this.dryRun = dryRun;
 
             Scores = scores;
-            Task = run(scores);
+            Task = Task.Run(() => run(scores));
         }
 
         private async Task run(HighScore[] scores)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -172,7 +172,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
             using (var db = DatabaseAccess.GetConnection())
             {
-                ulong firstInsertId = db.QuerySingle<ulong>(sql, commandTimeout: 120);
+                ulong firstInsertId = db.ExecuteScalar<ulong>(sql, commandTimeout: 120);
                 ulong lastInsertId = firstInsertId + (ulong)scores.Length - 1;
                 Console.WriteLine($" Command completed in {sw.Elapsed.TotalSeconds:N1} seconds");
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -145,6 +145,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                             insertBuilder.Append(",");
                         first = false;
 
+                        if (referenceScore.TotalScore > 4294967295)
+                            referenceScore.TotalScore = 0;
+
+                        if (referenceScore.LegacyTotalScore > 4294967295)
+                            referenceScore.LegacyTotalScore = 0;
+
                         insertBuilder.Append($"({highScore.user_id}, {rulesetId}, {highScore.beatmap_id}, {(highScore.replay ? "1" : "0")}, 1, '{referenceScore.Rank.ToString()}', 1, {referenceScore.Accuracy}, {referenceScore.MaxCombo}, {referenceScore.TotalScore}, '{serialisedScore}', {highScore.pp?.ToString() ?? "null"}, {highScore.score_id}, {referenceScore.LegacyTotalScore}, '{highScore.date.ToString("yyyy-MM-dd HH:mm:ss")}', {highScore.date.ToUnixTimeSeconds()})");
                     }
                 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -83,7 +83,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
             StringBuilder insertBuilder = new StringBuilder("INSERT INTO scores (`user_id`, `ruleset_id`, `beatmap_id`, `has_replay`, `preserve`, `rank`, `passed`, `accuracy`, `max_combo`, `total_score`, `data`, `pp`, `legacy_score_id`, `legacy_total_score`, `ended_at`, `unix_updated_at`) VALUES ");
 
-            Console.WriteLine($"Processing scores {scores.First().score_id} to {scores.Last().score_id}");
+            Console.WriteLine($" Processing scores {scores.First().score_id} to {scores.Last().score_id}");
             Stopwatch sw = new Stopwatch();
             sw.Start();
             Parallel.ForEach(scores, new ParallelOptions
@@ -130,7 +130,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                     // MySQL doesn't like empty dates, so let's ensure we have a valid one.
                     if (highScore.date < DateTimeOffset.UnixEpoch)
                     {
-                        Console.WriteLine($"Legacy score {highScore.score_id} has invalid date ({highScore.date}), fixing.");
+                        Console.WriteLine($" Legacy score {highScore.score_id} has invalid date ({highScore.date}), fixing.");
                         highScore.date = DateTimeOffset.UnixEpoch;
                     }
 
@@ -154,11 +154,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                 }
             });
 
-            Console.WriteLine($"Processing completed in {sw.Elapsed.TotalSeconds:N1} seconds");
+            Console.WriteLine($" Processing completed in {sw.Elapsed.TotalSeconds:N1} seconds");
 
             if (insertCount == 0)
             {
-                Console.WriteLine($"Skipped all {scores.Length} scores");
+                Console.WriteLine($" Skipped all {scores.Length} scores");
+
                 return;
             }
 
@@ -166,14 +167,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
             string sql = insertBuilder.ToString().Trim(',', ' ') + "; SELECT LAST_INSERT_ID()";
 
-            Console.WriteLine($"Running insert command with {sql.Length:#,0} bytes");
+            Console.WriteLine($" Running insert command with {sql.Length:#,0} bytes");
             sw.Restart();
 
             using (var db = DatabaseAccess.GetConnection())
             {
                 ulong firstInsertId = db.QuerySingle<ulong>(sql, commandTimeout: 120);
                 ulong lastInsertId = firstInsertId + (ulong)scores.Length - 1;
-                Console.WriteLine($"Command completed in {sw.Elapsed.TotalSeconds:N1} seconds");
+                Console.WriteLine($" Command completed in {sw.Elapsed.TotalSeconds:N1} seconds");
 
                 await enqueueForFurtherProcessing(firstInsertId, lastInsertId, db);
             }
@@ -290,7 +291,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                 if (!dbAttributes.TryGetValue(9, out BeatmapDifficultyAttribute? maxComboAttribute))
                 {
                     // TODO: LOG
-                    Console.Error.WriteLine($"{highScore.score_id}: Could not determine max combo from the difficulty attributes of beatmap {highScore.beatmap_id}.");
+                    Console.Error.WriteLine($" {highScore.score_id}: Could not determine max combo from the difficulty attributes of beatmap {highScore.beatmap_id}.");
                     return scoreInfo;
                 }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -172,6 +172,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
             using (var db = DatabaseAccess.GetConnection())
             {
+                // https://dev.mysql.com/doc/refman/8.0/en/information-functions.html#function_last-insert-id
+                // If you insert multiple rows using a single INSERT statement, LAST_INSERT_ID() returns the value generated for the first inserted row only.
                 ulong firstInsertId = db.ExecuteScalar<ulong>(sql, commandTimeout: 120);
                 ulong lastInsertId = firstInsertId + (ulong)scores.Length - 1;
                 Console.WriteLine($" Command completed in {sw.Elapsed.TotalSeconds:N1} seconds");

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -179,12 +179,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                 ulong firstInsertId = (ulong)cmd.LastInsertedId;
                 ulong lastInsertId = firstInsertId + (ulong)scores.Length - 1;
 
-                // check consecutive inserts (can probably remove this now that we're sure).
-                long firstId = db.QuerySingle<long>($"SELECT legacy_score_id FROM scores WHERE id = {firstInsertId}");
-                long lastId = db.QuerySingle<long>($"SELECT legacy_score_id FROM scores WHERE id = {lastInsertId}");
-                if (lastId != (long)scores.Last().score_id) throw new InvalidOperationException("OUT OF ORDER");
-                if (firstId != (long)scores.First().score_id) throw new InvalidOperationException("OUT OF ORDER");
-
                 await enqueueForFurtherProcessing(firstInsertId, lastInsertId, db);
 
                 Interlocked.Add(ref CurrentReportInsertCount, scores.Length);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -138,9 +138,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                     }
                 }
 
-                // This could potentially be batched further (ie. to run more SQL statements in a single NonQuery call), but in practice
-                // this does not improve throughput.
-
                 using var cmd = db.CreateCommand();
                 cmd.CommandText = insertCommand.ToString().Trim(',', ' ');
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -75,6 +75,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
             StringBuilder insertBuilder = new StringBuilder("INSERT INTO scores (`user_id`, `ruleset_id`, `beatmap_id`, `has_replay`, `preserve`, `rank`, `passed`, `accuracy`, `max_combo`, `total_score`, `data`, `pp`, `legacy_score_id`, `legacy_total_score`, `ended_at`, `unix_updated_at`) VALUES ");
 
+            Console.WriteLine($"Processing scores {scores.First().score_id} to {scores.Last().score_id}");
             Parallel.ForEach(scores, new ParallelOptions
             {
                 MaxDegreeOfParallelism = Environment.ProcessorCount,
@@ -137,7 +138,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
             });
 
             if (insertCount == 0)
+            {
+                Console.WriteLine($"Skipped all {scores.Length} scores");
                 return;
+            }
 
             string sql = insertBuilder.ToString().Trim(',', ' ') + "; SELECT LAST_INSERT_ID()";
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -39,18 +39,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
     public class BatchInserter
     {
         public static int CurrentReportInsertCount;
-        public static int CurrentReportUpdateCount;
         public static int CurrentReportDeleteCount;
         public static int TotalInsertCount;
-        public static int TotalUpdateCount;
         public static int TotalDeleteCount;
 
         public static int TotalSkipCount;
 
         private readonly Ruleset ruleset;
         private readonly bool importLegacyPP;
-        private readonly bool skipExisting;
-        private readonly bool skipNew;
         private readonly bool dryRun;
 
         public HighScore[] Scores { get; }
@@ -61,12 +57,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
         public List<ScoreItem> ScoreStatisticsItems { get; } = new List<ScoreItem>();
 
-        public BatchInserter(Ruleset ruleset, HighScore[] scores, bool importLegacyPP, bool skipExisting, bool skipNew, bool dryRun = false)
+        public BatchInserter(Ruleset ruleset, HighScore[] scores, bool importLegacyPP, bool dryRun = false)
         {
             this.ruleset = ruleset;
             this.importLegacyPP = importLegacyPP;
-            this.skipExisting = skipExisting;
-            this.skipNew = skipNew;
             this.dryRun = dryRun;
 
             Scores = scores;
@@ -111,7 +105,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                         // Look away please.
                         bool isDeletion = highScore.user_id == 0 && highScore.score == 0;
 
-                        if ((existingMapping != null && skipExisting) || (existingMapping == null && skipNew))
+                        if (isDeletion)
+                        {
+                            // TODO: handle deletion
+                        }
+
+                        if (existingMapping != null || isDeletion)
                         {
                             Interlocked.Increment(ref TotalSkipCount);
                             continue;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -165,7 +165,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
             insertBuilder.Append("; SELECT LAST_INSERT_ID()");
 
-            string sql = insertBuilder.ToString().Trim(',', ' ') + "; SELECT LAST_INSERT_ID()";
+            string sql = insertBuilder.ToString();
 
             Console.WriteLine($" Running insert command with {sql.Length:#,0} bytes");
             sw.Restart();

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
@@ -33,5 +33,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
         // These come from score_process_queue. Used in join context.
         public uint? queue_id { get; set; }
         public byte? status { get; set; }
+
+        public ulong? new_id { get; set; }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
@@ -34,6 +34,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
         public uint? queue_id { get; set; }
         public byte? status { get; set; }
 
+        // ID of this score in the `scores` table. Used in join context.
         public ulong? new_id { get; set; }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -293,12 +293,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                 // state before resuming operations.
                 latency = db.QueryFirstOrDefault<int?>("SELECT `count` FROM `osu_counts` WHERE NAME = 'slave_latency'");
 
-                if (latency == null)
+                if (latency == null || latency < maximum_slave_latency_seconds)
                     return;
 
                 Console.WriteLine($"Current slave latency of {latency} seconds exceeded maximum of {maximum_slave_latency_seconds} seconds.");
-                Console.WriteLine($"Sleeping for {latency} seconds to allow catch-up.");
-                await Task.Delay(latency.Value * 1000, cancellationToken);
+                Console.WriteLine($"Sleeping to allow catch-up.");
+
+                await Task.Delay(maximum_slave_latency_seconds * 1000, cancellationToken);
             } while (latency > maximum_slave_latency_seconds);
         }
     }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -118,7 +118,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                     if (CheckSlaveLatency)
                         checkSlaveLatency(db);
 
-                    var highScores = await db.QueryAsync<HighScore>($"SELECT * FROM {highScoreTable} h WHERE score_id >= @lastId AND score_id <= @maxProcessableId" +
+                    var highScores = await db.QueryAsync<HighScore>($"SELECT h.*, s.id as new_id FROM {highScoreTable} h "
+                                                                    + $"LEFT JOIN scores s ON h.score_id = s.legacy_score_id AND s.ruleset_id = {RulesetId} "
+                                                                    + $"WHERE score_id >= @lastId AND score_id <= @maxProcessableId" +
                                                                     " ORDER BY score_id LIMIT @batchSize", new
                     {
                         lastId,

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -123,8 +123,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                     Console.WriteLine($"Fetching next scores from {lastProcessedId}...");
                     var highScores = await db.QueryAsync<HighScore>($"SELECT h.*, s.id as new_id FROM {highScoreTable} h "
                                                                     + $"LEFT JOIN scores s ON h.score_id = s.legacy_score_id AND s.ruleset_id = {RulesetId} "
-                                                                    + $"WHERE score_id >= @lastId AND score_id <= @maxProcessableId" +
-                                                                    " ORDER BY score_id LIMIT @batchSize", new
+                                                                    + "WHERE score_id >= @lastId AND score_id <= @maxProcessableId "
+                                                                    + "ORDER BY score_id LIMIT @batchSize", new
                     {
                         lastId = lastProcessedId,
                         maxProcessableId,

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -71,11 +71,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
         private ElasticQueuePusher? elasticQueueProcessor;
 
         /// <summary>
-        /// The number of seconds between console progress reports.
-        /// </summary>
-        private const double seconds_between_report = 2;
-
-        /// <summary>
         /// The number of seconds between checks for slave latency.
         /// </summary>
         private const int seconds_between_latency_checks = 60;
@@ -297,7 +292,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                     return;
 
                 Console.WriteLine($"Current slave latency of {latency} seconds exceeded maximum of {maximum_slave_latency_seconds} seconds.");
-                Console.WriteLine($"Sleeping to allow catch-up.");
+                Console.WriteLine("Sleeping to allow catch-up.");
 
                 await Task.Delay(maximum_slave_latency_seconds * 1000, cancellationToken);
             } while (latency > maximum_slave_latency_seconds);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -243,7 +243,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                 startupTimestamp = lastCommitTimestamp;
 
             double secondsSinceStart = (double)(currentTimestamp - startupTimestamp) / 1000;
-            double processingRate = BatchInserter.TotalInsertCount / secondsSinceStart;
+            double processingRate = (BatchInserter.TotalInsertCount - InsertBatchSize * ThreadCount) / secondsSinceStart;
 
             double secondsLeft = (maxProcessableId - lastProcessedId) / processingRate;
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -62,7 +62,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
         /// The number of scores to run in each batch. Setting this higher will cause larger SQL statements for insert.
         /// </summary>
         [Option(CommandOptionType.SingleValue, Template = "--batch-size")]
-        public int InsertBatchSize { get; set; } = 256000;
+        public int InsertBatchSize { get; set; } = 128000;
 
         private long lastCommitTimestamp;
         private long startupTimestamp;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -118,6 +118,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                     if (CheckSlaveLatency)
                         checkSlaveLatency(db);
 
+                    Console.WriteLine($"Fetching next scores from {lastProcessedId}...");
                     var highScores = await db.QueryAsync<HighScore>($"SELECT h.*, s.id as new_id FROM {highScoreTable} h "
                                                                     + $"LEFT JOIN scores s ON h.score_id = s.legacy_score_id AND s.ruleset_id = {RulesetId} "
                                                                     + $"WHERE score_id >= @lastId AND score_id <= @maxProcessableId" +

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
@@ -147,7 +147,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                         continue;
                     }
 
-                    var inserter = new BatchInserter(ruleset, highScores, importLegacyPP: SkipScoreProcessor, skipExisting: true, skipNew: false, dryRun: DryRun);
+                    var inserter = new BatchInserter(ruleset, highScores, importLegacyPP: SkipScoreProcessor, dryRun: DryRun);
 
                     while (!inserter.Task.IsCompleted)
                     {
@@ -215,18 +215,17 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
             if ((currentTimestamp - lastCommitTimestamp) / 1000f >= seconds_between_report)
             {
                 int inserted = Interlocked.Exchange(ref BatchInserter.CurrentReportInsertCount, 0);
-                int updated = Interlocked.Exchange(ref BatchInserter.CurrentReportUpdateCount, 0);
                 int deleted = Interlocked.Exchange(ref BatchInserter.CurrentReportDeleteCount, 0);
 
                 // Only set startup timestamp after first insert actual insert/update run to avoid weighting during catch-up.
-                if (inserted + updated > 0 && startupTimestamp == 0)
+                if (inserted > 0 && startupTimestamp == 0)
                     startupTimestamp = lastCommitTimestamp;
 
                 double secondsSinceStart = (double)(currentTimestamp - startupTimestamp) / 1000;
-                double processingRate = (BatchInserter.TotalInsertCount + BatchInserter.TotalUpdateCount) / secondsSinceStart;
+                double processingRate = BatchInserter.TotalInsertCount / secondsSinceStart;
 
                 Console.WriteLine($"Inserting up to {lastQueueId:N0}: "
-                                  + $"{BatchInserter.TotalInsertCount:N0} ins {BatchInserter.TotalUpdateCount:N0} upd {BatchInserter.TotalDeleteCount:N0} del {BatchInserter.TotalSkipCount:N0} skip (+{inserted:N0} new +{updated:N0} upd +{deleted:N0} del) {processingRate:N0}/s");
+                                  + $"{BatchInserter.TotalInsertCount:N0} ins {BatchInserter.TotalDeleteCount:N0} del {BatchInserter.TotalSkipCount:N0} skip (+{inserted:N0} new +{deleted:N0} del) {processingRate:N0}/s");
 
                 lastCommitTimestamp = currentTimestamp;
             }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
@@ -123,7 +123,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                 while (!cancellationToken.IsCancellationRequested)
                 {
                     HighScore[] highScores = (await dbMainQuery.QueryAsync<HighScore>(
-                                                 $"SELECT h.*, s.id as new_id FROM osu.score_process_queue "
+                                                 "SELECT h.*, s.id as new_id FROM osu.score_process_queue "
                                                  + $"LEFT JOIN {highScoreTable} h USING (score_id) "
                                                  + $"LEFT JOIN scores s ON h.score_id = s.legacy_score_id AND s.ruleset_id = {RulesetId} "
                                                  + $"WHERE queue_id >= @lastQueueId AND mode = {RulesetId} ORDER BY queue_id LIMIT 50", new


### PR DESCRIPTION
Primary goal: avoid table fragmentation from having 80 threads inserting at once.
Secondary goal: improve performance when running in single thread mode.

Can now insert consistently at 8.4k rows/second with one thread. Increasing threads now results in insane performance (4 threads can reach 16k rows/second), but the higher you go, the more table fragmentation you incur. Might still be useful for CI etc. though. Might need tuning if we want to push threads too high as it currently consumed a lot of mysql connections when populating beatmap attribute caches.

Have not tested watch mode yet. Just PRing for initial visibility, as always, already testing on production.