### PR TITLE
Update user highest rank & rolling rank history

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -74,6 +74,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 db.Execute("REPLACE INTO osu_counts (name, count) VALUES ('playcount', 0)");
 
                 TestBuildID = db.QuerySingle<ushort>("INSERT INTO osu_builds (version, allow_performance) VALUES ('1.0.0', 1); SELECT LAST_INSERT_ID();");
+
+                db.Execute("TRUNCATE TABLE `osu_user_performance_rank`");
+                db.Execute("TRUNCATE TABLE `osu_user_performance_rank_highest`");
             }
 
             Task.Run(() => Processor.Run(CancellationToken), CancellationToken);

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Text;
+using System.Threading.Tasks;
 using Dapper;
 using Dapper.Contrib.Extensions;
 using MySqlConnector;
@@ -342,6 +344,123 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             WaitForDatabaseState("SELECT COUNT(*) FROM scores WHERE id = @ScoreId AND pp IS NULL", 1, CancellationToken, new
             {
                 ScoreId = score.Score.id
+            });
+        }
+
+        [Theory]
+        [InlineData(null, 799)]
+        [InlineData(0, 799)]
+        [InlineData(850, 799)]
+        [InlineData(150, 150)]
+        public async Task UserHighestRankUpdates(int? highestRankBefore, int highestRankAfter)
+        {
+            // simulate fake users to beat as we climb up ranks.
+            // this is going to be a bit of a chonker query...
+            using var db = Processor.GetDatabaseConnection();
+
+            var stringBuilder = new StringBuilder();
+
+            stringBuilder.Append("INSERT INTO osu_user_stats (`user_id`, `rank_score`, `rank_score_index`, "
+                                 + "`accuracy_total`, `accuracy_count`, `accuracy`, `accuracy_new`, `playcount`, `ranked_score`, `total_score`, "
+                                 + "`x_rank_count`, `xh_rank_count`, `s_rank_count`, `sh_rank_count`, `a_rank_count`, `rank`, `level`) VALUES ");
+
+            for (int i = 0; i < 1000; ++i)
+            {
+                if (i > 0)
+                    stringBuilder.Append(',');
+
+                stringBuilder.Append($"({1000 + i}, {1000 - i}, {i}, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)");
+            }
+
+            await db.ExecuteAsync(stringBuilder.ToString());
+
+            if (highestRankBefore != null)
+            {
+                await db.ExecuteAsync("INSERT INTO `osu_user_performance_rank_highest` (`user_id`, `mode`, `rank`) VALUES (@userId, @mode, @rank)", new
+                {
+                    userId = 2,
+                    mode = 0,
+                    rank = highestRankBefore.Value,
+                });
+            }
+
+            var beatmap = AddBeatmap();
+
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.preserve = s.Score.ranked = true;
+                s.Score.pp = 200; // ~202 pp total, including bonus pp
+            });
+
+            WaitForDatabaseState("SELECT `rank` FROM `osu_user_performance_rank_highest` WHERE `user_id` = @userId AND `mode` = @mode", highestRankAfter, CancellationToken, new
+            {
+                userId = 2,
+                mode = 0,
+            });
+        }
+
+        [Fact]
+        public async Task UserDailyRankUpdates()
+        {
+            // simulate fake users to beat as we climb up ranks.
+            // this is going to be a bit of a chonker query...
+            using var db = Processor.GetDatabaseConnection();
+
+            var stringBuilder = new StringBuilder();
+
+            stringBuilder.Append("INSERT INTO osu_user_stats (`user_id`, `rank_score`, `rank_score_index`, "
+                                 + "`accuracy_total`, `accuracy_count`, `accuracy`, `accuracy_new`, `playcount`, `ranked_score`, `total_score`, "
+                                 + "`x_rank_count`, `xh_rank_count`, `s_rank_count`, `sh_rank_count`, `a_rank_count`, `rank`, `level`) VALUES ");
+
+            for (int i = 0; i < 1000; ++i)
+            {
+                if (i > 0)
+                    stringBuilder.Append(',');
+
+                stringBuilder.Append($"({1000 + i}, {1000 - i}, {i}, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)");
+            }
+
+            await db.ExecuteAsync(stringBuilder.ToString());
+            await db.ExecuteAsync($"REPLACE INTO `osu_counts` (name, count) VALUES ('pp_rank_column_osu', 13)");
+
+            var beatmap = AddBeatmap();
+
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.preserve = s.Score.ranked = true;
+                s.Score.pp = 200; // ~202 pp total, including bonus pp
+            });
+
+            WaitForDatabaseState("SELECT `r13` FROM `osu_user_performance_rank` WHERE `user_id` = @userId AND `mode` = @mode", 799, CancellationToken, new
+            {
+                userId = 2,
+                mode = 0,
+            });
+
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.preserve = s.Score.ranked = true;
+                s.Score.pp = 400; // ~404 pp total, including bonus pp
+            });
+
+            WaitForDatabaseState("SELECT `r13` FROM `osu_user_performance_rank` WHERE `user_id` = @userId AND `mode` = @mode", 597, CancellationToken, new
+            {
+                userId = 2,
+                mode = 0,
+            });
+
+            await db.ExecuteAsync($"REPLACE INTO `osu_counts` (name, count) VALUES ('pp_rank_column_osu', 14)");
+
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.preserve = s.Score.ranked = true;
+                s.Score.pp = 600; // ~606 pp total, including bonus pp
+            });
+
+            WaitForDatabaseState("SELECT `r13`, `r14` FROM `osu_user_performance_rank` WHERE `user_id` = @userId AND `mode` = @mode", (597, 395), CancellationToken, new
+            {
+                userId = 2,
+                mode = 0,
             });
         }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
@@ -421,7 +421,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             }
 
             await db.ExecuteAsync(stringBuilder.ToString());
-            await db.ExecuteAsync($"REPLACE INTO `osu_counts` (name, count) VALUES ('pp_rank_column_osu', 13)");
+            await db.ExecuteAsync("REPLACE INTO `osu_counts` (name, count) VALUES ('pp_rank_column_osu', 13)");
 
             var beatmap = AddBeatmap();
 
@@ -449,7 +449,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 mode = 0,
             });
 
-            await db.ExecuteAsync($"REPLACE INTO `osu_counts` (name, count) VALUES ('pp_rank_column_osu', 14)");
+            await db.ExecuteAsync("REPLACE INTO `osu_counts` (name, count) VALUES ('pp_rank_column_osu', 14)");
 
             SetScoreForBeatmap(beatmap.beatmap_id, s =>
             {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/LegacyDatabaseHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/LegacyDatabaseHelper.cs
@@ -36,6 +36,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
 
         public class RulesetDatabaseInfo
         {
+            public readonly int RulesetId;
             public readonly string UsersTable;
             public readonly string ScoreTable;
             public readonly string HighScoreTable;
@@ -44,9 +45,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
             public readonly string ReplayTable;
             public readonly string LastProcessedPpUserCount;
             public readonly string LastProcessedPpScoreCount;
+            public readonly string TodaysRankColumn;
 
             public RulesetDatabaseInfo(int rulesetId, string rulesetIdentifier, bool legacySuffix)
             {
+                RulesetId = rulesetId;
+
                 string tableSuffix = legacySuffix ? $"_{rulesetIdentifier}" : string.Empty;
 
                 // If using the dumps, set this environment variable to "sample_users".
@@ -61,6 +65,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
                 ReplayTable = $"`{dbName}`.`osu_replays{tableSuffix}`";
                 LastProcessedPpUserCount = $"pp_last_user_id{tableSuffix}";
                 LastProcessedPpScoreCount = $"pp_last_score_id{tableSuffix}";
+                TodaysRankColumn = $"pp_rank_column_{rulesetIdentifier}";
             }
         }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -118,7 +118,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             userStats.rank_score_index = (await connection.QuerySingleAsync<int>($"SELECT COUNT(*) FROM {dbInfo.UserStatsTable} WHERE rank_score > {userStats.rank_score}", transaction: transaction)) + 1;
 
             // User's historical best rank (ever).
-            int userHistoricalHighestRank = await connection.QuerySingleOrDefaultAsync<int?>($"SELECT `rank` FROM `osu_user_performance_rank_highest` WHERE `user_id` = @userId AND `mode` = @mode",
+            int userHistoricalHighestRank = await connection.QuerySingleOrDefaultAsync<int?>("SELECT `rank` FROM `osu_user_performance_rank_highest` WHERE `user_id` = @userId AND `mode` = @mode",
                 new
                 {
                     userId = userStats.user_id,
@@ -127,7 +127,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
             if (userHistoricalHighestRank == 0 || userHistoricalHighestRank > userStats.rank_score_index)
             {
-                await connection.ExecuteAsync($"REPLACE INTO `osu_user_performance_rank_highest` (`user_id`, `mode`, `rank`) VALUES (@userId, @mode, @rank)",
+                await connection.ExecuteAsync("REPLACE INTO `osu_user_performance_rank_highest` (`user_id`, `mode`, `rank`) VALUES (@userId, @mode, @rank)",
                     new
                     {
                         userId = userStats.user_id,


### PR DESCRIPTION
- Closes https://github.com/ppy/osu-web/issues/10937

I believe this to be a straight port of the correspondent `osu-web-10` logic, but please do double-check the logic, especially around the 90-day history handling since there's some implicit understanding on how that works that I basically inferred backwards from `osu-web` and `osu-web-10` source.

May be best to deploy after https://github.com/ppy/osu/issues/27174 is resolved.