### PR TITLE
Make verify command faster by bypassing second-level data lookup

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
@@ -46,6 +46,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
         private ElasticQueuePusher? elasticQueueProcessor;
 
+        private int skipOutput;
+
         public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
         {
             var rulesetSpecifics = LegacyDatabaseHelper.GetRulesetSpecifics(RulesetId);
@@ -103,8 +105,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
                     lastId += (ulong)BatchSize;
 
-                    if (lastId % (ulong)BatchSize * 100 == 0)
-                        Console.Write(".");
+                    if (++skipOutput % 100 == 0)
+                        Console.WriteLine($"Skipped up to {lastId}...");
                     continue;
                 }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
@@ -134,7 +134,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                         if (importedScore.legacy_score_id == null) continue;
 
                         // Score was deleted in legacy table.
-                        if (importedScore.HighScore == null)
+                        //
+                        // Importantly, `legacy_score_id` of 0 implies a non-high-score (which doesn't have a matching entry).
+                        // We should leave these.
+                        if (importedScore.HighScore == null && importedScore.legacy_score_id > 0)
                         {
                             Interlocked.Increment(ref deleted);
                             requiresIndexing = true;


### PR DESCRIPTION
Unfortunately requires to be per-ruleset now, but can run much faster. At least in delete mode.