### PR TITLE
Check ranked state when retrieving user best scores

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/RankedScoreProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/RankedScoreProcessorTests.cs
@@ -47,6 +47,19 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         }
 
         [Fact]
+        public void TestUnrankedScoreOnRankedMapDoesNotIncreaseRankedScore()
+        {
+            AddBeatmap(b => b.approved = BeatmapOnlineStatus.Ranked);
+            waitForRankedScore("osu_user_stats", 0);
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, s => s.Score.ranked = false);
+            waitForRankedScore("osu_user_stats", 0);
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, s => s.Score.total_score = 50000);
+            waitForRankedScore("osu_user_stats", 5041);
+        }
+
+        [Fact]
         public void TestScoresFromDifferentBeatmapsAreCountedSeparately()
         {
             var firstBeatmap = AddBeatmap(b => b.beatmap_id = 1001, s => s.beatmapset_id = 1);

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/UserRankCountProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/UserRankCountProcessorTests.cs
@@ -117,6 +117,32 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         }
 
         [Fact]
+        public void TestUnrankedScoreWithRankAOrAboveOnRankedMapDoesNotChangeRankCounts()
+        {
+            AddBeatmap(b => b.approved = BeatmapOnlineStatus.Ranked);
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
+            {
+                item.Score.total_score = 100_000;
+                item.Score.rank = ScoreRank.A;
+                item.Score.ranked = false;
+            });
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
+            {
+                item.Score.total_score = 50_000;
+                item.Score.rank = ScoreRank.S;
+                item.Score.ranked = true;
+            });
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.S] = 1
+            });
+        }
+
+        [Fact]
         public void TestScoreFromSameBeatmapAndHigherTotalChangesCountedRank()
         {
             AddBeatmap();

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/DatabaseHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/DatabaseHelper.cs
@@ -205,6 +205,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
                 // usages in processors will generally pass in an unprocessed score, but still expect it to be included in the results of this query as if it was processed.
                 // therefore we need to make an exception here to ensure it's included.
                 + "AND (`preserve` = 1 OR `id` = @new_score_id) "
+                + "AND `ranked` = 1 "
                 + "ORDER BY total_score DESC, `id` DESC "
                 + "LIMIT @offset, 1", new
                 {


### PR DESCRIPTION
`DatabaseHelper.GetUserBestScoreFor()` did not check the value of `ranked` for the rows it was looking through to find the user's best score, which means that it could wrongly select an unranked score (i.e. one set back when a map was in qualified).

This potentially impacts: user total ranked score and user total letter rank counts in all rulesets (including mania keymodes). Please see added test cases for explanation as to how. The worst case scenario is that the user's real best score would not be counted towards those stats because of an unranked score with a higher total.

I don't believe there to be a sane path for retroactively fixing that (if it ever even happened, which I don't know - I only realised this could be a possibility when working on medals / https://github.com/ppy/osu-queue-score-statistics/pull/254). Potentially reprocessing those scores could work, if they can be located easily - which is going to be the bigger problem here.