### PR TITLE
Check ranked state when determining user best score in mark non-preserved scores command

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MarkNonPreservedScoresCommandTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MarkNonPreservedScoresCommandTest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Threading.Tasks;
+using Dapper;
 using osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 using Xunit;
@@ -15,6 +16,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         public MarkNonPreservedScoresCommandTest()
         {
             beatmap = AddBeatmap();
+
+            using var db = Processor.GetDatabaseConnection();
+
+            db.Execute("DELETE FROM `multiplayer_playlist_item_scores`");
+            db.Execute("TRUNCATE TABLE `score_pins`");
         }
 
         [Fact]
@@ -46,6 +52,64 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 1", 2, CancellationToken);
             WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 0", 1, CancellationToken);
             WaitForDatabaseState("SELECT `preserve` FROM `scores` WHERE `id` = 3", false, CancellationToken);
+        }
+
+        [Fact]
+        public async Task NonBestScoresRemainPreservedIfPinned()
+        {
+            using var db = Processor.GetDatabaseConnection();
+
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 1;
+                s.Score.total_score = 800_000;
+                s.Score.pp = 95;
+            });
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 2;
+                s.Score.total_score = 500_000;
+                s.Score.pp = 85;
+            });
+            await db.ExecuteAsync("INSERT INTO `score_pins` (`user_id`, `score_type`, `score_id`, `ruleset_id`, `display_order`) VALUES (2, 'solo_score', 2, 0, 0)");
+
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 1", 2, CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 0", 0, CancellationToken);
+
+            var command = new MarkNonPreservedScoresCommand { RulesetId = 0 };
+            await command.OnExecuteAsync(CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 1", 2, CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 0", 0, CancellationToken);
+            WaitForDatabaseState("SELECT `preserve` FROM `scores` WHERE `id` = 2", true, CancellationToken);
+        }
+
+        [Fact]
+        public async Task NonBestScoresRemainPreservedIfAssociatedWithPlaylistItem()
+        {
+            using var db = Processor.GetDatabaseConnection();
+
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 1;
+                s.Score.total_score = 800_000;
+                s.Score.pp = 95;
+            });
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 2;
+                s.Score.total_score = 500_000;
+                s.Score.pp = 85;
+            });
+            await db.ExecuteAsync("INSERT INTO `multiplayer_playlist_item_scores` (`user_id`, `playlist_item_id`, `score_id`) VALUES (2, 1, 2)");
+
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 1", 2, CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 0", 0, CancellationToken);
+
+            var command = new MarkNonPreservedScoresCommand { RulesetId = 0 };
+            await command.OnExecuteAsync(CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 1", 2, CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 0", 0, CancellationToken);
+            WaitForDatabaseState("SELECT `preserve` FROM `scores` WHERE `id` = 2", true, CancellationToken);
         }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MarkNonPreservedScoresCommandTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MarkNonPreservedScoresCommandTest.cs
@@ -1,0 +1,51 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading.Tasks;
+using osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using Xunit;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
+{
+    public class MarkNonPreservedScoresCommandTest : DatabaseTest
+    {
+        private readonly Beatmap beatmap;
+
+        public MarkNonPreservedScoresCommandTest()
+        {
+            beatmap = AddBeatmap();
+        }
+
+        [Fact]
+        public async Task OnlyBestPPAndTotalScoresArePreserved()
+        {
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 1;
+                s.Score.total_score = 800_000;
+                s.Score.pp = 95;
+            });
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 2;
+                s.Score.total_score = 850_000;
+                s.Score.pp = 90;
+            });
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 3;
+                s.Score.total_score = 500_000;
+                s.Score.pp = 85;
+            });
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 1", 3, CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 0", 0, CancellationToken);
+
+            var command = new MarkNonPreservedScoresCommand { RulesetId = 0 };
+            await command.OnExecuteAsync(CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 1", 2, CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 0", 1, CancellationToken);
+            WaitForDatabaseState("SELECT `preserve` FROM `scores` WHERE `id` = 3", false, CancellationToken);
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MarkNonPreservedScoresCommandTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MarkNonPreservedScoresCommandTest.cs
@@ -111,5 +111,31 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 0", 0, CancellationToken);
             WaitForDatabaseState("SELECT `preserve` FROM `scores` WHERE `id` = 2", true, CancellationToken);
         }
+
+        [Fact]
+        public async Task ScoreNotConsideredBestIfNotRanked()
+        {
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 1;
+                s.Score.total_score = 800_000;
+                s.Score.pp = 95;
+                s.Score.ranked = false;
+            });
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 2;
+                s.Score.total_score = 500_000;
+                s.Score.pp = 85;
+            });
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 1", 2, CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 0", 0, CancellationToken);
+
+            var command = new MarkNonPreservedScoresCommand { RulesetId = 0 };
+            await command.OnExecuteAsync(CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 1", 1, CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 0", 1, CancellationToken);
+            WaitForDatabaseState("SELECT `preserve` FROM `scores` WHERE `id` = 1", false, CancellationToken);
+        }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MarkNonPreservedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MarkNonPreservedScoresCommand.cs
@@ -120,11 +120,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
         private static bool checkIsUserHigh(IEnumerable<SoloScore> userScores, SoloScore candidate)
         {
             var maxPPUserScore = userScores
-                                 .Where(s => s.beatmap_id == candidate.beatmap_id && s.ruleset_id == candidate.ruleset_id && compareMods(candidate, s))
+                                 .Where(s => s.beatmap_id == candidate.beatmap_id && s.ruleset_id == candidate.ruleset_id && compareMods(candidate, s) && s.ranked)
                                  .MaxBy(s => s.pp);
 
             var maxScoreUserScore = userScores
-                                    .Where(s => s.beatmap_id == candidate.beatmap_id && s.ruleset_id == candidate.ruleset_id && compareMods(candidate, s))
+                                    .Where(s => s.beatmap_id == candidate.beatmap_id && s.ruleset_id == candidate.ruleset_id && compareMods(candidate, s) && s.ranked)
                                     .MaxBy(s => s.total_score);
 
             // Check whether this score is the user's highest

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MarkNonPreservedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MarkNonPreservedScoresCommand.cs
@@ -98,7 +98,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
                 if (!DryRun)
                 {
-                    await db.ExecuteAsync("UPDATE scores SET preserve = 0, unix_updated_at = CURRENT_TIMESTAMP WHERE id = @scoreId;", new
+                    await db.ExecuteAsync("UPDATE scores SET preserve = 0, unix_updated_at = UNIX_TIMESTAMP() WHERE id = @scoreId;", new
                     {
                         scoreId = score.id
                     });


### PR DESCRIPTION
This came up yesterday - @peppy found a score with `ranked=0` and no corresponding `osu_scores_high` row, which ended up originating from a recently-ranked beatmap. `ranked=0` was [correctly set by osu-web](https://github.com/ppy/osu-web/blob/e1c3f5a907085d0b228ff848e956d34ec280cf95/app/Jobs/RemoveBeatmapsetSoloScores.php#L61), but the preserve command wasn't really even attempting to correctly account for it, which it should do now after 912b135eaf2440e62235740cac7a0454eaa6be56.

Note that this means that _every_ unranked score will be subject to non-preservation unless pinned and/or associated with a multiplayer room. This seems fine to me, but I'm not super sure it will be to everyone else.

Checking the ranked date was also brought up in related discussions but today I'm not really sure any ranked date checks are required anymore in light of the above, but I might be missing something? Also, if we still want such checks they're going to be a little annoying to write well at power user scale (thinking completionists with tens of thousands of unique maps completed and probably hundreds of thousands of scores to go through).

Diff also includes test coverage of existing mark non-preserved logic, as well as an actual SQL fix (865885993d278115dba15b479115e058c5e143b6 - I'm not sure how I even worked with this command at all without fixing this before, must have been running dry-run only or something).