### PR TITLE
Add processor to update last played date in user stats table

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/LastPlayedDateProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/LastPlayedDateProcessorTests.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using Xunit;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
+{
+    public class LastPlayedDateProcessorTests : DatabaseTest
+    {
+        [Fact]
+        public void LastPlayedDateUpdates()
+        {
+            var beatmap = AddBeatmap();
+
+            var firstDate = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            SetScoreForBeatmap(beatmap.beatmap_id, s => s.Score.ended_at = firstDate);
+            WaitForDatabaseState("SELECT `last_played` FROM `osu_user_stats` WHERE user_id = 2", firstDate, CancellationToken);
+
+            var secondDate = new DateTimeOffset(2024, 3, 1, 0, 0, 0, TimeSpan.Zero);
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.ended_at = secondDate;
+                s.Score.passed = false;
+            });
+            WaitForDatabaseState("SELECT `last_played` FROM `osu_user_stats` WHERE user_id = 2", secondDate, CancellationToken);
+
+            // thirdDate is earlier than secondDate => it is expected that `last_played` is not inadvertently rolled back
+            var thirdDate = new DateTimeOffset(2024, 2, 1, 0, 0, 0, TimeSpan.Zero);
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.ended_at = thirdDate;
+                s.Score.passed = false;
+            });
+            WaitForDatabaseState("SELECT `last_played` FROM `osu_user_stats` WHERE user_id = 2", secondDate, CancellationToken);
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/LastPlayedDateProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/LastPlayedDateProcessor.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using JetBrains.Annotations;
+using MySqlConnector;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
+{
+    [UsedImplicitly]
+    public class LastPlayedDateProcessor : IProcessor
+    {
+        public const int ORDER = 0;
+
+        public int Order => ORDER;
+
+        public bool RunOnFailedScores => true;
+        public bool RunOnLegacyScores => false;
+
+        public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
+        {
+        }
+
+        public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
+        {
+            if (userStats.last_played < score.EndedAt || userStats.playcount == 0)
+                userStats.last_played = score.EndedAt;
+        }
+
+        public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
+        {
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
@@ -20,6 +20,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
     [UsedImplicitly]
     public class PlayCountProcessor : IProcessor
     {
+        public int Order => LastPlayedDateProcessor.ORDER + 1;
+
         public bool RunOnFailedScores => true;
 
         public bool RunOnLegacyScores => false;


### PR DESCRIPTION
Not sure how widely used this is exactly, but `osu-web-10` updates this during submission.