### PR TITLE
Delete replays from S3 when cleaning up non-preserved scores

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/DeleteNonPreservedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/DeleteNonPreservedScoresCommand.cs
@@ -37,7 +37,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                 await deleteCommand.PrepareAsync(cancellationToken);
 
                 var scores = await readConnection.QueryAsync<SoloScore>(new CommandDefinition(
-                    $"SELECT * FROM scores WHERE preserve = 0 AND updated_at < DATE_SUB(NOW(), INTERVAL {preserve_hours} HOUR)", flags: CommandFlags.None, cancellationToken: cancellationToken));
+                    $"SELECT * FROM `scores` WHERE `preserve` = 0 AND `unix_updated_at` < UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL {preserve_hours} HOUR))", flags: CommandFlags.None, cancellationToken: cancellationToken));
 
                 foreach (var score in scores)
                 {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/DeleteNonPreservedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/DeleteNonPreservedScoresCommand.cs
@@ -2,12 +2,15 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Globalization;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Dapper;
 using McMaster.Extensions.CommandLineUtils;
 using MySqlConnector;
 using osu.Server.QueueProcessor;
+using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
@@ -25,6 +28,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
             using (var readConnection = DatabaseAccess.GetConnection())
             using (var deleteConnection = DatabaseAccess.GetConnection())
             using (var deleteCommand = deleteConnection.CreateCommand())
+            using (var s3 = S3.GetClient())
             {
                 deleteCommand.CommandText = "DELETE FROM scores WHERE id = @id;";
 
@@ -48,7 +52,22 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
                     if (score.has_replay)
                     {
-                        // TODO: delete replay from s3
+                        Console.WriteLine("* Removing replay from S3...");
+                        var deleteResult = await s3.DeleteObjectAsync(S3.REPLAYS_BUCKET, score.id.ToString(CultureInfo.InvariantCulture), cancellationToken);
+
+                        switch (deleteResult.HttpStatusCode)
+                        {
+                            case HttpStatusCode.NoContent:
+                                // below wording is intentionally very roundabout, because s3 does not actually really seem to produce the types of error you'd expect.
+                                // for instance, even if you request removal of a nonexistent object, it'll just throw a 204 No Content back
+                                // with no real way to determine whether it actually even did anything.
+                                Console.WriteLine("* Deletion request completed without error.");
+                                break;
+
+                            default:
+                                await Console.Error.WriteLineAsync($"* Received unexpected status code when attempting to delete replay: {deleteResult.HttpStatusCode}.");
+                                break;
+                        }
                     }
                 }
             }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyReplayExistsCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyReplayExistsCommand.cs
@@ -8,14 +8,13 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Amazon;
 using Amazon.Runtime;
 using Amazon.S3;
 using Dapper;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Server.QueueProcessor;
+using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
-using InvalidOperationException = System.InvalidOperationException;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 {
@@ -41,18 +40,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
         {
             ulong lastId = StartId ?? 0;
 
-            string s3Key = Environment.GetEnvironmentVariable("S3_KEY") ?? throw new InvalidOperationException("S3_KEY must be specified.");
-            string s3Secret = Environment.GetEnvironmentVariable("S3_SECRET") ?? throw new InvalidOperationException("S3_SECRET must be specified.");
-
-            using var s3 = new AmazonS3Client(new BasicAWSCredentials(s3Key, s3Secret), new AmazonS3Config
-            {
-                CacheHttpClient = true,
-                HttpClientCacheSize = 32,
-                RegionEndpoint = RegionEndpoint.USWest1,
-                UseHttp = true,
-                ForcePathStyle = true
-            });
-
+            using var s3 = S3.GetClient();
             using var conn = DatabaseAccess.GetConnection();
 
             Console.WriteLine();

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyReplayExistsCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyReplayExistsCommand.cs
@@ -78,7 +78,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                     try
                     {
                         // check the replay is available on s3.
-                        _ = await s3.GetObjectMetadataAsync("score-replays", score.id.ToString(CultureInfo.InvariantCulture), cancellationToken);
+                        _ = await s3.GetObjectMetadataAsync(S3.REPLAYS_BUCKET, score.id.ToString(CultureInfo.InvariantCulture), cancellationToken);
                     }
                     catch (AmazonS3Exception ex)
                     {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/S3.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/S3.cs
@@ -10,6 +10,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
 {
     public static class S3
     {
+        public const string REPLAYS_BUCKET = "score-replays";
+
         public static AmazonS3Client GetClient(RegionEndpoint? endpoint = null)
         {
             string s3Key = Environment.GetEnvironmentVariable("S3_KEY") ?? throw new InvalidOperationException("S3_KEY must be specified.");

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/S3.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/S3.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using Amazon;
+using Amazon.Runtime;
+using Amazon.S3;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
+{
+    public static class S3
+    {
+        public static AmazonS3Client GetClient(RegionEndpoint? endpoint = null)
+        {
+            string s3Key = Environment.GetEnvironmentVariable("S3_KEY") ?? throw new InvalidOperationException("S3_KEY must be specified.");
+            string s3Secret = Environment.GetEnvironmentVariable("S3_SECRET") ?? throw new InvalidOperationException("S3_SECRET must be specified.");
+
+            return new AmazonS3Client(new BasicAWSCredentials(s3Key, s3Secret), new AmazonS3Config
+            {
+                CacheHttpClient = true,
+                HttpClientCacheSize = 32,
+                RegionEndpoint = endpoint ?? RegionEndpoint.USWest1,
+                UseHttp = true,
+                ForcePathStyle = true
+            });
+        }
+    }
+}


### PR DESCRIPTION
One of the pending items in https://github.com/ppy/osu-queue-score-statistics/issues/141.

Tested against a real S3 bucket, seems to work.