### PR TITLE
Stop marking scores as `ranked = 0` for pp only purposes

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
@@ -309,14 +309,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 score.Score.preserve = true;
             });
 
-            WaitForDatabaseState("SELECT COUNT(*) FROM scores WHERE id = @ScoreId AND ranked = 0", 1, CancellationToken, new
+            WaitForDatabaseState("SELECT COUNT(*) FROM scores WHERE id = @ScoreId AND pp IS NULL", 1, CancellationToken, new
             {
                 ScoreId = score.Score.id
             });
         }
 
         [Fact]
-        public void ScoresThatHavePpButInvalidModsIsNotRanked()
+        public void ScoresThatHavePpButInvalidModsGetsNoPP()
         {
             AddBeatmap();
             AddBeatmapAttributes<OsuDifficultyAttributes>();
@@ -332,7 +332,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 score.Score.accuracy = 1;
                 score.Score.build_id = TestBuildID;
                 score.Score.ScoreData.Mods = new[] { new APIMod(new InvalidMod()) };
-                score.Score.pp = 1;
                 score.Score.preserve = true;
 
                 conn.Insert(score.Score);
@@ -340,7 +339,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 PushToQueueAndWaitForProcess(score);
             }
 
-            WaitForDatabaseState("SELECT COUNT(*) FROM scores WHERE id = @ScoreId AND ranked = 0", 1, CancellationToken, new
+            WaitForDatabaseState("SELECT COUNT(*) FROM scores WHERE id = @ScoreId AND pp IS NULL", 1, CancellationToken, new
             {
                 ScoreId = score.Score.id
             });

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -125,26 +125,16 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 Beatmap? beatmap = await beatmapStore.GetBeatmapAsync((uint)score.BeatmapID, connection, transaction);
 
                 if (beatmap == null)
-                {
-                    await markNonRanked();
-
                     return;
-                }
 
                 if (!beatmapStore.IsBeatmapValidForPerformance(beatmap, (uint)score.RulesetID))
-                {
-                    await markNonRanked();
                     return;
-                }
 
                 Ruleset ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(score.RulesetID);
                 Mod[] mods = score.Mods.Select(m => m.ToMod(ruleset)).ToArray();
 
                 if (!AllModsValidForPerformance(score, mods))
-                {
-                    await markNonRanked();
                     return;
-                }
 
                 APIBeatmap apiBeatmap = beatmap.ToAPIBeatmap();
                 DifficultyAttributes? difficultyAttributes = await beatmapStore.GetDifficultyAttributesAsync(apiBeatmap, ruleset, mods, connection, transaction);
@@ -152,25 +142,16 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 // Performance needs to be allowed for the build.
                 // legacy scores don't need a build id
                 if (score.LegacyScoreId == null && (score.BuildID == null || buildStore.GetBuild(score.BuildID.Value)?.allow_performance != true))
-                {
-                    await markNonRanked();
                     return;
-                }
 
                 if (difficultyAttributes == null)
-                {
-                    await markNonRanked();
                     return;
-                }
 
                 ScoreInfo scoreInfo = score.ToScoreInfo(mods, apiBeatmap);
                 PerformanceAttributes? performanceAttributes = ruleset.CreatePerformanceCalculator()?.Calculate(scoreInfo, difficultyAttributes);
 
                 if (performanceAttributes == null)
-                {
-                    await markNonRanked();
                     return;
-                }
 
                 await connection.ExecuteAsync("UPDATE scores SET pp = @Pp WHERE id = @ScoreId", new
                 {
@@ -181,15 +162,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             catch (Exception ex)
             {
                 await Console.Error.WriteLineAsync($"{score.ID} failed with: {ex}");
-            }
-
-            // TODO: this should probably just update the model once we switch to SoloScore (the local updated class).
-            Task<int> markNonRanked()
-            {
-                return connection.ExecuteAsync("UPDATE scores SET ranked = 0 WHERE id = @ScoreId", new
-                {
-                    ScoreId = score.ID,
-                }, transaction: transaction);
             }
         }
 


### PR DESCRIPTION
We use this flag for cases where scores should not be considered for PP or leaderboards now. Cases where PP is not required simply leaves it as null.