### PR TITLE
Fix possible overestimation of inserted row count in batch inserter

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -183,11 +183,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
             StringBuilder insertBuilder = new StringBuilder(
                 "INSERT INTO scores (`user_id`, `ruleset_id`, `beatmap_id`, `has_replay`, `preserve`, `ranked`, `rank`, `passed`, `accuracy`, `max_combo`, `total_score`, `data`, `pp`, `legacy_score_id`, `legacy_total_score`, `ended_at`, `unix_updated_at`) VALUES ");
 
+            scores = scores.Where(score => !string.IsNullOrEmpty(score.InsertSql)).ToArray();
+
             foreach (var score in scores)
             {
-                if (string.IsNullOrEmpty(score.InsertSql))
-                    continue;
-
                 if (!first)
                     insertBuilder.Append(",");
                 first = false;


### PR DESCRIPTION
If a score to be batch-inserted had no associated insertion SQL (e.g. due to being deleted), it would get skipped when assembling the full batch SQL insertion statement - however it would continue to remain in the `scores` array, which is important since statements lower down implicitly assume that all scores from the array have actually been inserted (by using `LAST_INSERT_ID()` from mysql and offsetting it by `scores.Length - 1`).

To avoid this scenario, drop such items from the array entirely prior to the insertion.