### PR TITLE
Add processor for mania keymode user stats

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ManiaKeyModeUserStatsProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ManiaKeyModeUserStatsProcessorTests.cs
@@ -1,0 +1,277 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Text;
+using Dapper;
+using osu.Game.Scoring;
+using Xunit;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
+{
+    public class ManiaKeyModeUserStatsProcessorTests : DatabaseTest
+    {
+        public ManiaKeyModeUserStatsProcessorTests()
+        {
+            using (var db = Processor.GetDatabaseConnection())
+            {
+                db.Execute("TRUNCATE TABLE `phpbb_users`");
+                db.Execute("TRUNCATE TABLE `osu_user_stats_mania_4k`");
+                db.Execute("TRUNCATE TABLE `osu_user_stats_mania_7k`");
+
+                db.Execute("INSERT INTO `phpbb_users` (`user_id`, `username`, `country_acronym`, `user_permissions`, `user_sig`, `user_occ`, `user_interests`) VALUES (2, 'test', 'JP', '', '', '', '')");
+            }
+        }
+
+        [Fact]
+        public void NonManiaPlaysAreIgnored()
+        {
+            WaitForDatabaseState("SELECT COUNT(1) FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", 0, CancellationToken, new { userId = 2 });
+            WaitForDatabaseState("SELECT COUNT(1) FROM `osu_user_stats_mania_7k` WHERE `user_id` = @userId", 0, CancellationToken, new { userId = 2 });
+
+            var beatmap = AddBeatmap(b => b.beatmap_id = 10);
+
+            SetScoreForBeatmap(beatmap.beatmap_id);
+
+            WaitForDatabaseState("SELECT COUNT(1) FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", 0, CancellationToken, new { userId = 2 });
+            WaitForDatabaseState("SELECT COUNT(1) FROM `osu_user_stats_mania_7k` WHERE `user_id` = @userId", 0, CancellationToken, new { userId = 2 });
+        }
+
+        [Fact]
+        public void PlaysOnMapsWithWrongKeyCountAreIgnored()
+        {
+            WaitForDatabaseState("SELECT COUNT(1) FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", 0, CancellationToken, new { userId = 2 });
+            WaitForDatabaseState("SELECT COUNT(1) FROM `osu_user_stats_mania_7k` WHERE `user_id` = @userId", 0, CancellationToken, new { userId = 2 });
+
+            var beatmap = AddBeatmap(b =>
+            {
+                b.beatmap_id = 11;
+                b.playmode = 3;
+                b.diff_size = 6;
+            });
+
+            SetScoreForBeatmap(beatmap.beatmap_id, s => s.Score.ruleset_id = 3);
+
+            WaitForDatabaseState("SELECT COUNT(1) FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", 0, CancellationToken, new { userId = 2 });
+            WaitForDatabaseState("SELECT COUNT(1) FROM `osu_user_stats_mania_7k` WHERE `user_id` = @userId", 0, CancellationToken, new { userId = 2 });
+        }
+
+        [Fact]
+        public void PlaysOnMapsWithCorrectKeyCountAreCounted()
+        {
+            WaitForDatabaseState("SELECT `playcount` FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", (int?)null, CancellationToken, new { userId = 2 });
+            WaitForDatabaseState("SELECT `playcount` FROM `osu_user_stats_mania_7k` WHERE `user_id` = @userId", (int?)null, CancellationToken, new { userId = 2 });
+
+            var beatmap4K = AddBeatmap(b =>
+            {
+                b.beatmap_id = 12;
+                b.playmode = 3;
+                b.diff_size = 4;
+            }, s => s.beatmapset_id = 1);
+            var beatmap7K = AddBeatmap(b =>
+            {
+                b.beatmap_id = 13;
+                b.playmode = 3;
+                b.diff_size = 7;
+            }, s => s.beatmapset_id = 2);
+
+            SetScoreForBeatmap(beatmap4K.beatmap_id, s => s.Score.ruleset_id = 3);
+
+            WaitForDatabaseState("SELECT `playcount` FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", 1, CancellationToken, new { userId = 2 });
+            WaitForDatabaseState("SELECT `playcount` FROM `osu_user_stats_mania_7k` WHERE `user_id` = @userId", (int?)null, CancellationToken, new { userId = 2 });
+
+            SetScoreForBeatmap(beatmap7K.beatmap_id, s => s.Score.ruleset_id = 3);
+
+            WaitForDatabaseState("SELECT `playcount` FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", 1, CancellationToken, new { userId = 2 });
+            WaitForDatabaseState("SELECT `playcount` FROM `osu_user_stats_mania_7k` WHERE `user_id` = @userId", 1, CancellationToken, new { userId = 2 });
+
+            SetScoreForBeatmap(beatmap7K.beatmap_id, s => s.Score.ruleset_id = 3);
+
+            WaitForDatabaseState("SELECT `playcount` FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", 1, CancellationToken, new { userId = 2 });
+            WaitForDatabaseState("SELECT `playcount` FROM `osu_user_stats_mania_7k` WHERE `user_id` = @userId", 2, CancellationToken, new { userId = 2 });
+        }
+
+        [Fact]
+        public void RankCountsCorrect()
+        {
+            var beatmap4K = AddBeatmap(b =>
+            {
+                b.beatmap_id = 12;
+                b.playmode = 3;
+                b.diff_size = 4;
+            }, s => s.beatmapset_id = 1);
+            var beatmap7K = AddBeatmap(b =>
+            {
+                b.beatmap_id = 13;
+                b.playmode = 3;
+                b.diff_size = 7;
+            }, s => s.beatmapset_id = 2);
+
+            WaitForDatabaseState<(int?, int?)>("SELECT `a_rank_count`, `s_rank_count` FROM `osu_user_stats_mania_7k` WHERE `user_id` = @userId", (null, null), CancellationToken, new { userId = 2 });
+            WaitForDatabaseState<(int?, int?)>("SELECT `a_rank_count`, `s_rank_count` FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", (null, null), CancellationToken, new { userId = 2 });
+
+            SetScoreForBeatmap(beatmap4K.beatmap_id, s =>
+            {
+                s.Score.ranked = s.Score.preserve = true;
+                s.Score.total_score = 500_000;
+                s.Score.rank = ScoreRank.A;
+                s.Score.ruleset_id = 3;
+            });
+
+            WaitForDatabaseState<(int?, int?)>("SELECT `a_rank_count`, `s_rank_count` FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", (1, 0), CancellationToken, new { userId = 2 });
+
+            SetScoreForBeatmap(beatmap4K.beatmap_id, s =>
+            {
+                s.Score.ranked = s.Score.preserve = true;
+                s.Score.total_score = 300_000; // same map and keymode as above, lower score => should not count
+                s.Score.rank = ScoreRank.S;
+                s.Score.ruleset_id = 3;
+            });
+
+            WaitForDatabaseState<(int?, int?)>("SELECT `a_rank_count`, `s_rank_count` FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", (1, 0), CancellationToken, new { userId = 2 });
+
+            SetScoreForBeatmap(beatmap4K.beatmap_id, s =>
+            {
+                s.Score.ranked = s.Score.preserve = true;
+                s.Score.total_score = 700_000; // same map and keymode as above, higher score => should count
+                s.Score.rank = ScoreRank.S;
+                s.Score.ruleset_id = 3;
+            });
+
+            WaitForDatabaseState<(int?, int?)>("SELECT `a_rank_count`, `s_rank_count` FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", (0, 1), CancellationToken, new { userId = 2 });
+
+            SetScoreForBeatmap(beatmap7K.beatmap_id, s =>
+            {
+                s.Score.ranked = s.Score.preserve = true;
+                s.Score.ruleset_id = 3;
+                s.Score.rank = ScoreRank.A;
+            });
+
+            WaitForDatabaseState<(int?, int?)>("SELECT `a_rank_count`, `s_rank_count` FROM `osu_user_stats_mania_7k` WHERE `user_id` = @userId", (1, 0), CancellationToken, new { userId = 2 });
+            WaitForDatabaseState<(int?, int?)>("SELECT `a_rank_count`, `s_rank_count` FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", (0, 1), CancellationToken, new { userId = 2 });
+        }
+
+        [Fact]
+        public void PerformancePointTotalAndRankUpdated()
+        {
+            WaitForDatabaseState("SELECT `playcount` FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", (int?)null, CancellationToken, new { userId = 2 });
+
+            using (var db = Processor.GetDatabaseConnection())
+            {
+                // simulate fake users to beat as we climb up ranks.
+                // this is going to be a bit of a chonker query...
+                var stringBuilder = new StringBuilder();
+
+                stringBuilder.Append("INSERT INTO `osu_user_stats_mania_4k` (`user_id`, `rank_score`, `rank_score_index`, `accuracy_new`, `playcount`, "
+                                     + "`x_rank_count`, `xh_rank_count`, `s_rank_count`, `sh_rank_count`, `a_rank_count`) VALUES ");
+
+                for (int i = 0; i < 100; ++i)
+                {
+                    if (i > 0)
+                        stringBuilder.Append(',');
+
+                    stringBuilder.Append($"({100 + i}, {100 - i}, {i}, 1, 0, 0, 0, 0, 0, 0)");
+                }
+
+                db.Execute(stringBuilder.ToString());
+            }
+
+            var beatmap = AddBeatmap(b =>
+            {
+                b.beatmap_id = 12;
+                b.playmode = 3;
+                b.diff_size = 4;
+            });
+
+            WaitForDatabaseState<bool?>("SELECT `rank_score` > 0 FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", null, CancellationToken, new { userId = 2 });
+            WaitForDatabaseState<int?>("SELECT `rank_score_index` FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", null, CancellationToken, new { userId = 2 });
+
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.ranked = s.Score.preserve = true;
+                s.Score.ruleset_id = 3;
+                s.Score.pp = 50;
+            });
+
+            WaitForDatabaseState<bool?>("SELECT `rank_score` > 0 FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", true, CancellationToken, new { userId = 2 });
+            WaitForDatabaseState<int?>("SELECT `rank_score_index` FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", 49, CancellationToken, new { userId = 2 });
+        }
+
+        [Fact]
+        public void BackfillPlaycountEstimate()
+        {
+            var beatmapMania4K = AddBeatmap(b =>
+            {
+                b.beatmap_id = 100;
+                b.playmode = 3;
+                b.diff_size = 4;
+            }, s => s.beatmapset_id = 10);
+
+            var beatmapMania7K = AddBeatmap(b =>
+            {
+                b.beatmap_id = 101;
+                b.playmode = 3;
+                b.diff_size = 7;
+            }, s => s.beatmapset_id = 11);
+
+            var beatmapOsu = AddBeatmap(b =>
+            {
+                b.beatmap_id = 102;
+            }, s => s.beatmapset_id = 12);
+
+            using (var db = Processor.GetDatabaseConnection())
+            {
+                // insert some scores manually without pushing them for processing.
+                // this is because we wish to exercise the initial estimation logic, which will only run the first time round.
+                var stringBuilder = new StringBuilder();
+
+                stringBuilder.Append("INSERT INTO `scores` (`user_id`, `ruleset_id`, `beatmap_id`, `has_replay`, `preserve`, `ranked`, `rank`, "
+                                     + "`passed`, `accuracy`, `max_combo`, `total_score`, `data`, `pp`, `legacy_score_id`, `legacy_total_score`, "
+                                     + "`started_at`, `ended_at`, `build_id`) VALUES ");
+
+                const string scoreData = @"{""mods"": [], ""statistics"": {""perfect"": 5, ""large_bonus"": 0}, ""maximum_statistics"": {""perfect"": 5, ""large_bonus"": 2}}";
+                var endedAt = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+                // 4k scores
+                for (int i = 0; i < 19; ++i)
+                {
+                    if (i > 0)
+                        stringBuilder.Append(',');
+
+                    stringBuilder.Append($"(2, 3, {beatmapMania4K.beatmap_id}, 0, 1, 1, 'S', 1, 1, 100, 1000000, '{scoreData}', NULL, NULL, 0, '{endedAt:O}', '{endedAt:O}', NULL)");
+                }
+
+                // 7k scores
+                for (int i = 0; i < 30; ++i)
+                {
+                    stringBuilder.Append(',');
+                    stringBuilder.Append($"(2, 3, {beatmapMania7K.beatmap_id}, 0, 1, 1, 'S', 1, 1, 100, 1000000, '{scoreData}', NULL, NULL, 0, '{endedAt:O}', '{endedAt:O}', NULL)");
+                }
+
+                // osu! scores
+                for (int i = 0; i < 50; ++i)
+                {
+                    stringBuilder.Append(',');
+                    stringBuilder.Append($"(2, 0, {beatmapOsu.beatmap_id}, 0, 1, 1, 'S', 1, 1, 100, 1000000, '{scoreData}', NULL, NULL, 0, '{endedAt:O}', '{endedAt:O}', NULL)");
+                }
+
+                db.Execute(stringBuilder.ToString());
+
+                db.Execute("INSERT INTO `osu_user_stats_mania` (`user_id`, `rank_score`, `rank_score_index`, "
+                           + "`accuracy_total`, `accuracy_count`, `accuracy`, `accuracy_new`, `playcount`, `ranked_score`, `total_score`, "
+                           + "`x_rank_count`, `xh_rank_count`, `s_rank_count`, `sh_rank_count`, `a_rank_count`, `rank`, `level`) VALUES "
+                           + "(2, 0, 0, 0, 0, 1, 1, 99, 0, 0, 0, 0, 0, 0, 0, 0, 1)");
+            }
+
+            WaitForDatabaseState("SELECT `playcount` FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", (int?)null, CancellationToken, new { userId = 2 });
+            WaitForDatabaseState("SELECT `playcount` FROM `osu_user_stats_mania_7k` WHERE `user_id` = @userId", (int?)null, CancellationToken, new { userId = 2 });
+
+            SetScoreForBeatmap(beatmapMania4K.beatmap_id, s =>
+            {
+                s.Score.ranked = s.Score.preserve = true;
+                s.Score.ruleset_id = 3;
+            });
+            WaitForDatabaseState("SELECT `playcount` FROM `osu_user_stats_mania_4k` WHERE `user_id` = @userId", 40, CancellationToken, new { userId = 2 }); // 20 / (20 + 30) * 100
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ManiaKeyModeUserStatsProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ManiaKeyModeUserStatsProcessorTests.cs
@@ -229,7 +229,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                                      + "`passed`, `accuracy`, `max_combo`, `total_score`, `data`, `pp`, `legacy_score_id`, `legacy_total_score`, "
                                      + "`started_at`, `ended_at`, `build_id`) VALUES ");
 
-                const string scoreData = @"{""mods"": [], ""statistics"": {""perfect"": 5, ""large_bonus"": 0}, ""maximum_statistics"": {""perfect"": 5, ""large_bonus"": 2}}";
+                const string score_data = @"{""mods"": [], ""statistics"": {""perfect"": 5, ""large_bonus"": 0}, ""maximum_statistics"": {""perfect"": 5, ""large_bonus"": 2}}";
                 var endedAt = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
                 // 4k scores
@@ -238,21 +238,21 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                     if (i > 0)
                         stringBuilder.Append(',');
 
-                    stringBuilder.Append($"(2, 3, {beatmapMania4K.beatmap_id}, 0, 1, 1, 'S', 1, 1, 100, 1000000, '{scoreData}', NULL, NULL, 0, '{endedAt:O}', '{endedAt:O}', NULL)");
+                    stringBuilder.Append($"(2, 3, {beatmapMania4K.beatmap_id}, 0, 1, 1, 'S', 1, 1, 100, 1000000, '{score_data}', NULL, NULL, 0, '{endedAt:O}', '{endedAt:O}', NULL)");
                 }
 
                 // 7k scores
                 for (int i = 0; i < 30; ++i)
                 {
                     stringBuilder.Append(',');
-                    stringBuilder.Append($"(2, 3, {beatmapMania7K.beatmap_id}, 0, 1, 1, 'S', 1, 1, 100, 1000000, '{scoreData}', NULL, NULL, 0, '{endedAt:O}', '{endedAt:O}', NULL)");
+                    stringBuilder.Append($"(2, 3, {beatmapMania7K.beatmap_id}, 0, 1, 1, 'S', 1, 1, 100, 1000000, '{score_data}', NULL, NULL, 0, '{endedAt:O}', '{endedAt:O}', NULL)");
                 }
 
                 // osu! scores
                 for (int i = 0; i < 50; ++i)
                 {
                     stringBuilder.Append(',');
-                    stringBuilder.Append($"(2, 0, {beatmapOsu.beatmap_id}, 0, 1, 1, 'S', 1, 1, 100, 1000000, '{scoreData}', NULL, NULL, 0, '{endedAt:O}', '{endedAt:O}', NULL)");
+                    stringBuilder.Append($"(2, 0, {beatmapOsu.beatmap_id}, 0, 1, 1, 'S', 1, 1, 100, 1000000, '{score_data}', NULL, NULL, 0, '{endedAt:O}', '{endedAt:O}', NULL)");
                 }
 
                 db.Execute(stringBuilder.ToString());

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ManiaKeyModeUserStatsProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ManiaKeyModeUserStatsProcessorTests.cs
@@ -225,7 +225,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 // this is because we wish to exercise the initial estimation logic, which will only run the first time round.
                 var stringBuilder = new StringBuilder();
 
-                stringBuilder.Append("INSERT INTO `scores` (`user_id`, `ruleset_id`, `beatmap_id`, `has_replay`, `preserve`, `ranked`, `rank`, "
+                stringBuilder.Append("INSERT INTO `scores` (`id`, `user_id`, `ruleset_id`, `beatmap_id`, `has_replay`, `preserve`, `ranked`, `rank`, "
                                      + "`passed`, `accuracy`, `max_combo`, `total_score`, `data`, `pp`, `legacy_score_id`, `legacy_total_score`, "
                                      + "`started_at`, `ended_at`, `build_id`) VALUES ");
 
@@ -238,21 +238,21 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                     if (i > 0)
                         stringBuilder.Append(',');
 
-                    stringBuilder.Append($"(2, 3, {beatmapMania4K.beatmap_id}, 0, 1, 1, 'S', 1, 1, 100, 1000000, '{score_data}', NULL, NULL, 0, '{endedAt:O}', '{endedAt:O}', NULL)");
+                    stringBuilder.Append($"({i + 1}, 2, 3, {beatmapMania4K.beatmap_id}, 0, 1, 1, 'S', 1, 1, 100, 1000000, '{score_data}', NULL, NULL, 0, '{endedAt:O}', '{endedAt:O}', NULL)");
                 }
 
                 // 7k scores
                 for (int i = 0; i < 30; ++i)
                 {
                     stringBuilder.Append(',');
-                    stringBuilder.Append($"(2, 3, {beatmapMania7K.beatmap_id}, 0, 1, 1, 'S', 1, 1, 100, 1000000, '{score_data}', NULL, NULL, 0, '{endedAt:O}', '{endedAt:O}', NULL)");
+                    stringBuilder.Append($"({i + 20}, 2, 3, {beatmapMania7K.beatmap_id}, 0, 1, 1, 'S', 1, 1, 100, 1000000, '{score_data}', NULL, NULL, 0, '{endedAt:O}', '{endedAt:O}', NULL)");
                 }
 
                 // osu! scores
                 for (int i = 0; i < 50; ++i)
                 {
                     stringBuilder.Append(',');
-                    stringBuilder.Append($"(2, 0, {beatmapOsu.beatmap_id}, 0, 1, 1, 'S', 1, 1, 100, 1000000, '{score_data}', NULL, NULL, 0, '{endedAt:O}', '{endedAt:O}', NULL)");
+                    stringBuilder.Append($"({i + 50}, 2, 0, {beatmapOsu.beatmap_id}, 0, 1, 1, 'S', 1, 1, 100, 1000000, '{score_data}', NULL, NULL, 0, '{endedAt:O}', '{endedAt:O}', NULL)");
                 }
 
                 db.Execute(stringBuilder.ToString());
@@ -268,6 +268,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             SetScoreForBeatmap(beatmapMania4K.beatmap_id, s =>
             {
+                s.Score.id = 100;
                 s.Score.ranked = s.Score.preserve = true;
                 s.Score.ruleset_id = 3;
             });

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/UserTotalPerformanceAggregateHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/UserTotalPerformanceAggregateHelper.cs
@@ -1,0 +1,50 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
+{
+    public static class UserTotalPerformanceAggregateHelper
+    {
+        public static (float totalPp, float totalAccuracy) CalculateUserTotalPerformanceAggregates(List<SoloScore> scores)
+        {
+            SoloScore[] groupedScores = scores
+                                        // Group by beatmap ID.
+                                        .GroupBy(i => i.beatmap_id)
+                                        // Extract the maximum PP for each beatmap.
+                                        .Select(g => g.OrderByDescending(i => i.pp).First())
+                                        // And order the beatmaps by decreasing value.
+                                        .OrderByDescending(i => i.pp)
+                                        .ToArray();
+
+            // Build the diminishing sum
+            double factor = 1;
+            double totalPp = 0;
+            double totalAccuracy = 0;
+
+            foreach (var score in groupedScores)
+            {
+                totalPp += score.pp!.Value * factor;
+                totalAccuracy += score.accuracy * factor;
+                factor *= 0.95;
+            }
+
+            // This weird factor is to keep legacy compatibility with the diminishing bonus of 0.25 by 0.9994 each score.
+            // Of note, this is using de-duped scores which may be below 1,000 depending on how the user plays.
+            totalPp += (417.0 - 1.0 / 3.0) * (1.0 - Math.Pow(0.995, scores.Count));
+
+            // We want our accuracy to be normalized.
+            if (groupedScores.Length > 0)
+            {
+                // We want the percentage, not a factor in [0, 1], hence we divide 20 by 100.
+                totalAccuracy *= 100.0 / (20 * (1 - Math.Pow(0.95, groupedScores.Length)));
+            }
+
+            return ((float)totalPp, (float)totalAccuracy);
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/UserStatsManiaKeyCount.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/UserStatsManiaKeyCount.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Dapper.Contrib.Extensions;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
+{
+    /// <summary>
+    /// Base class for mania keycount-specific user stats.
+    /// Very close resemblance to <see cref="UserStats"/>, but the mania keycount tables have less columns.
+    /// </summary>
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [Serializable]
+    public class UserStatsManiaKeyCount
+    {
+        [ExplicitKey]
+        public uint user_id { get; set; }
+
+        public int playcount { get; set; }
+
+        public int x_rank_count { get; set; }
+        public int xh_rank_count { get; set; }
+        public int s_rank_count { get; set; }
+        public int sh_rank_count { get; set; }
+        public int a_rank_count { get; set; }
+
+        public string country_acronym { get; set; } = "XX";
+
+        public float rank_score { get; set; }
+        public int rank_score_index { get; set; }
+
+        public float accuracy_new { get; set; }
+        public DateTimeOffset last_update { get; set; } = DateTimeOffset.Now;
+        public DateTimeOffset last_played { get; set; } = DateTimeOffset.Now;
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ManiaKeyModeUserStatsProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ManiaKeyModeUserStatsProcessor.cs
@@ -1,0 +1,171 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Dapper;
+using JetBrains.Annotations;
+using MySqlConnector;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Scoring;
+using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
+{
+    [UsedImplicitly]
+    public class ManiaKeyModeUserStatsProcessor : IProcessor
+    {
+        public int Order => int.MaxValue;
+
+        public bool RunOnFailedScores => false;
+        public bool RunOnLegacyScores => true;
+
+        public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
+        {
+        }
+
+        public void ApplyToUserStats(SoloScoreInfo score, UserStats fullRulesetStats, MySqlConnection conn, MySqlTransaction transaction)
+        {
+            if (score.RulesetID != 3)
+                return;
+
+            if (score.Beatmap == null)
+                return;
+
+            int keyCount = (int)score.Beatmap.CircleSize;
+            // TODO: reconsider when handling key conversion mods in the future?
+            if (keyCount != 4 && keyCount != 7)
+                return;
+
+            string keyCountTableName = $"osu_user_stats_mania_{keyCount}k";
+            var keymodeStats = new UserStatsManiaKeyCount
+            {
+                user_id = (uint)score.UserID
+            };
+
+            var existingRow = conn.QueryFirstOrDefault<UserStatsManiaKeyCount>($"SELECT * FROM `{keyCountTableName}` WHERE `user_id` = @user_id", keymodeStats, transaction);
+
+            // this should really not be necessary, but there is no real good way to expose the value of `preserve` *inside* a processor
+            // as it does not have access to the raw database row anymore...
+            bool preserve = conn.QuerySingle<bool>($"SELECT `preserve` FROM `scores` WHERE `id` = @id", new { id = score.ID }, transaction);
+
+            if (preserve || existingRow == null)
+            {
+                keymodeStats = existingRow ?? keymodeStats;
+
+                updateRankCounts(score, keymodeStats, conn, transaction);
+
+                List<SoloScore> scores = conn.Query<SoloScore>(
+                    "SELECT beatmap_id, pp, accuracy FROM scores WHERE "
+                    + "`user_id` = @UserId AND "
+                    + "`ruleset_id` = @RulesetId AND "
+                    + "`pp` IS NOT NULL AND "
+                    + "`preserve` = 1 AND "
+                    + "`ranked` = 1 AND "
+                    + "`beatmap_id` IN (SELECT `beatmap_id` FROM `osu_beatmaps` WHERE `playmode` = @RulesetId AND `diff_size` = @KeyCount) "
+                    + "ORDER BY pp DESC LIMIT 1000", new
+                    {
+                        UserId = keymodeStats.user_id,
+                        RulesetId = score.RulesetID,
+                        KeyCount = keyCount,
+                    }, transaction: transaction).ToList();
+
+                (keymodeStats.rank_score, keymodeStats.accuracy_new) = UserTotalPerformanceAggregateHelper.CalculateUserTotalPerformanceAggregates(scores);
+
+                keymodeStats.rank_score_index = conn.QuerySingle<int>($"SELECT COUNT(*) FROM {keyCountTableName} WHERE rank_score > {keymodeStats.rank_score}", transaction: transaction) + 1;
+
+                if (existingRow != null)
+                {
+                    conn.Execute(
+                        $"UPDATE `{keyCountTableName}` "
+                        + $"SET `rank_score` = @rank_score, `playcount` = @playcount + 1, `rank_score_index` = @rank_score_index, `accuracy_new` = @accuracy_new, "
+                        + $"`x_rank_count` = @x_rank_count, `xh_rank_count` = @xh_rank_count, `s_rank_count` = @s_rank_count, `sh_rank_count` = @sh_rank_count, `a_rank_count` = @a_rank_count "
+                        + $"WHERE `user_id` = @user_id", keymodeStats, transaction);
+                }
+                else
+                {
+                    // make up a rough playcount based on user play distribution.
+                    keymodeStats.playcount = conn.QuerySingle<int?>(
+                        "SELECT @playcount * (SELECT COUNT(1) FROM `scores` "
+                        + "WHERE `user_id` = @userId "
+                        + "AND `beatmap_id` IN (SELECT `beatmap_id` FROM `osu_beatmaps` WHERE `playmode` = @rulesetId AND `diff_size` = @keyCount)) "
+                        + "/ (SELECT GREATEST(1, COUNT(*)) FROM `scores` WHERE `user_id` = @userId AND `ruleset_id` = @rulesetId)",
+                        new
+                        {
+                            playcount = fullRulesetStats.playcount,
+                            userId = score.UserID,
+                            rulesetId = score.RulesetID,
+                            keyCount = keyCount,
+                        }, transaction) ?? 1;
+
+                    conn.Execute(
+                        $"REPLACE INTO `{keyCountTableName}` "
+                        + $"(`user_id`, `country_acronym`, `playcount`, `x_rank_count`, `xh_rank_count`, `s_rank_count`, `sh_rank_count`, `a_rank_count`, `rank_score`, `rank_score_index`, `accuracy_new`) "
+                        + $"SELECT @user_id, `country_acronym`, @playcount, @x_rank_count, @xh_rank_count, @s_rank_count, @sh_rank_count, @a_rank_count, @rank_score, @rank_score_index, @accuracy_new "
+                        + $"FROM `phpbb_users` WHERE `user_id` = @user_id",
+                        keymodeStats, transaction);
+                }
+            }
+            else
+            {
+                conn.Execute($"UPDATE `{keyCountTableName}` SET `playcount` = `playcount` + 1 WHERE `user_id` = @user_id", keymodeStats, transaction);
+            }
+        }
+
+        // local reimplementation of `UserRankCountProcessor` for keymodes.
+        // it's a bit unfortunate but it is the only way this can implemented for now until `preserve = 0` is set on lazer scores correctly.
+        private void updateRankCounts(SoloScoreInfo score, UserStatsManiaKeyCount keymodeStats, MySqlConnection conn, MySqlTransaction transaction)
+        {
+            if (!DatabaseHelper.IsBeatmapValidForRankedCounts(score.BeatmapID, conn, transaction))
+                return;
+
+            var bestScore = DatabaseHelper.GetUserBestScoreFor(score, conn, transaction);
+
+            // If there's already another higher score than this one, nothing needs to be done.
+            if (bestScore?.ID != score.ID)
+                return;
+
+            // If this score is the new best and there's a previous higher score, that score's rank should be removed before we apply the new one.
+            var secondBestScore = DatabaseHelper.GetUserBestScoreFor(score, conn, transaction, offset: 1);
+            if (secondBestScore != null)
+                updateRankCounts(keymodeStats, secondBestScore.Rank, revert: true);
+
+            Debug.Assert(bestScore != null);
+            updateRankCounts(keymodeStats, bestScore.Rank, revert: false);
+        }
+
+        private static void updateRankCounts(UserStatsManiaKeyCount stats, ScoreRank rank, bool revert)
+        {
+            int delta = revert ? -1 : 1;
+
+            switch (rank)
+            {
+                case ScoreRank.XH:
+                    stats.xh_rank_count += delta;
+                    break;
+
+                case ScoreRank.X:
+                    stats.x_rank_count += delta;
+                    break;
+
+                case ScoreRank.SH:
+                    stats.sh_rank_count += delta;
+                    break;
+
+                case ScoreRank.S:
+                    stats.s_rank_count += delta;
+                    break;
+
+                case ScoreRank.A:
+                    stats.a_rank_count += delta;
+                    break;
+            }
+        }
+
+        public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
+        {
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ManiaKeyModeUserStatsProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ManiaKeyModeUserStatsProcessor.cs
@@ -49,7 +49,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
             // this should really not be necessary, but there is no real good way to expose the value of `preserve` *inside* a processor
             // as it does not have access to the raw database row anymore...
-            bool preserve = conn.QuerySingle<bool>($"SELECT `preserve` FROM `scores` WHERE `id` = @id", new { id = score.ID }, transaction);
+            bool preserve = conn.QuerySingle<bool>("SELECT `preserve` FROM `scores` WHERE `id` = @id", new { id = score.ID }, transaction);
 
             if (preserve || existingRow == null)
             {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -76,42 +75,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                     RulesetId = rulesetId
                 }, transaction: transaction)).ToList();
 
-            SoloScore[] groupedScores = scores
-                                        // Group by beatmap ID.
-                                        .GroupBy(i => i.beatmap_id)
-                                        // Extract the maximum PP for each beatmap.
-                                        .Select(g => g.OrderByDescending(i => i.pp).First())
-                                        // And order the beatmaps by decreasing value.
-                                        .OrderByDescending(i => i.pp)
-                                        .ToArray();
+            (userStats.rank_score, userStats.accuracy_new) = UserTotalPerformanceAggregateHelper.CalculateUserTotalPerformanceAggregates(scores);
 
-            // Build the diminishing sum
-            double factor = 1;
-            double totalPp = 0;
-            double totalAccuracy = 0;
-
-            foreach (var score in groupedScores)
-            {
-                totalPp += score.pp!.Value * factor;
-                totalAccuracy += score.accuracy * factor;
-                factor *= 0.95;
-            }
-
-            // This weird factor is to keep legacy compatibility with the diminishing bonus of 0.25 by 0.9994 each score.
-            // Of note, this is using de-duped scores which may be below 1,000 depending on how the user plays.
-            totalPp += (417.0 - 1.0 / 3.0) * (1.0 - Math.Pow(0.995, scores.Count));
-
-            // We want our accuracy to be normalized.
-            if (groupedScores.Length > 0)
-            {
-                // We want the percentage, not a factor in [0, 1], hence we divide 20 by 100.
-                totalAccuracy *= 100.0 / (20 * (1 - Math.Pow(0.95, groupedScores.Length)));
-            }
-
-            userStats.rank_score = (float)totalPp;
             if (updateIndex)
                 await updateGlobalRank(userStats, connection, transaction, dbInfo);
-            userStats.accuracy_new = (float)totalAccuracy;
         }
 
         private static async Task updateGlobalRank(UserStats userStats, MySqlConnection connection, MySqlTransaction? transaction, LegacyDatabaseHelper.RulesetDatabaseInfo dbInfo)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu-web/issues/11026
- Intends to obsolete https://github.com/ppy/osu-queue-mania-key-rank-processor

RFC. The logic is more or less a straight port of the old processor, and things appear to work in my testing, but at least all of the queries need a cross-check to determine whether they're going to obliterate mysql on the new table.

The intention is that when this gets deployed, `osu-queue-mania-key-rank-processor` can be turned off, `osu-web-10` can stop pushing to the `osu-queue:mania4k7k` queue, and then we can delete said queue at the end of it all. That is why I made this run on legacy scores too.