### PR TITLE
Order by `score_id` instead of `queue_id`

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
@@ -133,7 +133,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                                                  }))
                                              // there might be multiple queue entries for the same insert. this can cause issues due to how we do the mapping lookup so let's fix that.
                                              .DistinctBy(s => s.score_id)
-                                             .OrderBy(s => s.score)
+                                             .OrderBy(s => s.score_id)
                                              .ToArray();
 
                     var pendingProcessing = highScores.FirstOrDefault(s => s.status == 0);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
@@ -133,7 +133,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                                                  }))
                                              // there might be multiple queue entries for the same insert. this can cause issues due to how we do the mapping lookup so let's fix that.
                                              .DistinctBy(s => s.score_id)
-                                             .OrderBy(s => s.queue_id)
+                                             .OrderBy(s => s.score)
                                              .ToArray();
 
                     var pendingProcessing = highScores.FirstOrDefault(s => s.status == 0);


### PR DESCRIPTION
Probably never going to actually be an issue, but this is more correct. Basically as there's no transaction around the score and queue insert during web-10 score submission, two submissions could execute in a different ordering. We should preserve `score_id` ordering as much as possible.
