### PR TITLE
Add command to process total PP for users based on sql

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
@@ -277,7 +277,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         }
 
         [Fact]
-        public void LegacyScoreDoesProcess()
+        public void LegacyScoreDoesNotProcess()
         {
             AddBeatmap();
             AddBeatmapAttributes<OsuDifficultyAttributes>();
@@ -291,7 +291,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 score.Score.preserve = true;
             });
 
-            WaitForDatabaseState("SELECT COUNT(*) FROM scores WHERE id = @ScoreId AND pp IS NOT NULL AND ranked = 1 AND preserve = 1", 1, CancellationToken, new
+            WaitForDatabaseState("SELECT COUNT(*) FROM scores WHERE id = @ScoreId AND pp IS NULL AND ranked = 1 AND preserve = 1", 1, CancellationToken, new
             {
                 ScoreId = score.Score.id
             });

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/PerformanceCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/PerformanceCommand.cs
@@ -69,7 +69,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance
                     if (userStats == null)
                         return;
 
-                    await TotalProcessor.UpdateUserStatsAsync(userStats, RulesetId, db);
+                    await TotalProcessor.UpdateUserStatsAsync(userStats, RulesetId, db, updateIndex: false);
                     await DatabaseHelper.UpdateUserStatsAsync(userStats, db);
                 }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/UpdateUserTotalsCommands.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/UpdateUserTotalsCommands.cs
@@ -11,6 +11,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance
     [Command("user-totals", Description = "Updates user total PP values.")]
     [Subcommand(typeof(UpdateAllUserTotalsCommand))]
     [Subcommand(typeof(UpdateUserTotalsForUsersCommand))]
+    [Subcommand(typeof(UpdateUserTotalsFromSqlCommand))]
     public sealed class UpdateUserTotalsCommands
     {
         public Task<int> OnExecuteAsync(CommandLineApplication app, CancellationToken cancellationToken)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/UserTotals/UpdateUserTotalsFromSqlCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/UserTotals/UpdateUserTotalsFromSqlCommand.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using JetBrains.Annotations;
+using McMaster.Extensions.CommandLineUtils;
+using osu.Server.QueueProcessor;
+using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.UserTotals
+{
+    [Command("sql", Description = "Updates the total PP of scoped users.")]
+    public class UpdateUserTotalsFromSqlCommand : PerformanceCommand
+    {
+        [UsedImplicitly]
+        [Required]
+        [Argument(0, Description = "Specify a custom query to limit the scope of users to process.")]
+        public string? Query { get; set; }
+
+        protected override async Task<int> ExecuteAsync(CancellationToken cancellationToken)
+        {
+            using var db = DatabaseAccess.GetConnection();
+
+            LegacyDatabaseHelper.RulesetDatabaseInfo databaseInfo = LegacyDatabaseHelper.GetRulesetSpecifics(RulesetId);
+
+            Console.WriteLine($"Fetching scoped users ({Query})...");
+
+            int[] userIds = (await db.QueryAsync<int>($"SELECT `user_id` FROM {databaseInfo.UserStatsTable} WHERE {Query}")).ToArray();
+
+            Console.WriteLine($"Fetched {userIds.Length} users");
+
+            await ProcessUserTotals(userIds, cancellationToken);
+            return 0;
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -34,7 +34,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnFailedScores => false;
 
-        public bool RunOnLegacyScores => true;
+        public bool RunOnLegacyScores => false;
 
         public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -139,21 +139,24 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                     }, transaction);
             }
 
-            // User's 90-day rolling rank history.
-            int todaysRankColumn = await connection.QuerySingleOrDefaultAsync<int?>(@"SELECT `count` FROM `osu_counts` WHERE `name` = @todaysRankColumn", new
-            {
-                dbInfo.TodaysRankColumn
-            }, transaction) ?? 0;
+            // Update user's 90-day rolling rank history for today.
+            // TODO: This doesn't need to be updated here. the osu-web graph always uses `rank_score_index` for the current day.
+            // TODO: code is left for now as it will need to be used in the future for daily processing purposes (once migrated from web-10).
 
-            await connection.ExecuteAsync(
-                $"INSERT INTO `osu_user_performance_rank` (`user_id`, `mode`, `r{todaysRankColumn}`) VALUES (@userId, @mode, @rank) "
-                + $"ON DUPLICATE KEY UPDATE `r{todaysRankColumn}` = @rank",
-                new
-                {
-                    userId = userStats.user_id,
-                    mode = dbInfo.RulesetId,
-                    rank = userStats.rank_score_index
-                }, transaction);
+            // int todaysRankColumn = await connection.QuerySingleOrDefaultAsync<int?>(@"SELECT `count` FROM `osu_counts` WHERE `name` = @todaysRankColumn", new
+            // {
+            //     dbInfo.TodaysRankColumn
+            // }, transaction) ?? 0;
+            //
+            // await connection.ExecuteAsync(
+            //     $"INSERT INTO `osu_user_performance_rank` (`user_id`, `mode`, `r{todaysRankColumn}`) VALUES (@userId, @mode, @rank) "
+            //     + $"ON DUPLICATE KEY UPDATE `r{todaysRankColumn}` = @rank",
+            //     new
+            //     {
+            //         userId = userStats.user_id,
+            //         mode = dbInfo.RulesetId,
+            //         rank = userStats.rank_score_index
+            //     }, transaction);
         }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -141,22 +141,22 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
             // Update user's 90-day rolling rank history for today.
             // TODO: This doesn't need to be updated here. the osu-web graph always uses `rank_score_index` for the current day.
-            // TODO: code is left for now as it will need to be used in the future for daily processing purposes (once migrated from web-10).
+            // TODO: code should be moved/used in the future for daily processing purposes (once migrated from web-10).
 
-            // int todaysRankColumn = await connection.QuerySingleOrDefaultAsync<int?>(@"SELECT `count` FROM `osu_counts` WHERE `name` = @todaysRankColumn", new
-            // {
-            //     dbInfo.TodaysRankColumn
-            // }, transaction) ?? 0;
-            //
-            // await connection.ExecuteAsync(
-            //     $"INSERT INTO `osu_user_performance_rank` (`user_id`, `mode`, `r{todaysRankColumn}`) VALUES (@userId, @mode, @rank) "
-            //     + $"ON DUPLICATE KEY UPDATE `r{todaysRankColumn}` = @rank",
-            //     new
-            //     {
-            //         userId = userStats.user_id,
-            //         mode = dbInfo.RulesetId,
-            //         rank = userStats.rank_score_index
-            //     }, transaction);
+            int todaysRankColumn = await connection.QuerySingleOrDefaultAsync<int?>(@"SELECT `count` FROM `osu_counts` WHERE `name` = @todaysRankColumn", new
+            {
+                dbInfo.TodaysRankColumn
+            }, transaction) ?? 0;
+
+            await connection.ExecuteAsync(
+                $"INSERT INTO `osu_user_performance_rank` (`user_id`, `mode`, `r{todaysRankColumn}`) VALUES (@userId, @mode, @rank) "
+                + $"ON DUPLICATE KEY UPDATE `r{todaysRankColumn}` = @rank",
+                new
+                {
+                    userId = userStats.user_id,
+                    mode = dbInfo.RulesetId,
+                    rank = userStats.rank_score_index
+                }, transaction);
         }
     }
 }


### PR DESCRIPTION
Will be used for an initial run to update total PPs to new algorithm.

Previous runs would do batch reprocessing via `osu-performance` using something like:

```bash
./osu-performance sql "select user_id from osu_user_stats where rank_score > 0 and last_played > '2021-01-14' order by rank_score asc" -m osu
```

Of note, see commit message of [ea09969](https://github.com/ppy/osu-queue-score-statistics/pull/239/commits/ea099693b5aa75e50f64e56269caeb81fc032fc1) for reasoning for not updating some pieces.