### PR TITLE
Fix failed plays being included in pack medal query

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
@@ -62,11 +62,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             addPackMedal(medal_id, pack_id, new[] { beatmap });
 
             assertNoneAwarded();
-            SetScoreForBeatmap(beatmap.beatmap_id);
+            SetScoreForBeatmap(beatmap.beatmap_id, s => s.Score.preserve = true);
 
             assertAwarded(medal_id);
 
-            SetScoreForBeatmap(beatmap.beatmap_id);
+            SetScoreForBeatmap(beatmap.beatmap_id, s => s.Score.preserve = true);
             assertAwarded(medal_id);
         }
 
@@ -105,10 +105,18 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             assertNoneAwarded();
 
-            SetScoreForBeatmap(firstBeatmap.beatmap_id, s => s.Score.passed = false);
+            SetScoreForBeatmap(firstBeatmap.beatmap_id, s =>
+            {
+                s.Score.passed = false;
+                s.Score.preserve = false;
+            });
             assertNoneAwarded();
 
-            SetScoreForBeatmap(secondBeatmap.beatmap_id);
+            SetScoreForBeatmap(secondBeatmap.beatmap_id, s =>
+            {
+                s.Score.passed = true;
+                s.Score.preserve = true;
+            });
             assertNoneAwarded();
         }
 
@@ -149,7 +157,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             foreach (var beatmap in allBeatmaps)
             {
                 assertNoneAwarded();
-                SetScoreForBeatmap(beatmap.beatmap_id, s => s.Score.ended_at = DateTimeOffset.Now.AddMinutes(minutesOffset++));
+                SetScoreForBeatmap(beatmap.beatmap_id, s =>
+                {
+                    s.Score.ended_at = DateTimeOffset.Now.AddMinutes(minutesOffset++);
+                    s.Score.preserve = true;
+                });
             }
 
             assertAwarded(medal_id);
@@ -195,7 +207,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             foreach (var beatmap in beatmaps)
             {
                 assertNoneAwarded();
-                SetScoreForBeatmap(beatmap.beatmap_id);
+                SetScoreForBeatmap(beatmap.beatmap_id, s => s.Score.preserve = true);
             }
 
             // Awarding should only happen after the final set is hit.
@@ -217,14 +229,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             addPackMedal(medal_id, pack_id, new[] { beatmap1, beatmap2 });
 
-            SetScoreForBeatmap(beatmap1.beatmap_id);
+            SetScoreForBeatmap(beatmap1.beatmap_id, s => s.Score.preserve = true);
             assertNoneAwarded();
-            SetScoreForBeatmap(beatmap1.beatmap_id);
+            SetScoreForBeatmap(beatmap1.beatmap_id, s => s.Score.preserve = true);
             assertNoneAwarded();
-            SetScoreForBeatmap(beatmap1.beatmap_id);
+            SetScoreForBeatmap(beatmap1.beatmap_id, s => s.Score.preserve = true);
             assertNoneAwarded();
 
-            SetScoreForBeatmap(beatmap2.beatmap_id);
+            SetScoreForBeatmap(beatmap2.beatmap_id, s => s.Score.preserve = true);
             assertAwarded(medal_id);
         }
 
@@ -255,7 +267,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             foreach (var beatmap in allBeatmaps)
             {
                 assertNoneAwarded();
-                SetScoreForBeatmap(beatmap.beatmap_id, s => s.Score.ScoreData.Mods = new[] { new APIMod(new OsuModEasy()) });
+                SetScoreForBeatmap(beatmap.beatmap_id, s =>
+                {
+                    s.Score.ScoreData.Mods = new[] { new APIMod(new OsuModEasy()) };
+                    s.Score.preserve = true;
+                });
             }
 
             // Even after completing all beatmaps with easy mod, the pack medal is not awarded.
@@ -264,7 +280,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             foreach (var beatmap in allBeatmaps)
             {
                 assertNoneAwarded();
-                SetScoreForBeatmap(beatmap.beatmap_id, s => s.Score.ScoreData.Mods = new[] { new APIMod(new OsuModDoubleTime()) });
+                SetScoreForBeatmap(beatmap.beatmap_id, s =>
+                {
+                    s.Score.ScoreData.Mods = new[] { new APIMod(new OsuModDoubleTime()) };
+                    s.Score.preserve = true;
+                });
             }
 
             // Only after completing each beatmap again without easy mod (double time arbitrarily added to mix things up)

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
@@ -90,6 +90,29 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         }
 
         /// <summary>
+        /// The pack awarder should skip scores that are failed.
+        /// </summary>
+        [Fact]
+        public void TestPackMedalsDoNotIncludePreviousFails()
+        {
+            var firstBeatmap = AddBeatmap(b => b.beatmap_id = 1234, s => s.beatmapset_id = 4321);
+            var secondBeatmap = AddBeatmap(b => b.beatmap_id = 5678, s => s.beatmapset_id = 8765);
+
+            const int medal_id = 7;
+            const int pack_id = 40;
+
+            addPackMedal(medal_id, pack_id, new[] { firstBeatmap, secondBeatmap });
+
+            assertNoneAwarded();
+
+            SetScoreForBeatmap(firstBeatmap.beatmap_id, s => s.Score.passed = false);
+            assertNoneAwarded();
+
+            SetScoreForBeatmap(secondBeatmap.beatmap_id);
+            assertNoneAwarded();
+        }
+
+        /// <summary>
         /// This tests the simplest case of a medal being awarded for completing a pack.
         /// This mimics the "video game" pack, but is intended to test the process rather than the
         /// content of that pack specifically.

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
@@ -271,12 +271,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
                 }
 
                 // TODO: no index on (beatmap_id, user_id) may mean this is too slow.
+                // note that the `preserve = 1` condition relies on the flag being set before score processing (https://github.com/ppy/osu-web/pull/10946).
                 int completed = context.Connection.QuerySingle<int>(
                     "SELECT COUNT(distinct p.beatmapset_id)"
                     + "FROM osu_beatmappacks_items p "
                     + "JOIN osu_beatmaps b USING (beatmapset_id) "
                     + "JOIN scores s USING (beatmap_id)"
-                    + $"WHERE s.user_id = {context.Score.UserID} AND s.passed = 1 AND pack_id = {packId} {rulesetCriteria} {modsCriteria}", transaction: context.Transaction);
+                    + $"WHERE s.user_id = {context.Score.UserID} AND s.passed = 1 AND s.preserve = 1 AND pack_id = {packId} {rulesetCriteria} {modsCriteria}", transaction: context.Transaction);
 
                 int countForPack = context.Connection.QuerySingle<int>($"SELECT COUNT(*) FROM `osu_beatmappacks_items` WHERE pack_id = {packId}", transaction: context.Transaction);
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
@@ -276,7 +276,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
                     + "FROM osu_beatmappacks_items p "
                     + "JOIN osu_beatmaps b USING (beatmapset_id) "
                     + "JOIN scores s USING (beatmap_id)"
-                    + $"WHERE s.user_id = {context.Score.UserID} AND pack_id = {packId} {rulesetCriteria} {modsCriteria}", transaction: context.Transaction);
+                    + $"WHERE s.user_id = {context.Score.UserID} AND s.passed = 1 AND pack_id = {packId} {rulesetCriteria} {modsCriteria}", transaction: context.Transaction);
 
                 int countForPack = context.Connection.QuerySingle<int>($"SELECT COUNT(*) FROM `osu_beatmappacks_items` WHERE pack_id = {packId}", transaction: context.Transaction);
 


### PR DESCRIPTION
The fact that *this* awarder is the one with the most issues despite being in source for months now is ironic.

As far as I can tell `passed = 1` is the only viable condition here? `ranked = 0` seems useless although I'm not sure what that flag means anymore (I think its goal is now to be set to 0 when a map exits qualified, and most maps in packs are ranked already?) and I'm not sure `preserved = 1` is doing anything right now?

I'm not sure if the indices are able to support this query. Probably needs a safety check.