### PR TITLE
Change verify command to support batched writes

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
@@ -34,6 +34,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
         [Option(CommandOptionType.SingleValue, Template = "--ruleset-id")]
         public int RulesetId { get; set; }
 
+        [Option(CommandOptionType.SingleOrNoValue, Template = "-v|--verbose", Description = "Output when a score is preserved too.")]
+        public bool Verbose { get; set; }
+
         /// <summary>
         /// The number of scores to run in each batch. Setting this higher will cause larger SQL statements for insert.
         /// </summary>
@@ -285,7 +288,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
             if (imported?.Equals(original) != true)
             {
-                Console.WriteLine($"{scoreId}: {name} doesn't match ({imported} vs {original})");
+                if (Verbose)
+                    Console.WriteLine($"{scoreId}: {name} doesn't match ({imported} vs {original})");
                 return false;
             }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
@@ -263,11 +263,16 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
         private void flush(MySqlConnection conn, bool force = false)
         {
-            if (sqlBuffer.Length > 1024 || force)
+            int bufferLength = sqlBuffer.Length;
+
+            if (bufferLength == 0)
+                return;
+
+            if (bufferLength > 1024 || force)
             {
                 if (!DryRun)
                 {
-                    Console.WriteLine($"Flushing sql batch ({sqlBuffer.Length:N0} bytes)");
+                    Console.WriteLine($"Flushing sql batch ({bufferLength:N0} bytes)");
                     conn.Execute(sqlBuffer.ToString());
                 }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
@@ -58,13 +58,16 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
             using var conn = DatabaseAccess.GetConnection();
 
-            lastId = await conn.QuerySingleAsync<ulong?>(
-                "SELECT id FROM scores WHERE ruleset_id = @rulesetId AND legacy_score_id = (SELECT MIN(legacy_score_id) FROM scores WHERE ruleset_id = @rulesetId AND id >= @lastId AND legacy_score_id > 0)",
-                new
-                {
-                    lastId,
-                    rulesetId = RulesetId,
-                }) ?? lastId;
+            if (lastId == 0)
+            {
+                lastId = await conn.QuerySingleAsync<ulong?>(
+                    "SELECT id FROM scores WHERE ruleset_id = @rulesetId AND legacy_score_id = (SELECT MIN(legacy_score_id) FROM scores WHERE ruleset_id = @rulesetId AND id >= @lastId AND legacy_score_id > 0)",
+                    new
+                    {
+                        lastId,
+                        rulesetId = RulesetId,
+                    }) ?? lastId;
+            }
 
             Console.WriteLine();
             Console.WriteLine($"Verifying scores starting from {lastId} for ruleset {RulesetId}");

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
@@ -99,7 +99,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                     + "s.`pp`, "
                     + "h.* "
                     + "FROM scores s "
-                    + $"LEFT JOIN {rulesetSpecifics.HighScoreTable} h ON (legacy_score_id = score_id)"
+                    + $"LEFT JOIN {rulesetSpecifics.HighScoreTable} h ON (legacy_score_id = score_id) "
                     + "WHERE id BETWEEN @lastId AND (@lastId + @batchSize - 1) AND legacy_score_id IS NOT NULL AND ruleset_id = @rulesetId ORDER BY id",
                     (ComparableScore score, HighScore highScore) =>
                     {
@@ -127,8 +127,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                         Console.WriteLine($"Skipped up to {lastId}...");
                     continue;
                 }
-
-                elasticItems.Clear();
 
                 if (!DeleteOnly)
                 {
@@ -270,6 +268,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                         if (!DryRun)
                             elasticQueueProcessor.PushToQueue(elasticItems.ToList());
                         Console.WriteLine($"Queued {elasticItems.Count} items for indexing");
+                        elasticItems.Clear();
                     }
                 }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
@@ -239,8 +239,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                     }
                 }
 
-                Console.SetCursorPosition(0, Console.GetCursorPosition().Top);
                 Console.Write($"Processed up to {importedScores.Max(s => s.id)} ({deleted} deleted {fail} failed)");
+                Console.SetCursorPosition(0, Console.GetCursorPosition().Top);
 
                 lastId += (ulong)BatchSize;
                 flush(conn);
@@ -262,6 +262,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
             {
                 if (!DryRun)
                 {
+                    Console.WriteLine();
                     Console.WriteLine($"Flushing sql batch ({bufferLength:N0} bytes)");
                     conn.Execute(sqlBuffer.ToString());
 
@@ -284,7 +285,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
             if (imported?.Equals(original) != true)
             {
-                Console.WriteLine();
                 Console.WriteLine($"{scoreId}: {name} doesn't match ({imported} vs {original})");
                 return false;
             }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
@@ -265,8 +265,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
                     if (elasticItems.Count > 0)
                     {
-                        if (!DryRun)
-                            elasticQueueProcessor.PushToQueue(elasticItems.ToList());
+                        elasticQueueProcessor.PushToQueue(elasticItems.ToList());
                         Console.WriteLine($"Queued {elasticItems.Count} items for indexing");
                         elasticItems.Clear();
                     }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
@@ -186,12 +186,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                             Interlocked.Increment(ref fail);
                             requiresIndexing = true;
 
-                            // PP was reset (had a value in new table but no value in old).
-                            if (importedScore.HighScore.pp == null)
-                                sqlBuffer.Append($"UPDATE scores SET pp = NULL WHERE id = {importedScore.id};");
-                            // PP doesn't match.
-                            else
-                                sqlBuffer.Append($"UPDATE scores SET pp = {importedScore.HighScore.pp} WHERE id = {importedScore.id};");
+                            // PP was reset (had a value in new table but no value in old) or doesn't match.
+                            sqlBuffer.Append($"UPDATE scores SET pp = {importedScore.HighScore.pp.ToString() ?? "NULL"} WHERE id = {importedScore.id};");
                         }
 
                         if (!check(importedScore.id, "replay", importedScore.has_replay, importedScore.HighScore.replay))


### PR DESCRIPTION
I'd been meaning to do this for a while now, in order to allow rewriting ranks to the correct equations, something I've not been able to do due to the overhead of individual SQL writes in this command.

I already have this stabilised and running on production, updating around 3,000 rows per second (ample for this kind of operation).