### PR TITLE
Delete score pins when cleaning up old user high scores during high score import

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -103,7 +103,15 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                         }
 
                         using (var conn = DatabaseAccess.GetConnection())
-                            conn.Execute("DELETE FROM scores WHERE id = @new_id", new { highScore.new_id });
+                        {
+                            conn.Execute("DELETE FROM score_pins WHERE score_type = 'solo_score' AND user_id = @new_user_id AND id = @new_id;"
+                                         + "DELETE FROM scores WHERE id = @new_id", new
+                            {
+                                highScore.new_id,
+                                highScore.new_user_id,
+                            });
+                        }
+
                         ElasticScoreItems.Add(new ElasticQueuePusher.ElasticScoreItem { ScoreId = (long)highScore.new_id });
 
                         Interlocked.Increment(ref TotalDeleteCount);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
@@ -34,7 +34,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
         public uint? queue_id { get; set; }
         public byte? status { get; set; }
 
-        // ID of this score in the `scores` table. Used in join context.
+        // ID of this score and ID of the user associated with it in the `scores` table. Used in join context.
         public ulong? new_id { get; set; }
         public int? new_user_id { get; set; }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/HighScore.cs
@@ -36,6 +36,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
 
         // ID of this score in the `scores` table. Used in join context.
         public ulong? new_id { get; set; }
+        public int? new_user_id { get; set; }
 
         // These come from osu_scores. If present, this is a non-high-score, ie. is sourced from the osu_scores table series.
         public byte[]? scorechecksum { get; set; }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs
@@ -116,7 +116,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                         await checkSlaveLatency(db, cancellationToken);
 
                     Console.WriteLine($"Fetching next scores from {lastProcessedId}...");
-                    var highScores = await db.QueryAsync<HighScore>($"SELECT h.*, s.id as new_id FROM {highScoreTable} h "
+                    var highScores = await db.QueryAsync<HighScore>($"SELECT h.*, s.id as new_id, s.user_id as new_user_id FROM {highScoreTable} h "
                                                                     + $"LEFT JOIN scores s ON h.score_id = s.legacy_score_id AND s.ruleset_id = {RulesetId} "
                                                                     + "WHERE score_id >= @lastId AND score_id <= @maxProcessableId "
                                                                     + "ORDER BY score_id LIMIT @batchSize", new

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/WatchHighScoresCommand.cs
@@ -127,7 +127,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                 while (!cancellationToken.IsCancellationRequested)
                 {
                     HighScore[] highScores = (await dbMainQuery.QueryAsync<HighScore>(
-                                                 "SELECT q.*, h.*, s.id as new_id FROM osu.score_process_queue q "
+                                                 "SELECT q.*, h.*, s.id as new_id, s.user_id as new_user_id FROM osu.score_process_queue q "
                                                  + $"LEFT JOIN {highScoreTable} h USING (score_id) "
                                                  + $"LEFT JOIN scores s ON q.score_id = s.legacy_score_id AND s.ruleset_id = {RulesetId} "
                                                  + $"WHERE queue_id >= @lastQueueId AND mode = {RulesetId} ORDER BY queue_id LIMIT 50", new


### PR DESCRIPTION
Score pins generally mark scores as `preserve=1` and therefore can be pinned indefinitely, but for the time being, the legacy score importer is forcefully (hard) deleting scores when they are beaten so that the stored scores match the old tables 1:1. So, let's nuke pinned scores along with the scores themselves to keep parity.