### PR TITLE
Use updated accuracy & grade definitions when importing stable scores

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/osu.Server.Queues.ScoreStatisticsProcessor.Tests.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/osu.Server.Queues.ScoreStatisticsProcessor.Tests.csproj
@@ -9,8 +9,8 @@
     <ItemGroup>
         <PackageReference Include="DeepEqual" Version="4.2.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="xunit" Version="2.6.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
+        <PackageReference Include="xunit" Version="2.6.6" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -228,7 +228,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
             scoreInfo.SetCountMiss(highScore.countmiss);
             scoreInfo.SetCountGeki(highScore.countgeki);
             scoreInfo.SetCountKatu(highScore.countkatu);
-            LegacyScoreDecoder.PopulateAccuracy(scoreInfo);
 
             // Trim zero values from statistics.
             scoreInfo.Statistics = scoreInfo.Statistics.Where(kvp => kvp.Value != 0).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
@@ -310,7 +309,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
             var difficulty = getDificultyInfo(highScore.beatmap_id);
 
-            StandardisedScoreMigrationTools.UpdateFromLegacy(scoreInfo, difficulty, scoreAttributes.ToAttributes());
+            StandardisedScoreMigrationTools.UpdateFromLegacy(scoreInfo, rulesetCache.Ruleset, difficulty, scoreAttributes.ToAttributes());
 
             return scoreInfo;
         }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
@@ -9,14 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dapper" Version="2.1.24" />
+        <PackageReference Include="Dapper" Version="2.1.28" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.113.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.113.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.113.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.113.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.113.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2024.124.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.124.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.124.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.124.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.124.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2023.1207.0" />
     </ItemGroup>
 


### PR DESCRIPTION
- Will close https://github.com/ppy/osu/issues/26595
- [x] Depends on https://github.com/ppy/osu/pull/26630
- [x] Depends on game package w/ above

~~**Caution: This is very untested.** It only works in my head. I would test but right now my box is working as a heater doing diffcalc spreadsheets, and I'd rather not push my luck and have it hang on me. I'm PRing early for visibility and for visibility alone. And testing convenience I guess since I will want to run score sheets using this diff to verify that I didn't break anything.~~

As requested in https://github.com/ppy/osu/issues/26595#issuecomment-1903767921, this includes a rank check in the verify command from https://github.com/ppy/osu-queue-score-statistics/commit/68e53cda1583d44ec0466ba23a69348eb93edeba. But with fixes around quoting the `rank` column name (and actually selecting it from DB).