### PR TITLE
Point user performance processor to update final pp value

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
@@ -46,8 +46,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 score.Score.preserve = true;
             });
 
-            WaitForDatabaseState("SELECT COUNT(*) FROM osu_user_stats WHERE rank_score_exp > 0 AND user_id = 2", 1, CancellationToken);
-            WaitForDatabaseState("SELECT rank_score_index_exp FROM osu_user_stats WHERE user_id = 2", 1, CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(*) FROM osu_user_stats WHERE rank_score > 0 AND user_id = 2", 1, CancellationToken);
+            WaitForDatabaseState("SELECT rank_score_index FROM osu_user_stats WHERE user_id = 2", 1, CancellationToken);
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 score.Score.preserve = true;
             });
 
-            WaitForDatabaseState("SELECT COUNT(*) FROM osu_user_stats WHERE rank_score_exp > 0 AND user_id = 2", 0, CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(*) FROM osu_user_stats WHERE rank_score > 0 AND user_id = 2", 0, CancellationToken);
         }
 
         [Fact]
@@ -90,7 +90,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 PushToQueueAndWaitForProcess(score);
             }
 
-            WaitForDatabaseState("SELECT COUNT(*) FROM osu_user_stats WHERE rank_score_exp > 0 AND user_id = 2", 0, CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(*) FROM osu_user_stats WHERE rank_score > 0 AND user_id = 2", 0, CancellationToken);
         }
 
         [Fact]

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/UserStats.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/UserStats.cs
@@ -42,8 +42,5 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
         public DateTimeOffset last_update { get; set; } = DateTimeOffset.Now;
         public DateTimeOffset last_played { get; set; } = DateTimeOffset.Now;
         public long total_seconds_played { get; set; }
-
-        public float rank_score_exp { get; set; }
-        public int rank_score_index_exp { get; set; }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -160,8 +160,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 totalAccuracy *= 100.0 / (20 * (1 - Math.Pow(0.95, groupedItems.Length)));
             }
 
-            userStats.rank_score_exp = (float)totalPp;
-            userStats.rank_score_index_exp = (await connection.QuerySingleAsync<int>($"SELECT COUNT(*) FROM {dbInfo.UserStatsTable} WHERE rank_score_exp > {totalPp}", transaction: transaction)) + 1;
+            userStats.rank_score = (float)totalPp;
+            userStats.rank_score_index = (await connection.QuerySingleAsync<int>($"SELECT COUNT(*) FROM {dbInfo.UserStatsTable} WHERE rank_score > {totalPp}", transaction: transaction)) + 1;
             userStats.accuracy_new = (float)totalAccuracy;
         }
     }


### PR DESCRIPTION
This switches away from the "experimental" or "pp^next" to the true pp value.