### PR TITLE
Use reintroduced `IMod.Ranked` property from game to determine eligibility of score for pp

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "nvika": {
-      "version": "2.2.0",
+      "version": "3.0.0",
       "commands": [
         "nvika"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "jetbrains.resharper.globaltools": {
-      "version": "2022.3.2",
+      "version": "2023.3.3",
       "commands": [
         "jb"
       ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,19 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      # FIXME: Tools won't run in .NET 6.0 unless you install 3.1.x LTS side by side.
-      # https://itnext.io/how-to-support-multiple-net-sdks-in-github-actions-workflows-b988daa884e
-      - name: Install .NET 3.1.x LTS
-        uses: actions/setup-dotnet@v1
+      - name: Install .NET 8.0.x
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: "3.1.x"
-
-      - name: Install .NET 6.0.x
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: "6.0.x"
+          dotnet-version: "8.0.x"
 
       - name: Restore Tools
         run: dotnet tool restore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install .NET 6.0.x
+      - name: Install .NET 8.0.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "6.0.x"
+          dotnet-version: "8.0.x"
 
       - name: Docker compose
         run: docker compose up -d

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/osu.Server.Queues.ScoreStatisticsProcessor.Tests.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/osu.Server.Queues.ScoreStatisticsProcessor.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/osu.Server.Queues.ScoreStatisticsProcessor.sln.DotSettings
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.sln.DotSettings
@@ -127,6 +127,8 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleInterfaceMemberAmbiguity/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleMultipleEnumeration/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PrivateVariableCanBeMadeReadonly/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PropertyCanBeMadeInitOnly_002EGlobal/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PropertyCanBeMadeInitOnly_002ELocal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PublicConstructorInAbstractClass/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantAnonymousTypePropertyName/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantArgumentDefaultValue/@EntryIndexedValue">HINT</s:String>
@@ -142,6 +144,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantExplicitParamsArrayCreation/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantImmediateDelegateInvocation/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantLambdaSignatureParentheses/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantTypeDeclarationBody/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantTypeSpecificationInDefaultExpression/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantLinebreak/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantSpace/@EntryIndexedValue">WARNING</s:String>

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Dockerfile
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -12,7 +12,7 @@ RUN dotnet publish -c Release -o out
 RUN rm -rf ./out/runtimes ./out/osu.Game.Resources.dll
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/runtime:6.0
+FROM mcr.microsoft.com/dotnet/runtime:8.0
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "osu.Server.Queues.ScoreStatisticsProcessor.dll"]

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
@@ -9,9 +10,7 @@ using MySqlConnector;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Difficulty;
-using osu.Game.Rulesets.Mania.Mods;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Scoring;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
@@ -199,56 +198,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         /// </summary>
         public static bool AllModsValidForPerformance(SoloScoreInfo score, Mod[] mods)
         {
-            foreach (var m in mods)
-            {
-                switch (m)
-                {
-                    // Overrides for mods which would otherwise be allowed by the block below.
-                    case ManiaModHardRock:
-                    case ManiaModKey1:
-                    case ManiaModKey2:
-                    case ManiaModKey3:
-                    case ManiaModKey10:
-                        return false;
+            IEnumerable<Mod> modsToCheck = mods;
 
-                    // The mods which are allowed.
-                    case ModEasy:
-                    case ModNoFail:
-                    case ModSuddenDeath:
-                    case ModPerfect:
-                    case ModHardRock:
-                    case ModHidden:
-                    case ModFlashlight:
-                    case ModMuted:
-                    case ModNightcore:
-                    case ModDoubleTime:
-                    case ModDaycore:
-                    case ModHalfTime:
-                    // osu!-specific:
-                    case OsuModSpunOut:
-                    case OsuModTouchDevice:
-                    // mania-specific:
-                    case ManiaKeyMod:
-                    case ManiaModMirror:
-                        break;
+            // Classic mod is only allowed on legacy scores.
+            if (score.IsLegacyScore)
+                modsToCheck = mods.Where(mod => mod is not ModClassic);
 
-                    // Classic mod is only allowed on legacy scores.
-                    case ModClassic:
-                        if (!score.IsLegacyScore)
-                            return false;
-
-                        break;
-
-                    // Any other mods not in the above list aren't allowed.
-                    default:
-                        return false;
-                }
-
-                if (!m.UsesDefaultConfiguration)
-                    return false;
-            }
-
-            return true;
+            return modsToCheck.All(m => m.Ranked);
         }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <RootNamespace>osu.Server.Queues.ScoreStatisticsProcessor</RootNamespace>
         <AssemblyName>osu.Server.Queues.ScoreStatisticsProcessor</AssemblyName>

--- a/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
@@ -12,11 +12,11 @@
         <PackageReference Include="Dapper" Version="2.1.28" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.0" />
-        <PackageReference Include="ppy.osu.Game" Version="2024.124.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.124.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.124.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.124.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.124.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2024.210.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.210.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.210.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.210.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.210.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2023.1207.0" />
     </ItemGroup>
 


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/26934
- [x] Loosely depends on https://github.com/ppy/osu/pull/26935 (just to save on ceremony)
- [x] Depends on game package w/ above

Note classic mod carve-out. This is [covered by tests](https://github.com/ppy/osu-queue-score-statistics/blob/2264bfa68e14bb16ec71a7cac2072bdcfaf565b6/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs#L231-L241).