### PR TITLE
Fix some test-specific issues

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -174,7 +174,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             using (var db = Processor.GetDatabaseConnection())
             {
                 db.Insert(beatmap);
-                db.Insert(beatmapSet);
+                if (db.QuerySingleOrDefault<int>("SELECT COUNT(1) FROM `osu_beatmapsets` WHERE `beatmapset_id` = @beatmapSetId", new { beatmapSetId = beatmapSet.beatmapset_id }) == 0)
+                    db.Insert(beatmapSet);
             }
 
             return beatmap;

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -91,7 +91,34 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
                 scoreSetup?.Invoke(score);
 
-                conn.Insert(score.Score);
+                conn.Execute("INSERT INTO `scores` (`id`, `user_id`, `ruleset_id`, `beatmap_id`, `has_replay`, `preserve`, `ranked`, "
+                             + "`rank`, `passed`, `accuracy`, `max_combo`, `total_score`, `data`, `pp`, `legacy_score_id`, `legacy_total_score`, "
+                             + "`started_at`, `ended_at`, `build_id`) "
+                             + "VALUES (@id, @user_id, @ruleset_id, @beatmap_id, @has_replay, @preserve, @ranked, "
+                             + "@rank, @passed, @accuracy, @max_combo, @total_score, @data, @pp, @legacy_score_id, @legacy_total_score,"
+                             + "@started_at, @ended_at, @build_id)",
+                    new
+                    {
+                        score.Score.id,
+                        score.Score.user_id,
+                        score.Score.ruleset_id,
+                        score.Score.beatmap_id,
+                        score.Score.has_replay,
+                        score.Score.preserve,
+                        score.Score.ranked,
+                        rank = score.Score.rank.ToString(),
+                        score.Score.passed,
+                        score.Score.accuracy,
+                        score.Score.max_combo,
+                        score.Score.total_score,
+                        score.Score.data,
+                        score.Score.pp,
+                        score.Score.legacy_score_id,
+                        score.Score.legacy_total_score,
+                        score.Score.started_at,
+                        score.Score.ended_at,
+                        score.Score.build_id,
+                    });
                 PushToQueueAndWaitForProcess(score);
 
                 return score;

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalAwarderTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalAwarderTest.cs
@@ -28,10 +28,17 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             }
         }
 
-        protected void AddMedal(int medalId)
+        protected void AddMedal(int medalId, int? mode = null)
         {
             using (var db = Processor.GetDatabaseConnection())
-                db.Execute($"INSERT INTO osu_achievements (achievement_id, slug, ordering, progression, name) VALUES ({medalId}, 'A', 1, 1, 'medal')");
+            {
+                db.Execute("INSERT INTO osu_achievements (achievement_id, slug, ordering, progression, name, mode) VALUES (@medalId, 'A', 1, 1, 'medal', @mode)",
+                    new
+                    {
+                        medalId,
+                        mode
+                    });
+            }
         }
 
         protected void AssertSingleMedalAwarded(int medalId)


### PR DESCRIPTION
## [Fix database tests failing if multiple beatmaps specify the same set](https://github.com/ppy/osu-queue-score-statistics/commit/5658eae61a325ddd0cab65d827580f90e38bad14)

This is a little annoying - if you attempt to call `AddBeatmap()` multiple times with the same set ID with the intention of creating a multi-difficulty beatmap set, it'll fail due to a duplicate primary key.

## [Fix scores inserted via tests having invalid rank](https://github.com/ppy/osu-queue-score-statistics/commit/d82391d9ab92e5e45daa3c9ae21cea5f25a1ad55)

Dapper type mapping nonsense [strikes again](https://github.com/ppy/osu-queue-score-statistics/commit/26bcebd0c7898c44074192fba82b49ec0c723d29) (scores would have numbers instead of letter ranks after insertions).

This only becomes apparent when querying the database directly rather than relying on dapper _un_-mapping.

## [Allow specifying mode when adding medal in tests](https://github.com/ppy/osu-queue-score-statistics/commit/644dfc9b6de65a76dc1bfe00caf21510e31292d1)

For use _elsewhere_.