### PR TITLE
Add command to fix score ordering

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/ReindexBeatmapCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/ReindexBeatmapCommand.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using McMaster.Extensions.CommandLineUtils;
+using osu.Server.QueueProcessor;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
+{
+    [Command("reindex-beatmap", Description = "Queue all scores from a beatmap for reindexing.")]
+    public class ReindexBeatmapCommand
+    {
+        /// <summary>
+        /// The beatmap to reindex.
+        /// </summary>
+        [Argument(0, Description = "The beatmap to reindex.")]
+        public int BeatmapId { get; set; }
+
+        private readonly ElasticQueuePusher elasticQueueProcessor = new ElasticQueuePusher();
+
+        public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
+        {
+            Console.WriteLine($"Indexing to elasticsearch queue(s) {elasticQueueProcessor.ActiveQueues}");
+
+            using var conn = DatabaseAccess.GetConnection();
+
+            var scores = (await conn.QueryAsync<SoloScore>("SELECT id FROM scores WHERE beatmap_id = @beatmapId AND preserve = 1", new
+            {
+                beatmapId = BeatmapId
+            })).ToArray();
+
+            Console.WriteLine($"Pushing {scores.Length} scores for reindexing...");
+
+            elasticQueueProcessor.PushToQueue(scores.Select(s => new ElasticQueuePusher.ElasticScoreItem
+            {
+                ScoreId = (long)s.id
+            }).ToList());
+
+            Console.WriteLine("Done!");
+            return 0;
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/ReorderIncorrectlyImportedTiedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/ReorderIncorrectlyImportedTiedScoresCommand.cs
@@ -1,0 +1,79 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using McMaster.Extensions.CommandLineUtils;
+using osu.Server.QueueProcessor;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
+{
+    [Command("reorder-tied-scores", Description = "Single use command to fix incorrectly ordered score inserts.")]
+    public class ReorderIncorrectlyImportedTiedScoresCommand
+    {
+        /// <summary>
+        /// The ruleset to run this verify job for.
+        /// </summary>
+        [Option(CommandOptionType.SingleValue, Template = "--ruleset-id")]
+        public int RulesetId { get; set; }
+
+        [Option(CommandOptionType.SingleOrNoValue, Template = "--dry-run")]
+        public bool DryRun { get; set; }
+
+        /// <summary>
+        /// The beatmap ID to start verifying from.
+        /// </summary>
+        [Option(CommandOptionType.SingleValue, Template = "--start-id")]
+        public ulong? StartId { get; set; }
+
+        private readonly ElasticQueuePusher elasticQueueProcessor = new ElasticQueuePusher();
+
+        public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"Verifying tied score orders for ruleset {RulesetId}");
+            Console.WriteLine($"Indexing to elasticsearch queue(s) {elasticQueueProcessor.ActiveQueues}");
+
+            if (DryRun)
+                Console.WriteLine("RUNNING IN DRY RUN MODE.");
+
+            using var conn = DatabaseAccess.GetConnection();
+
+            dynamic[] beatmaps = (await conn.QueryAsync($"SELECT * FROM osu_beatmaps WHERE approved > 0 and beatmap_id >= {StartId ?? 0}")).ToArray();
+
+            foreach (dynamic beatmap in beatmaps)
+            {
+                Console.WriteLine($"Processing {beatmap.beatmap_id}...");
+
+                ulong[] topScoresCheck =
+                    (await conn.QueryAsync<ulong>(
+                        $"SELECT total_score FROM scores WHERE beatmap_id = {beatmap.beatmap_id} and ruleset_id = {RulesetId} AND preserve = 1 AND legacy_score_id IS NOT NULL ORDER BY total_score DESC LIMIT 2"))
+                    .ToArray();
+
+                if (topScoresCheck.Length != 2 || topScoresCheck[0] != topScoresCheck[1])
+                    continue;
+
+                ulong topScore = topScoresCheck[0];
+
+                Console.WriteLine("Has tied scores, checking order...");
+
+                var topScores = (await conn.QueryAsync<SoloScore>(
+                        $"SELECT * FROM scores WHERE beatmap_id = {beatmap.beatmap_id} and ruleset_id = {RulesetId} AND preserve = 1 AND total_score = {topScore} ORDER BY id"))
+                    .ToArray();
+
+                var topScoresSorted = topScores.OrderBy(s => s.legacy_score_id).ToArray();
+
+                if (topScores.SequenceEqual(topScoresSorted))
+                    continue;
+
+                Console.WriteLine("Requires reordering...");
+            }
+
+            return 0;
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/ReorderIncorrectlyImportedTiedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/ReorderIncorrectlyImportedTiedScoresCommand.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Dapper;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Server.QueueProcessor;
+using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
@@ -38,6 +39,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
             Console.WriteLine($"Verifying tied score orders for ruleset {RulesetId}");
             Console.WriteLine($"Indexing to elasticsearch queue(s) {elasticQueueProcessor.ActiveQueues}");
 
+            var rulesetSpecifics = LegacyDatabaseHelper.GetRulesetSpecifics(RulesetId);
+
             int totalReordered = 0;
 
             if (DryRun)
@@ -49,12 +52,19 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
             for (int i = 0; i < beatmaps.Length; i++)
             {
-                dynamic beatmap = beatmaps[i];
-                Console.WriteLine($"Processing {beatmap.beatmap_id}...");
+                if (cancellationToken.IsCancellationRequested)
+                    break;
 
+                dynamic beatmap = beatmaps[i];
+
+                if (i % 1000 == 0)
+                    Console.WriteLine($"Processing {beatmap.beatmap_id}...");
+
+                // Use old scores table because the lookup is faster.
                 ulong[] topScoresCheck =
                     (await conn.QueryAsync<ulong>(
-                        $"SELECT total_score FROM scores WHERE beatmap_id = {beatmap.beatmap_id} and ruleset_id = {RulesetId} AND preserve = 1 AND legacy_score_id IS NOT NULL ORDER BY total_score DESC LIMIT 2", commandTimeout: 60000))
+                        $"SELECT score FROM {rulesetSpecifics.HighScoreTable} WHERE beatmap_id = {beatmap.beatmap_id} AND hidden = 0 ORDER BY score DESC LIMIT 2",
+                        commandTimeout: 60000))
                     .ToArray();
 
                 if (topScoresCheck.Length != 2 || topScoresCheck[0] != topScoresCheck[1])
@@ -62,18 +72,22 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
                 ulong topScore = topScoresCheck[0];
 
-                Console.WriteLine("Has tied scores, checking order...");
+                Console.Write($"{beatmap.beatmap_id} has tied scores, checking order... ");
 
                 var topScores = (await conn.QueryAsync<SoloScore>(
-                        $"SELECT * FROM scores WHERE beatmap_id = {beatmap.beatmap_id} and ruleset_id = {RulesetId} AND preserve = 1 AND total_score = {topScore} ORDER BY id", commandTimeout: 60000))
+                        $"SELECT id, legacy_score_id FROM scores WHERE beatmap_id = {beatmap.beatmap_id} and ruleset_id = {RulesetId} AND preserve = 1 AND legacy_score_id IN (SELECT score_id FROM {rulesetSpecifics.HighScoreTable} WHERE beatmap_id = {beatmap.beatmap_id} AND hidden = 0 AND score = {topScore}) ORDER BY id",
+                        commandTimeout: 60000))
                     .ToArray();
 
                 var topScoresSorted = topScores.OrderBy(s => s.legacy_score_id).ToArray();
 
                 if (topScores.SequenceEqual(topScoresSorted))
+                {
+                    Console.WriteLine("OK");
                     continue;
+                }
 
-                Console.WriteLine("Requires reordering...");
+                Console.WriteLine("FAIL");
 
                 if (!DryRun)
                 {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/ReorderIncorrectlyImportedTiedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/ReorderIncorrectlyImportedTiedScoresCommand.cs
@@ -38,6 +38,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
             Console.WriteLine($"Verifying tied score orders for ruleset {RulesetId}");
             Console.WriteLine($"Indexing to elasticsearch queue(s) {elasticQueueProcessor.ActiveQueues}");
 
+            int totalReordered = 0;
+
             if (DryRun)
                 Console.WriteLine("RUNNING IN DRY RUN MODE.");
 
@@ -45,8 +47,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
             dynamic[] beatmaps = (await conn.QueryAsync($"SELECT * FROM osu_beatmaps WHERE approved > 0 and beatmap_id >= {StartId ?? 0}")).ToArray();
 
-            foreach (dynamic beatmap in beatmaps)
+            for (int i = 0; i < beatmaps.Length; i++)
             {
+                dynamic beatmap = beatmaps[i];
                 Console.WriteLine($"Processing {beatmap.beatmap_id}...");
 
                 ulong[] topScoresCheck =
@@ -71,6 +74,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                     continue;
 
                 Console.WriteLine("Requires reordering...");
+
+                totalReordered++;
+
+                Console.WriteLine($"Reordering complete ({totalReordered} reordered, {i}/{beatmaps.Length})");
             }
 
             return 0;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/ReorderIncorrectlyImportedTiedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/ReorderIncorrectlyImportedTiedScoresCommand.cs
@@ -124,7 +124,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
                 totalReordered++;
 
-                Console.WriteLine($"Reordering complete ({totalReordered} reordered, {i}/{beatmaps.Length})");
+                Console.WriteLine($"Reordering complete ({totalReordered} reordered, {i + 1}/{beatmaps.Length})");
             }
 
             return 0;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/MaintenanceCommands.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/MaintenanceCommands.cs
@@ -14,6 +14,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands
     [Subcommand(typeof(MigratePlaylistScoresToSoloScoresCommand))]
     [Subcommand(typeof(MigrateSoloScoresCommand))]
     [Subcommand(typeof(VerifyImportedScoresCommand))]
+    [Subcommand(typeof(ReorderIncorrectlyImportedTiedScoresCommand))]
     [Subcommand(typeof(DeleteImportedHighScoresCommand))]
     [Subcommand(typeof(VerifyReplaysExistCommand))]
     public sealed class MaintenanceCommands

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/MaintenanceCommands.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/MaintenanceCommands.cs
@@ -15,6 +15,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands
     [Subcommand(typeof(MigrateSoloScoresCommand))]
     [Subcommand(typeof(VerifyImportedScoresCommand))]
     [Subcommand(typeof(ReorderIncorrectlyImportedTiedScoresCommand))]
+    [Subcommand(typeof(ReindexBeatmapCommand))]
     [Subcommand(typeof(DeleteImportedHighScoresCommand))]
     [Subcommand(typeof(VerifyReplaysExistCommand))]
     public sealed class MaintenanceCommands


### PR DESCRIPTION
Will be used to close https://github.com/ppy/osu-web/issues/10922.

I've started to test this in production but the elastic indexing (or something in between) isn't working well, even though the IDs are correctly updating.

The case I ran this on already if you'd like to check on it:

before:

| score id   | legacy score id |
|------------|-----------------|
| [1961647015](https://osu.ppy.sh/scores/1961647015) | [214615400](https://osu.ppy.sh/scores/fruits/214615400) |
| [1961647016](https://osu.ppy.sh/scores/1961647016) | [214584096](https://osu.ppy.sh/scores/fruits/214584096) |

after:

| score id   | legacy score id |
|------------|-----------------|
| [1961647015](https://osu.ppy.sh/scores/1961647015) | [214584096](https://osu.ppy.sh/scores/fruits/214584096) |
| [1961647016](https://osu.ppy.sh/scores/1961647016) | [214615400](https://osu.ppy.sh/scores/fruits/214615400) |


```
Verifying tied score orders for ruleset 2
Indexing to elasticsearch queue(s) osu-queue:scores_20240113
Processing 4157529...
4157529 has tied scores, checking order... FAIL
- legacy 214584096 remapping from 1961647016 to 1961647015
- legacy 214584099 remapping from 1961647024 to 1961647016
- legacy 214584117 remapping from 1961647032 to 1961647024
- legacy 214584216 remapping from 1961647049 to 1961647032
- legacy 214584353 remapping from 1961647057 to 1961647049
- legacy 214615400 remapping from 1961647015 to 1961647057
- legacy 214830862 remapping from 1961852270 to 1961852270
- legacy 216039456 remapping from 2422252508 to 2422252508
Reordering complete (1 reordered, 0/8821)
```


Will hold off doing a full run until reviewed.