### PR TITLE
Don't throw on failure to convert scores

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -49,6 +49,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
         private readonly bool importLegacyPP;
         private readonly bool dryRun;
+        private readonly bool throwOnFailure;
 
         public HighScore[] Scores { get; }
 
@@ -58,11 +59,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
         public List<ScoreItem> ScoreStatisticsItems { get; } = new List<ScoreItem>();
 
-        public BatchInserter(Ruleset ruleset, HighScore[] scores, bool importLegacyPP, bool dryRun = false)
+        public BatchInserter(Ruleset ruleset, HighScore[] scores, bool importLegacyPP, bool dryRun = false, bool throwOnFailure = true)
         {
             this.ruleset = ruleset;
             this.importLegacyPP = importLegacyPP;
             this.dryRun = dryRun;
+            this.throwOnFailure = throwOnFailure;
 
             Scores = scores;
             Task = Task.Run(() => run(scores));
@@ -164,7 +166,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                 }
                 catch (Exception e)
                 {
-                    throw new AggregateException($"Processing legacy score {highScore.score_id} failed.", e);
+                    if (throwOnFailure)
+                        throw new AggregateException($"Processing legacy score {highScore.score_id} failed.", e);
+
+                    Console.WriteLine($"Processing legacy score {highScore.score_id} failed.", e);
                 }
             });
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -169,7 +169,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                     if (throwOnFailure)
                         throw new AggregateException($"Processing legacy score {highScore.score_id} failed.", e);
 
-                    Console.WriteLine($"Processing legacy score {highScore.score_id} failed.", e);
+                    Console.WriteLine($"Processing legacy score {highScore.score_id} failed.");
                 }
             });
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchScoresCommand.cs
@@ -100,7 +100,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                     // Need to obtain score_id before zeroing them out.
                     lastScoreId = scores.Last().score_id;
 
-                    var inserter = new BatchInserter(ruleset, scores, importLegacyPP: SkipScoreProcessor, dryRun: DryRun);
+                    var inserter = new BatchInserter(ruleset, scores, importLegacyPP: SkipScoreProcessor, dryRun: DryRun, throwOnFailure: false);
 
                     while (!inserter.Task.IsCompleted)
                     {


### PR DESCRIPTION
All failed scores are failing right now in osu! mode.

This is just a workaround until we fix the underlying issue.

Tracking at https://github.com/ppy/osu-queue-score-statistics/issues/209