### PR TITLE
Fix incorrect queue ID accounting in high scores command

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
@@ -170,10 +170,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
                     pushCompletedScoreToQueue(inserter);
 
-                    var lastScore = highScores.Last();
-
-                    lastQueueId = lastScore.queue_id!.Value;
-                    Console.WriteLine($"Workers processed up to (score_id: {lastScore.score_id} queue_id: {lastQueueId})");
+                    var lastScoreId = highScores.Last().score_id;
+                    lastQueueId = highScores.Max(score => score.queue_id!.Value);
+                    Console.WriteLine($"Workers processed up to (score_id: {lastScoreId} queue_id: {lastQueueId})");
                     lastQueueId++;
                 }
             }


### PR DESCRIPTION
Oversight from https://github.com/ppy/osu-queue-score-statistics/pull/214

If there is no guarantee that `score_id` and `queue_id` are monotonic with respect to one another, then taking the last score's `queue_id` as the max queue ID for the batch after sorting by `score_id` is incorrect.