### PR TITLE
👷 Trigger remote tag and build on private repo

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -70,9 +70,28 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.KUBERNETES_CONFIG_REPO_ACCESS_TOKEN }}
           repository: ppy/osu-kubernetes-config
           event-type: dev-ppy-sh-deploy
           client-payload: '{ "values": { "osu-queue-score-statistics": { "image": { "tag": "${{ github.sha }}" } } } }'
+
+  trigger_private_build:
+    if: ${{ github.ref_type == 'tag' }}
+    runs-on: ubuntu-latest
+    needs:
+      - push_to_registry
+    environment: production
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      - 
+        name: Invoke tag workflow in private repo
+        uses: benc-uk/workflow-dispatch@25b02cc069be46d637e8fe2f1e8484008e9e9609 # v1.2.3
+        with:
+          token: ${{ secrets.PRIVATE_REPO_ACCESS_TOKEN }}
+          repo: ppy/osu-queue-score-statistics-private
+          workflow: tag.yml
+          inputs: '{ "tag": "${{ github.ref_name }}" }'


### PR DESCRIPTION
@peppy Manual approval for deployments to the `production` environment can be set up in this project's settings, similar to `osu-web`.