### PR TITLE
Fix failing test

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
@@ -278,7 +278,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         }
 
         [Fact(Skip = "ScorePerformanceProcessor is disabled for legacy scores for now: https://github.com/ppy/osu-queue-score-statistics/pull/212#issuecomment-2011297448.")]
-        public void LegacyScoreDoesNotProcess()
+        public void LegacyScoreIsProcessedAndPpIsWrittenBackToLegacyTables()
         {
             AddBeatmap();
             AddBeatmapAttributes<OsuDifficultyAttributes>();

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
@@ -277,7 +277,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             });
         }
 
-        [Fact]
+        [Fact(Skip = "ScorePerformanceProcessor is disabled for legacy scores for now: https://github.com/ppy/osu-queue-score-statistics/pull/212#issuecomment-2011297448.")]
         public void LegacyScoreDoesNotProcess()
         {
             AddBeatmap();

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -161,6 +161,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                     Pp = performanceAttributes.Total
                 }, transaction: transaction);
 
+                // for the following code to take effect, `RunOnLegacyScores` must also be true (currently is false).
                 if (score.IsLegacyScore && write_legacy_score_pp)
                 {
                     var helper = LegacyDatabaseHelper.GetRulesetSpecifics(score.RulesetID);


### PR DESCRIPTION
A test added in https://github.com/ppy/osu-queue-score-statistics/pull/212, which was supposed to exercise the queue processor writing pp values back to legacy `scores_high` tables, [is currently failing on master](https://github.com/ppy/osu-queue-score-statistics/actions/runs/8370540426/job/22918071187).

The direct reason why is that `ScorePerformanceProcessor` is currently disabled for legacy scores as per https://github.com/ppy/osu-queue-score-statistics/pull/212#issuecomment-2011297448. This was required by https://github.com/ppy/osu-queue-score-statistics/pull/239.

The _indirect_ reason why this happened is that I cannot see CI test runs on _any_ of the commits authored by @tsunyoku in the PR, so there were never any tests run _to fail_. I'm not sure where _that_ comes from. May have something or other to do with first contribution to repository requiring maintainer approval for workflow runs.

The test can be re-enabled once `osu-performance` decommissioning goes under way.

---

This also adds a warning comment for future travelers to reduce confusion as to why the envvar is doing nothing right now, and also renames the involved test in line with its actual expectations (which were changed in https://github.com/ppy/osu-queue-score-statistics/pull/212/commits/4116beb5a3f79062a60985a7023d5006e4bec496 without adjusting the test name).