### PR TITLE
Add command to watch non-high-scores

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -89,6 +89,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
             {
                 try
                 {
+                    if (highScore.score_id == 0)
+                    {
+                        // Something really bad probably happened, abort for safety.
+                        throw new InvalidOperationException("Score arrived with no ID");
+                    }
+
                     // Yes this is a weird way of determining whether it's a deletion.
                     // Look away please.
                     bool isDeletion = highScore.user_id == 0 && highScore.score == 0;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -145,7 +145,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                         if (referenceScore.LegacyTotalScore > 4294967295)
                             referenceScore.LegacyTotalScore = 0;
 
-                        insertBuilder.Append($"({highScore.user_id}, {rulesetId}, {highScore.beatmap_id}, {(highScore.replay ? "1" : "0")}, 1, '{referenceScore.Rank.ToString()}', 1, {referenceScore.Accuracy}, {referenceScore.MaxCombo}, {referenceScore.TotalScore}, '{serialisedScore}', {highScore.pp?.ToString() ?? "null"}, {highScore.score_id}, {referenceScore.LegacyTotalScore}, '{highScore.date.ToString("yyyy-MM-dd HH:mm:ss")}', {highScore.date.ToUnixTimeSeconds()})");
+                        insertBuilder.Append($"({highScore.user_id}, {rulesetId}, {highScore.beatmap_id}, {(highScore.replay ? "1" : "0")}, {(highScore.ShouldPreserve ? "1" : "0")}, '{referenceScore.Rank.ToString()}', 1, {referenceScore.Accuracy}, {referenceScore.MaxCombo}, {referenceScore.TotalScore}, '{serialisedScore}', {highScore.pp?.ToString() ?? "null"}, {highScore.score_id}, {referenceScore.LegacyTotalScore}, '{highScore.date.ToString("yyyy-MM-dd HH:mm:ss")}', {highScore.date.ToUnixTimeSeconds()})");
                     }
                 }
                 catch (Exception e)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -149,7 +149,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
                         // For non-preserved flags, we zero the score_id.
                         // This is because they come from a different table with a different range and it would be hard to track.
-                        Debug.Assert(highScore.ShouldPreserve || highScore.score_id == 0);
+                        if (!highScore.ShouldPreserve)
+                            highScore.score_id = 0;
 
                         insertBuilder.Append(
                             $"({highScore.user_id}, {rulesetId}, {highScore.beatmap_id}, {(highScore.replay ? "1" : "0")}, {(highScore.ShouldPreserve ? "1" : "0")}, '{referenceScore.Rank.ToString()}', {(highScore.pass ? "1" : "0")}, {referenceScore.Accuracy}, {referenceScore.MaxCombo}, {referenceScore.TotalScore}, '{serialisedScore}', {highScore.pp?.ToString() ?? "null"}, {highScore.score_id}, {referenceScore.LegacyTotalScore}, '{highScore.date.ToString("yyyy-MM-dd HH:mm:ss")}', {highScore.date.ToUnixTimeSeconds()})");

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
@@ -36,5 +36,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
         // ID of this score in the `scores` table. Used in join context.
         public ulong? new_id { get; set; }
+
+        // These come from osu_scores.
+        public ulong? high_score_id { get; set; }
+        public byte[]? scorechecksum { get; set; }
+
+        public bool ShouldPreserve => scorechecksum == null;
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
@@ -37,9 +37,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
         // ID of this score in the `scores` table. Used in join context.
         public ulong? new_id { get; set; }
 
-        // These come from osu_scores.
-        public ulong? high_score_id { get; set; }
+        // These come from osu_scores. If present, this is a non-high-score, ie. is sourced from the osu_scores table series.
         public byte[]? scorechecksum { get; set; }
+        public bool pass { get; set; } = true; // defaults true since osu_scores_high does not have this column (all scores are pass).
 
         public bool ShouldPreserve => scorechecksum == null;
     }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchScoresCommand.cs
@@ -32,8 +32,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
         public int RulesetId { get; set; }
 
         /// <summary>
-        /// When set to <c>true</c>, scores will not be queued to the score statistics processor,
-        /// instead being sent straight to the elasticsearch indexing queue.
+        /// When set to <c>true</c>, scores will not be queued to the score statistics processor.
         /// </summary>
         [Option(CommandOptionType.SingleOrNoValue, Template = "--skip-score-processor")]
         public bool SkipScoreProcessor { get; set; }
@@ -130,18 +129,15 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
         private void pushCompletedScoreToQueue(BatchInserter inserter)
         {
-            if (scoreStatisticsQueueProcessor != null)
+            if (scoreStatisticsQueueProcessor == null) return;
+
+            var scoreStatisticsItems = inserter.ScoreStatisticsItems.ToList();
+
+            if (scoreStatisticsItems.Any())
             {
-                Debug.Assert(inserter.ElasticScoreItems.Any());
-
-                var scoreStatisticsItems = inserter.ScoreStatisticsItems.ToList();
-
-                if (scoreStatisticsItems.Any())
-                {
-                    if (!DryRun)
-                        scoreStatisticsQueueProcessor.PushToQueue(scoreStatisticsItems);
-                    Console.WriteLine($"Queued {scoreStatisticsItems.Count} item(s) for statistics processing");
-                }
+                if (!DryRun)
+                    scoreStatisticsQueueProcessor.PushToQueue(scoreStatisticsItems);
+                Console.WriteLine($"Queued {scoreStatisticsItems.Count} item(s) for statistics processing");
             }
         }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchScoresCommand.cs
@@ -1,0 +1,190 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using McMaster.Extensions.CommandLineUtils;
+using osu.Game.Rulesets;
+using osu.Server.QueueProcessor;
+using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
+{
+    /// <summary>
+    /// Watches for new scores from the osu_scores tables and imports into the new scores table.
+    /// </summary>
+    /// <remarks>
+    /// This command is written under the assumption that only one importer instance is running concurrently.
+    /// This is important to guarantee that scores are inserted in the same sequential order that they originally occured,
+    /// which can be used for tie-breaker scenarios.
+    /// </remarks>
+    [Command("watch-scores", Description = "Watches for new (non-)high scores from the osu_scores tables and imports into the new scores table.")]
+    public class WatchScoresCommand
+    {
+        /// <summary>
+        /// The ruleset to run this import job for.
+        /// </summary>
+        [Option(CommandOptionType.SingleValue, Template = "--ruleset-id")]
+        public int RulesetId { get; set; }
+
+        /// <summary>
+        /// When set to <c>true</c>, scores will not be queued to the score statistics processor,
+        /// instead being sent straight to the elasticsearch indexing queue.
+        /// </summary>
+        [Option(CommandOptionType.SingleOrNoValue, Template = "--skip-score-processor")]
+        public bool SkipScoreProcessor { get; set; }
+
+        [Option(CommandOptionType.SingleOrNoValue, Template = "--dry-run")]
+        public bool DryRun { get; set; }
+
+        private long lastCommitTimestamp;
+        private long startupTimestamp;
+
+        private ScoreStatisticsQueueProcessor? scoreStatisticsQueueProcessor;
+
+        /// <summary>
+        /// The number of seconds between console progress reports.
+        /// </summary>
+        private const double seconds_between_report = 2;
+
+        private ulong lastScoreId;
+
+        private readonly DateTimeOffset startedAt = DateTimeOffset.Now;
+
+        public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
+        {
+            Ruleset ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(RulesetId);
+            string scoreTable = LegacyDatabaseHelper.GetRulesetSpecifics(RulesetId).ScoreTable;
+
+            using var db = DatabaseAccess.GetConnection();
+
+            if (!SkipScoreProcessor)
+            {
+                scoreStatisticsQueueProcessor = new ScoreStatisticsQueueProcessor();
+                Console.WriteLine($"Pushing imported scores to redis queue {scoreStatisticsQueueProcessor.QueueName}");
+            }
+
+            if (DryRun)
+                Console.WriteLine("RUNNING IN DRY RUN MODE.");
+
+            Console.WriteLine();
+            Console.WriteLine("Starting processing in 5 seconds...");
+            await Task.Delay(5000, cancellationToken);
+
+            using (var dbMainQuery = DatabaseAccess.GetConnection())
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    HighScore[] scores = (await dbMainQuery.QueryAsync<HighScore>(
+                            $"SELECT * FROM {scoreTable} "
+                            // A delay is applied here to be sure that high_score_id has been populated.
+                            // This is a safety as web-10 doesn't hold a transaction between the insert to `osu_scores` and `osu_scores_high`.
+                            // Worst case scenario is that a high score exists twice, once with missing `legacy_score_id`.
+                            + "WHERE score_id >= @lastScoreId AND date < DATE_SUB(NOW(), INTERVAL 5 SECOND) AND high_score_id IS NULL ORDER BY score_id LIMIT 50", new
+                            {
+                                lastScoreId = lastScoreId,
+                                RulesetId,
+                            }))
+                        .ToArray();
+
+                    if (scores.Length == 0)
+                    {
+                        Thread.Sleep(500);
+                        continue;
+                    }
+
+                    // Need to obtain score_id before zeroing them out.
+                    lastScoreId = scores.Last().score_id;
+
+                    foreach (var score in scores)
+                    {
+                        // For non-preserved flags, we zero the score_id.
+                        // This is because they come from a different table with a different range and it would be hard to track.
+                        if (!score.ShouldPreserve)
+                            score.score_id = 0;
+                    }
+
+                    var inserter = new BatchInserter(ruleset, scores, importLegacyPP: SkipScoreProcessor, dryRun: DryRun);
+
+                    while (!inserter.Task.IsCompleted)
+                    {
+                        outputProgress();
+                        Thread.Sleep(10);
+                    }
+
+                    if (inserter.Task.IsFaulted)
+                    {
+                        Console.WriteLine("ERROR: Inserter failed. Aborting for safety.");
+                        Console.WriteLine($"Running batches were processing up to {lastScoreId}.");
+                        Console.WriteLine();
+
+                        throw inserter.Task.Exception!;
+                    }
+
+                    pushCompletedScoreToQueue(inserter);
+
+                    Console.WriteLine($"Workers processed up to (score_id: {lastScoreId})");
+                    lastScoreId++;
+                }
+            }
+
+            outputFinalStats();
+            return 0;
+        }
+
+        private void pushCompletedScoreToQueue(BatchInserter inserter)
+        {
+            if (scoreStatisticsQueueProcessor != null)
+            {
+                Debug.Assert(inserter.ElasticScoreItems.Any());
+
+                var scoreStatisticsItems = inserter.ScoreStatisticsItems.ToList();
+
+                if (scoreStatisticsItems.Any())
+                {
+                    if (!DryRun)
+                        scoreStatisticsQueueProcessor.PushToQueue(scoreStatisticsItems);
+                    Console.WriteLine($"Queued {scoreStatisticsItems.Count} item(s) for statistics processing");
+                }
+            }
+        }
+
+        private void outputProgress()
+        {
+            long currentTimestamp = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+
+            if ((currentTimestamp - lastCommitTimestamp) / 1000f >= seconds_between_report)
+            {
+                int inserted = Interlocked.Exchange(ref BatchInserter.CurrentReportInsertCount, 0);
+                int deleted = Interlocked.Exchange(ref BatchInserter.CurrentReportDeleteCount, 0);
+
+                // Only set startup timestamp after first insert actual insert/update run to avoid weighting during catch-up.
+                if (inserted > 0 && startupTimestamp == 0)
+                    startupTimestamp = lastCommitTimestamp;
+
+                double secondsSinceStart = (double)(currentTimestamp - startupTimestamp) / 1000;
+                double processingRate = BatchInserter.TotalInsertCount / secondsSinceStart;
+
+                Console.WriteLine($"Inserting up to {lastScoreId:N0}: "
+                                  + $"{BatchInserter.TotalInsertCount:N0} ins {BatchInserter.TotalDeleteCount:N0} del {BatchInserter.TotalSkipCount:N0} skip (+{inserted:N0} new +{deleted:N0} del) {processingRate:N0}/s");
+
+                lastCommitTimestamp = currentTimestamp;
+            }
+        }
+
+        private void outputFinalStats()
+        {
+            Console.WriteLine();
+            Console.WriteLine();
+            Console.WriteLine($"Cancelled after {(DateTimeOffset.Now - startedAt).TotalSeconds} seconds.");
+            Console.WriteLine($"Final stats: {BatchInserter.TotalInsertCount} inserted, {BatchInserter.TotalSkipCount} skipped, {BatchInserter.TotalDeleteCount} deleted");
+            Console.WriteLine($"Resume from start id {lastScoreId}");
+            Console.WriteLine();
+            Console.WriteLine();
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchScoresCommand.cs
@@ -100,14 +100,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                     // Need to obtain score_id before zeroing them out.
                     lastScoreId = scores.Last().score_id;
 
-                    foreach (var score in scores)
-                    {
-                        // For non-preserved flags, we zero the score_id.
-                        // This is because they come from a different table with a different range and it would be hard to track.
-                        if (!score.ShouldPreserve)
-                            score.score_id = 0;
-                    }
-
                     var inserter = new BatchInserter(ruleset, scores, importLegacyPP: SkipScoreProcessor, dryRun: DryRun);
 
                     while (!inserter.Task.IsCompleted)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchScoresCommand.cs
@@ -60,6 +60,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
             using var db = DatabaseAccess.GetConnection();
 
+            lastScoreId = await db.QuerySingleAsync<ulong>($"SELECT MAX(score_id) FROM {scoreTable}");
+
             if (!SkipScoreProcessor)
             {
                 scoreStatisticsQueueProcessor = new ScoreStatisticsQueueProcessor();

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchScoresCommand.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/QueueCommands.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/QueueCommands.cs
@@ -14,6 +14,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands
     [Subcommand(typeof(ClearQueueCommand))]
     [Subcommand(typeof(WatchQueueCommand))]
     [Subcommand(typeof(ImportHighScoresCommand))]
+    [Subcommand(typeof(WatchScoresCommand))]
     [Subcommand(typeof(WatchHighScoresCommand))]
     public sealed class QueueCommands
     {


### PR DESCRIPTION
Until now, `osu_scores` table has been used to show "recent plays" on user profiles. This doesn't contain lazer scores.

To allow osu-web to read from only a single source of truth (the new `scores` table) we must import these scores from the old tables.

This watcher handles that process. It's written to be as simple as possible to get this out for the initial launch.

- This only handles non-high-scores. To make this work, there's a 5 second delay applied, to ensure that the `high_score_id` column has been populated by `osu-web-10` (it doesn't guard the insertion into `osu_scores` and `osu_scores_high` with a transaction, so this is best-effort).
- There's no gap / resume / whatever support. If this isn't running, scores are just not imported. These scores are throwaway (they get partition cycled and are only expected to be displayed for 24 hours), and the assumption is that these importers will be setup once and never fail. If that's not the case we can reconsider.
- `total_score` (ie. the converted one) may be 0 for some scores which don't have score attributes populated yet. We'll fix this later. Probably after users start noticing it.

Sorry for the fact that this makes `HighScore` even weirder. Is what it is I think.

This is already production tested and will be deployed ahead of this being merged.