### PR TITLE
Fix play count processor not incrementing pass count

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
@@ -100,6 +100,15 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                     beatmapSetId = score.Beatmap.OnlineBeatmapSetID
                 }, transaction);
 
+                if (score.Passed)
+                {
+                    conn.Execute("UPDATE osu_beatmaps SET passcount = passcount + @increment WHERE beatmap_id = @beatmapId", new
+                    {
+                        increment,
+                        beatmapId = score.BeatmapID
+                    }, transaction);
+                }
+
                 // Reindex beatmap occasionally.
                 if (RNG.Next(0, 10) == 0)
                     LegacyDatabaseHelper.RunLegacyIO("indexing/bulk", "POST", $"beatmapset[]={score.Beatmap.OnlineBeatmapSetID}");


### PR DESCRIPTION
Intends to fix https://github.com/ppy/osu/issues/27485 for new incoming scores. I don't know what happens to existing scores. Is there a tool that can recompute these already maybe?

As far as I can tell the implementation of this should match `osu-web-10`. It makes *some* sense to me when I squint at it, but I'm not super sure.