### PR TITLE
Exclude more mods from challenge pack medals

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
@@ -59,19 +59,19 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         /// </summary>
         [Theory]
         [MemberData(nameof(MEDAL_PACK_IDS))]
-        public void TestOnlyAwardsOnce(int medal_id, int pack_id)
+        public void TestOnlyAwardsOnce(int medalId, int packId)
         {
             var beatmap = AddBeatmap();
 
-            addPackMedal(medal_id, pack_id, new[] { beatmap });
+            addPackMedal(medalId, packId, new[] { beatmap });
 
             assertNoneAwarded();
             SetScoreForBeatmap(beatmap.beatmap_id, s => s.Score.preserve = true);
 
-            assertAwarded(medal_id);
+            assertAwarded(medalId);
 
             SetScoreForBeatmap(beatmap.beatmap_id, s => s.Score.preserve = true);
-            assertAwarded(medal_id);
+            assertAwarded(medalId);
         }
 
         /// <summary>
@@ -79,11 +79,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         /// </summary>
         [Theory]
         [MemberData(nameof(MEDAL_PACK_IDS))]
-        public void TestDoesNotAwardOnFailedScores(int medal_id, int pack_id)
+        public void TestDoesNotAwardOnFailedScores(int medalId, int packId)
         {
             var beatmap = AddBeatmap();
 
-            addPackMedal(medal_id, pack_id, new[] { beatmap });
+            addPackMedal(medalId, packId, new[] { beatmap });
 
             assertNoneAwarded();
             SetScoreForBeatmap(beatmap.beatmap_id, s => s.Score.passed = false);
@@ -96,12 +96,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         /// </summary>
         [Theory]
         [MemberData(nameof(MEDAL_PACK_IDS))]
-        public void TestPackMedalsDoNotIncludePreviousFails(int medal_id, int pack_id)
+        public void TestPackMedalsDoNotIncludePreviousFails(int medalId, int packId)
         {
             var firstBeatmap = AddBeatmap(b => b.beatmap_id = 1234, s => s.beatmapset_id = 4321);
             var secondBeatmap = AddBeatmap(b => b.beatmap_id = 5678, s => s.beatmapset_id = 8765);
 
-            addPackMedal(medal_id, pack_id, new[] { firstBeatmap, secondBeatmap });
+            addPackMedal(medalId, packId, new[] { firstBeatmap, secondBeatmap });
 
             assertNoneAwarded();
 
@@ -127,7 +127,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         /// </summary>
         [Theory]
         [MemberData(nameof(MEDAL_PACK_IDS))]
-        public void TestSimplePack(int medal_id, int pack_id)
+        public void TestSimplePack(int medalId, int packId)
         {
             var allBeatmaps = new[]
             {
@@ -147,7 +147,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 AddBeatmap(b => b.beatmap_id = 497769, s => s.beatmapset_id = 211704),
             };
 
-            addPackMedal(medal_id, pack_id, allBeatmaps);
+            addPackMedal(medalId, packId, allBeatmaps);
 
             // Need to space out submissions else we will hit rate limits.
             int minutesOffset = -allBeatmaps.Length;
@@ -162,7 +162,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 });
             }
 
-            assertAwarded(medal_id);
+            assertAwarded(medalId);
 
             WaitForDatabaseState("SELECT playcount FROM osu_user_stats WHERE user_id = 2", allBeatmaps.Length, CancellationToken);
         }
@@ -174,7 +174,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         /// </summary>
         [Theory]
         [MemberData(nameof(MEDAL_PACK_IDS))]
-        public void TestPlayMultipleBeatmapsFromSameSetDoesNotAward(int medal_id, int pack_id)
+        public void TestPlayMultipleBeatmapsFromSameSetDoesNotAward(int medalId, int packId)
         {
             const int beatmapset_id = 13022;
 
@@ -199,7 +199,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             Assert.Equal(4, beatmaps.Count);
 
-            addPackMedal(medal_id, pack_id, beatmaps);
+            addPackMedal(medalId, packId, beatmaps);
 
             foreach (var beatmap in beatmaps)
             {
@@ -208,7 +208,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             }
 
             // Awarding should only happen after the final set is hit.
-            assertAwarded(medal_id);
+            assertAwarded(medalId);
         }
 
         /// <summary>
@@ -217,12 +217,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         /// </summary>
         [Theory]
         [MemberData(nameof(MEDAL_PACK_IDS))]
-        public void TestPlayMultipleTimeOnSameSetDoesNotAward(int medal_id, int pack_id)
+        public void TestPlayMultipleTimeOnSameSetDoesNotAward(int medalId, int packId)
         {
             var beatmap1 = AddBeatmap(b => b.beatmap_id = 71623, s => s.beatmapset_id = 13022);
             var beatmap2 = AddBeatmap(b => b.beatmap_id = 59225, s => s.beatmapset_id = 16520);
 
-            addPackMedal(medal_id, pack_id, new[] { beatmap1, beatmap2 });
+            addPackMedal(medalId, packId, new[] { beatmap1, beatmap2 });
 
             SetScoreForBeatmap(beatmap1.beatmap_id, s => s.Score.preserve = true);
             assertNoneAwarded();
@@ -232,7 +232,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             assertNoneAwarded();
 
             SetScoreForBeatmap(beatmap2.beatmap_id, s => s.Score.preserve = true);
-            assertAwarded(medal_id);
+            assertAwarded(medalId);
         }
 
         /// <summary>

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
@@ -47,17 +47,21 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         /// </summary>
         private static uint getNextBeatmapId() => (uint)Interlocked.Increment(ref lastBeatmapId);
 
+        public static readonly object[][] MEDAL_PACK_IDS =
+        {
+            [7, 40], // Normal pack
+            [267, 2036], // Challenge pack
+        };
+
         /// <summary>
         /// The medal processor should skip medals which have already been awarded.
         /// There are no medals which should trigger more than once.
         /// </summary>
-        [Fact]
-        public void TestOnlyAwardsOnce()
+        [Theory]
+        [MemberData(nameof(MEDAL_PACK_IDS))]
+        public void TestOnlyAwardsOnce(int medal_id, int pack_id)
         {
             var beatmap = AddBeatmap();
-
-            const int medal_id = 7;
-            const int pack_id = 40;
 
             addPackMedal(medal_id, pack_id, new[] { beatmap });
 
@@ -73,13 +77,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         /// <summary>
         /// The pack awarder should skip scores that are failed.
         /// </summary>
-        [Fact]
-        public void TestDoesNotAwardOnFailedScores()
+        [Theory]
+        [MemberData(nameof(MEDAL_PACK_IDS))]
+        public void TestDoesNotAwardOnFailedScores(int medal_id, int pack_id)
         {
             var beatmap = AddBeatmap();
-
-            const int medal_id = 7;
-            const int pack_id = 40;
 
             addPackMedal(medal_id, pack_id, new[] { beatmap });
 
@@ -92,14 +94,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         /// <summary>
         /// The pack awarder should skip scores that are failed.
         /// </summary>
-        [Fact]
-        public void TestPackMedalsDoNotIncludePreviousFails()
+        [Theory]
+        [MemberData(nameof(MEDAL_PACK_IDS))]
+        public void TestPackMedalsDoNotIncludePreviousFails(int medal_id, int pack_id)
         {
             var firstBeatmap = AddBeatmap(b => b.beatmap_id = 1234, s => s.beatmapset_id = 4321);
             var secondBeatmap = AddBeatmap(b => b.beatmap_id = 5678, s => s.beatmapset_id = 8765);
-
-            const int medal_id = 7;
-            const int pack_id = 40;
 
             addPackMedal(medal_id, pack_id, new[] { firstBeatmap, secondBeatmap });
 
@@ -125,12 +125,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         /// This mimics the "video game" pack, but is intended to test the process rather than the
         /// content of that pack specifically.
         /// </summary>
-        [Fact]
-        public void TestSimplePack()
+        [Theory]
+        [MemberData(nameof(MEDAL_PACK_IDS))]
+        public void TestSimplePack(int medal_id, int pack_id)
         {
-            const int medal_id = 7;
-            const int pack_id = 40;
-
             var allBeatmaps = new[]
             {
                 AddBeatmap(b => b.beatmap_id = 71621, s => s.beatmapset_id = 13022),
@@ -174,11 +172,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         /// When checking whether we should award, there's a need group user's plays across a single set to avoid counting
         /// plays on different difficulties of the same beatmap twice.
         /// </summary>
-        [Fact]
-        public void TestPlayMultipleBeatmapsFromSameSetDoesNotAward()
+        [Theory]
+        [MemberData(nameof(MEDAL_PACK_IDS))]
+        public void TestPlayMultipleBeatmapsFromSameSetDoesNotAward(int medal_id, int pack_id)
         {
-            const int medal_id = 7;
-            const int pack_id = 40;
             const int beatmapset_id = 13022;
 
             List<Beatmap> beatmaps = new List<Beatmap>
@@ -218,12 +215,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         /// We may have multiple scores in the database for a single user-beatmap combo.
         /// Only one should be counted.
         /// </summary>
-        [Fact]
-        public void TestPlayMultipleTimeOnSameSetDoesNotAward()
+        [Theory]
+        [MemberData(nameof(MEDAL_PACK_IDS))]
+        public void TestPlayMultipleTimeOnSameSetDoesNotAward(int medal_id, int pack_id)
         {
-            const int medal_id = 7;
-            const int pack_id = 40;
-
             var beatmap1 = AddBeatmap(b => b.beatmap_id = 71623, s => s.beatmapset_id = 13022);
             var beatmap2 = AddBeatmap(b => b.beatmap_id = 59225, s => s.beatmapset_id = 16520);
 


### PR DESCRIPTION
...using `IsDifficultyReductionMod()`. this is intended to fix that you can cheese challenge packs with mods like DA, magnetize, relax, etc

the mod check can't be easily translated to SQL, so it's now required to query all of the user's passed scores on the relevant maps, and I can't tell if that is an acceptable tradeoff.

i'm new to this project and might-as-well-be-new to C# so feel free to just edit this if it's easier than reviewing