### PR TITLE
General code quality improvements

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -60,6 +60,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                     throw new InvalidOperationException("You are trying to do something very silly.");
 
                 db.Execute("TRUNCATE TABLE osu_user_stats");
+                db.Execute("TRUNCATE TABLE osu_user_stats_taiko");
+                db.Execute("TRUNCATE TABLE osu_user_stats_fruits");
                 db.Execute("TRUNCATE TABLE osu_user_stats_mania");
                 db.Execute("TRUNCATE TABLE osu_user_beatmap_playcount");
                 db.Execute("TRUNCATE TABLE osu_user_month_playcount");

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -43,7 +43,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         {
             cancellationSource = Debugger.IsAttached
                 ? new CancellationTokenSource()
-                : new CancellationTokenSource(10000);
+                : new CancellationTokenSource(20000);
 
             Environment.SetEnvironmentVariable("REALTIME_DIFFICULTY", "0");
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalAwarderTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalAwarderTest.cs
@@ -2,8 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Dapper;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 using osu.Server.Queues.ScoreStatisticsProcessor.Processors;
 using Xunit;
 
@@ -38,6 +40,19 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                         medalId,
                         mode
                     });
+            }
+        }
+
+        protected void AddPackMedal(int medalId, int packId, IReadOnlyList<Beatmap> beatmaps)
+        {
+            AddMedal(medalId);
+
+            using (var db = Processor.GetDatabaseConnection())
+            {
+                db.Execute($"INSERT INTO osu_beatmappacks (pack_id, url, name, author, tag, date) VALUES ({packId}, 'https://osu.ppy.sh', 'pack', 'wang', 'PACK', NOW())");
+
+                foreach (int setId in beatmaps.GroupBy(b => b.beatmapset_id).Select(g => g.Key))
+                    db.Execute($"INSERT INTO osu_beatmappacks_items (pack_id, beatmapset_id) VALUES ({packId}, {setId})");
             }
         }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
@@ -394,7 +394,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             var beatmap = AddBeatmap();
 
-            addMedal(medal_id);
+            AddMedal(medal_id);
 
             AssertNoMedalsAwarded();
             SetScoreForBeatmap(beatmap.beatmap_id, s => s.Score.ScoreData.Mods = new[] { new APIMod(new OsuModDoubleTime()), new APIMod(new OsuModEasy()) });
@@ -425,7 +425,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             var beatmap = AddBeatmap();
 
-            addMedal(medal_id);
+            AddMedal(medal_id);
 
             AssertNoMedalsAwarded();
 
@@ -453,8 +453,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             });
             AddBeatmapAttributes<OsuDifficultyAttributes>(beatmap.beatmap_id);
 
-            addMedal(medal_id_pass);
-            addMedal(medal_id_fc);
+            AddMedal(medal_id_pass);
+            AddMedal(medal_id_fc);
 
             AssertNoMedalsAwarded();
             SetScoreForBeatmap(beatmap.beatmap_id, s =>
@@ -509,8 +509,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var beatmap = AddBeatmap(b => b.beatmap_id = getNextBeatmapId());
             AddBeatmapAttributes<OsuDifficultyAttributes>(beatmap.beatmap_id);
 
-            addMedal(medal_id_pass);
-            addMedal(medal_id_fc);
+            AddMedal(medal_id_pass);
+            AddMedal(medal_id_fc);
 
             AssertNoMedalsAwarded();
             SetScoreForBeatmap(beatmap.beatmap_id, s =>
@@ -546,8 +546,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var beatmap = AddBeatmap(b => b.beatmap_id = getNextBeatmapId());
             AddBeatmapAttributes<OsuDifficultyAttributes>(beatmap.beatmap_id);
 
-            addMedal(medal_id_5_star);
-            addMedal(medal_id_4_star);
+            AddMedal(medal_id_5_star);
+            AddMedal(medal_id_4_star);
 
             AssertNoMedalsAwarded();
             SetScoreForBeatmap(beatmap.beatmap_id);
@@ -580,9 +580,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             int[] fcMedalIds = { 63, 64, 65, 66, 67, 68, 69, 70, 243, 245 };
 
             foreach (int passMedal in passMedalIds)
-                addMedal(passMedal);
+                AddMedal(passMedal);
             foreach (int fcMedal in fcMedalIds)
-                addMedal(fcMedal);
+                AddMedal(fcMedal);
 
             AssertNoMedalsAwarded();
             SetScoreForBeatmap(beatmap.beatmap_id, s =>
@@ -617,7 +617,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var beatmap = AddBeatmap(b => b.beatmap_id = 19990);
             AddBeatmapAttributes<TaikoDifficultyAttributes>(beatmap.beatmap_id, mode: 1);
 
-            addMedal(medal_id_5_star);
+            AddMedal(medal_id_5_star);
 
             AssertNoMedalsAwarded();
 
@@ -638,7 +638,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var beatmap = AddBeatmap(b => b.beatmap_id = getNextBeatmapId());
             AddBeatmapAttributes<ManiaDifficultyAttributes>(beatmap.beatmap_id, mode: 3);
 
-            addMedal(medal_id_5_star);
+            AddMedal(medal_id_5_star);
 
             AssertNoMedalsAwarded();
 
@@ -687,7 +687,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             });
             AddBeatmapAttributes<OsuDifficultyAttributes>(beatmap.beatmap_id);
 
-            addMedal(medal_id_5_star);
+            AddMedal(medal_id_5_star);
 
             AssertNoMedalsAwarded();
 
@@ -711,7 +711,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             var beatmap = AddBeatmap(b => b.approved = onlineStatus);
 
-            addMedal(medal_id);
+            AddMedal(medal_id);
 
             AssertNoMedalsAwarded();
             SetScoreForBeatmap(beatmap.beatmap_id, s => s.Score.max_combo = 499);
@@ -732,7 +732,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             var beatmap = AddBeatmap(b => b.beatmap_id = getNextBeatmapId());
 
-            addMedal(medal_id);
+            AddMedal(medal_id);
             SetScoreForBeatmap(beatmap.beatmap_id, s =>
             {
                 s.Score.max_combo = 500;
@@ -754,7 +754,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             var beatmap = AddBeatmap(b => b.approved = onlineStatus);
 
-            addMedal(medal_id);
+            AddMedal(medal_id);
             SetScoreForBeatmap(beatmap.beatmap_id, s => s.Score.max_combo = 500);
             AssertNoMedalsAwarded();
         }
@@ -769,7 +769,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             var beatmap = AddBeatmap();
 
-            addMedal(medal_id);
+            AddMedal(medal_id);
 
             // Set up user stats with 4998 play count
             using (var db = Processor.GetDatabaseConnection())
@@ -807,7 +807,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             var beatmap = AddBeatmap();
 
-            addMedal(medal_id);
+            AddMedal(medal_id);
 
             // Set up user stats with 39998 mania key presses
             using (var db = Processor.GetDatabaseConnection())
@@ -846,10 +846,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         [Fact]
         public void TestRankMilestoneMedal()
         {
-            addMedal(50);
-            addMedal(51);
-            addMedal(52);
-            addMedal(53);
+            AddMedal(50);
+            AddMedal(51);
+            AddMedal(52);
+            AddMedal(53);
 
             // simulate fake users to beat as we climb up ranks.
             // this is going to be a bit of a chonker query...
@@ -907,14 +907,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 s.Score.pp = 99000; // ~990010 pp total, including bonus pp => rank above 1k
             });
             AssertMedalAwarded(53);
-        }
-
-        private void addMedal(int medalId)
-        {
-            using (var db = Processor.GetDatabaseConnection())
-            {
-                db.Execute($"INSERT INTO osu_achievements (achievement_id, slug, ordering, progression, name) VALUES ({medalId}, 'A', 1, 1, 'medal')");
-            }
         }
 
         private void addPackMedal(int medalId, int packId, IReadOnlyList<Beatmap> beatmaps)

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
@@ -63,7 +63,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         {
             var beatmap = AddBeatmap();
 
-            addPackMedal(medalId, packId, new[] { beatmap });
+            AddPackMedal(medalId, packId, new[] { beatmap });
             setUpBeatmapsForPackMedal([beatmap]);
 
             AssertNoMedalsAwarded();
@@ -92,7 +92,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         {
             var beatmap = AddBeatmap();
 
-            addPackMedal(medalId, packId, new[] { beatmap });
+            AddPackMedal(medalId, packId, new[] { beatmap });
 
             AssertNoMedalsAwarded();
             SetScoreForBeatmap(beatmap.beatmap_id, s =>
@@ -114,7 +114,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var firstBeatmap = AddBeatmap(b => b.beatmap_id = 1234, s => s.beatmapset_id = 4321);
             var secondBeatmap = AddBeatmap(b => b.beatmap_id = 5678, s => s.beatmapset_id = 8765);
 
-            addPackMedal(medalId, packId, new[] { firstBeatmap, secondBeatmap });
+            AddPackMedal(medalId, packId, new[] { firstBeatmap, secondBeatmap });
             setUpBeatmapsForPackMedal([firstBeatmap, secondBeatmap]);
 
             AssertNoMedalsAwarded();
@@ -163,7 +163,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 AddBeatmap(b => b.beatmap_id = 497769, s => s.beatmapset_id = 211704),
             };
 
-            addPackMedal(medalId, packId, allBeatmaps);
+            AddPackMedal(medalId, packId, allBeatmaps);
             setUpBeatmapsForPackMedal(allBeatmaps);
 
             // Need to space out submissions else we will hit rate limits.
@@ -217,7 +217,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             Assert.Equal(4, beatmaps.Count);
 
-            addPackMedal(medalId, packId, beatmaps);
+            AddPackMedal(medalId, packId, beatmaps);
             setUpBeatmapsForPackMedal(beatmaps);
 
             foreach (var beatmap in beatmaps)
@@ -245,7 +245,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var beatmap1 = AddBeatmap(b => b.beatmap_id = 71623, s => s.beatmapset_id = 13022);
             var beatmap2 = AddBeatmap(b => b.beatmap_id = 59225, s => s.beatmapset_id = 16520);
 
-            addPackMedal(medalId, packId, new[] { beatmap1, beatmap2 });
+            AddPackMedal(medalId, packId, new[] { beatmap1, beatmap2 });
             setUpBeatmapsForPackMedal([beatmap1, beatmap2]);
 
             SetScoreForBeatmap(beatmap1.beatmap_id, s =>
@@ -297,7 +297,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 AddBeatmap(b => b.beatmap_id = 2324126, s => s.beatmapset_id = 1112424),
             };
 
-            addPackMedal(medal_id, pack_id, allBeatmaps);
+            AddPackMedal(medal_id, pack_id, allBeatmaps);
             setUpBeatmapsForPackMedal(allBeatmaps);
             AssertNoMedalsAwarded();
 
@@ -367,7 +367,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var beatmap = AddBeatmap();
             setUpBeatmapsForPackMedal([beatmap], allModCombinations: true);
 
-            addPackMedal(medal_id, pack_id, new[] { beatmap });
+            AddPackMedal(medal_id, pack_id, new[] { beatmap });
             AssertNoMedalsAwarded();
 
             SetScoreForBeatmap(beatmap.beatmap_id, s =>
@@ -907,19 +907,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 s.Score.pp = 99000; // ~990010 pp total, including bonus pp => rank above 1k
             });
             AssertMedalAwarded(53);
-        }
-
-        private void addPackMedal(int medalId, int packId, IReadOnlyList<Beatmap> beatmaps)
-        {
-            AddMedal(medalId);
-
-            using (var db = Processor.GetDatabaseConnection())
-            {
-                db.Execute($"INSERT INTO osu_beatmappacks (pack_id, url, name, author, tag, date) VALUES ({packId}, 'https://osu.ppy.sh', 'pack', 'wang', 'PACK', NOW())");
-
-                foreach (int setId in beatmaps.GroupBy(b => b.beatmapset_id).Select(g => g.Key))
-                    db.Execute($"INSERT INTO osu_beatmappacks_items (pack_id, beatmapset_id) VALUES ({packId}, {setId})");
-            }
         }
 
         private void setUpBeatmapsForPackMedal(IEnumerable<Beatmap> beatmaps, bool allModCombinations = false)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/MedalHelpers.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/MedalHelpers.cs
@@ -1,4 +1,6 @@
-﻿using osu.Game.Rulesets.Mods;
+﻿using Dapper;
+using osu.Game.Rulesets.Mods;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
 {
@@ -44,6 +46,56 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
                 default:
                     return m.Type == ModType.System;
             }
+        }
+
+        /// <summary>
+        /// Checks whether the user associated with the given <paramref name="context"/> has passed pack with ID <paramref name="packId"/>.
+        /// </summary>
+        /// <param name="context">The context in which the medal is being checked.</param>
+        /// <param name="noReductionMods">Whether difficulty reduction mods are allowed (challenge packs don't allow them).</param>
+        /// <param name="packId">The ID of the pack to check.</param>
+        /// <returns></returns>
+        public static bool UserPassedPack(MedalAwarderContext context, bool noReductionMods, int packId)
+        {
+            string modsCriteria = string.Empty;
+            string rulesetCriteria = string.Empty;
+
+            if (noReductionMods)
+            {
+                modsCriteria = @"AND json_search(data, 'one', 'EZ', null, '$.mods[*].acronym') IS NULL"
+                               + " AND json_search(data, 'one', 'NF', null, '$.mods[*].acronym') IS NULL"
+                               + " AND json_search(data, 'one', 'HT', null, '$.mods[*].acronym') IS NULL"
+                               + " AND json_search(data, 'one', 'DC', null, '$.mods[*].acronym') IS NULL"
+                               + " AND json_search(data, 'one', 'SO', null, '$.mods[*].acronym') IS NULL"
+                               // this conditional's goal is to exclude plays with unranked mods from query.
+                               // the reason why this is done in this roundabout way is that expressing the query in SQL is complicated otherwise,
+                               // and materialising the collection of all scores to check this C#-side is likely to be prohibitively expensive.
+                               + " AND s.pp IS NOT NULL";
+            }
+
+            // ensure the correct mode, if one is specified
+            int? packRulesetId = context.Connection.QuerySingle<int?>($"SELECT playmode FROM `osu_beatmappacks` WHERE pack_id = {packId}", transaction: context.Transaction);
+
+            if (packRulesetId != null)
+            {
+                if (context.Score.RulesetID != packRulesetId)
+                    return false;
+
+                rulesetCriteria = $"AND ruleset_id = {packRulesetId}";
+            }
+
+            // TODO: no index on (beatmap_id, user_id) may mean this is too slow.
+            // note that the `preserve = 1` condition relies on the flag being set before score processing (https://github.com/ppy/osu-web/pull/10946).
+            int completed = context.Connection.QuerySingle<int>(
+                "SELECT COUNT(distinct p.beatmapset_id)"
+                + "FROM osu_beatmappacks_items p "
+                + "JOIN osu_beatmaps b USING (beatmapset_id) "
+                + "JOIN scores s USING (beatmap_id)"
+                + $"WHERE s.user_id = {context.Score.UserID} AND s.passed = 1 AND s.preserve = 1 AND pack_id = {packId} {rulesetCriteria} {modsCriteria}", transaction: context.Transaction);
+
+            int countForPack = context.Connection.QuerySingle<int>($"SELECT COUNT(*) FROM `osu_beatmappacks_items` WHERE pack_id = {packId}", transaction: context.Transaction);
+
+            return completed >= countForPack;
         }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/MedalHelpers.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/MedalHelpers.cs
@@ -24,5 +24,26 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
                     return false;
             }
         }
+
+        /// <summary>
+        /// Some medals on stable require no mods to be active,
+        /// but lazer submission specifics mean that some mods should be allowed.
+        /// <list type="bullet">
+        /// <item>Classic mod marks stable scores, so it should be allowed.</item>
+        /// <item>System mods like touch device should also be allowed, because they're typically not in the user's direct control.</item>
+        /// </list>
+        /// </summary>
+        public static bool IsPermittedInNoModContext(Mod m)
+        {
+            switch (m)
+            {
+                // Allow classic mod
+                case ModClassic:
+                    return true;
+
+                default:
+                    return m.Type == ModType.System;
+            }
+        }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/Beatmap.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/Beatmap.cs
@@ -19,6 +19,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 
         public uint beatmapset_id { get; set; }
 
+        public uint user_id { get; set; }
+
         public uint countTotal { get; set; }
         public uint countNormal { get; set; }
         public uint countSlider { get; set; }
@@ -32,11 +34,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
         public int playcount { get; set; }
         public BeatmapOnlineStatus approved { get; set; }
         public float difficultyrating { get; set; }
+        public uint hit_length { get; set; }
+        public float bpm { get; set; }
 
         public APIBeatmap ToAPIBeatmap() => new APIBeatmap
         {
             OnlineID = (int)beatmap_id,
             OnlineBeatmapSetID = (int)beatmapset_id,
+            AuthorID = (int)user_id,
             CircleCount = (int)countNormal,
             SliderCount = (int)countSlider,
             SpinnerCount = (int)countSpinner,
@@ -49,6 +54,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
             StarRating = difficultyrating,
             PlayCount = playcount,
             Status = approved,
+            HitLength = hit_length,
+            BPM = bpm,
         };
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/BeatmapSet.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/BeatmapSet.cs
@@ -16,6 +16,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
     {
         [ExplicitKey]
         public int beatmapset_id { get; set; }
+
         public uint user_id { get; set; }
 
         public string artist { get; set; } = string.Empty;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/BeatmapSet.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/BeatmapSet.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using Dapper.Contrib.Extensions;
 using osu.Game.Beatmaps;
+using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 {
@@ -15,6 +16,22 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
     {
         [ExplicitKey]
         public int beatmapset_id { get; set; }
+        public uint user_id { get; set; }
+
+        public string artist { get; set; } = string.Empty;
+        public string title { get; set; } = string.Empty;
+        public string creator { get; set; } = string.Empty;
+        public double bpm { get; set; }
+
+        public APIBeatmapSet ToAPIBeatmapSet() => new APIBeatmapSet
+        {
+            OnlineID = beatmapset_id,
+            Artist = artist,
+            Title = title,
+            AuthorString = creator,
+            AuthorID = (int)user_id,
+            BPM = bpm,
+        };
 
         public BeatmapOnlineStatus approved { get; set; }
     }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/ModIntroductionMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/ModIntroductionMedalAwarder.cs
@@ -20,7 +20,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
             Ruleset ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(context.Score.RulesetID);
 
             // Select score mods, ignoring certain mods that can be included in the combination for mod introduction medals
-            Mod[] mods = context.Score.Mods.Select(m => m.ToMod(ruleset)).Where(m => !isIgnoredForIntroductionMedal(m)).ToArray();
+            Mod[] mods = context.Score.Mods.Select(m => m.ToMod(ruleset)).Where(m => !MedalHelpers.IsPermittedInNoModContext(m)).ToArray();
 
             // Ensure the mod is the only one selected
             if (mods.Length != 1)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Dapper;
 using JetBrains.Annotations;
+using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
@@ -454,45 +455,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
                 if (!validPacksForBeatmapSet.Contains(packId))
                     return false;
 
-                string modsCriteria = string.Empty;
-                string rulesetCriteria = string.Empty;
-
-                if (noReductionMods)
-                {
-                    modsCriteria = @"AND json_search(data, 'one', 'EZ', null, '$.mods[*].acronym') IS NULL"
-                                   + " AND json_search(data, 'one', 'NF', null, '$.mods[*].acronym') IS NULL"
-                                   + " AND json_search(data, 'one', 'HT', null, '$.mods[*].acronym') IS NULL"
-                                   + " AND json_search(data, 'one', 'DC', null, '$.mods[*].acronym') IS NULL"
-                                   + " AND json_search(data, 'one', 'SO', null, '$.mods[*].acronym') IS NULL"
-                                   // this conditional's goal is to exclude plays with unranked mods from query.
-                                   // the reason why this is done in this roundabout way is that expressing the query in SQL is complicated otherwise,
-                                   // and materialising the collection of all scores to check this C#-side is likely to be prohibitively expensive.
-                                   + " AND s.pp IS NOT NULL";
-                }
-
-                // ensure the correct mode, if one is specified
-                int? packRulesetId = context.Connection.QuerySingle<int?>($"SELECT playmode FROM `osu_beatmappacks` WHERE pack_id = {packId}", transaction: context.Transaction);
-
-                if (packRulesetId != null)
-                {
-                    if (context.Score.RulesetID != packRulesetId)
-                        return false;
-
-                    rulesetCriteria = $"AND ruleset_id = {packRulesetId}";
-                }
-
-                // TODO: no index on (beatmap_id, user_id) may mean this is too slow.
-                // note that the `preserve = 1` condition relies on the flag being set before score processing (https://github.com/ppy/osu-web/pull/10946).
-                int completed = context.Connection.QuerySingle<int>(
-                    "SELECT COUNT(distinct p.beatmapset_id)"
-                    + "FROM osu_beatmappacks_items p "
-                    + "JOIN osu_beatmaps b USING (beatmapset_id) "
-                    + "JOIN scores s USING (beatmap_id)"
-                    + $"WHERE s.user_id = {context.Score.UserID} AND s.passed = 1 AND s.preserve = 1 AND pack_id = {packId} {rulesetCriteria} {modsCriteria}", transaction: context.Transaction);
-
-                int countForPack = context.Connection.QuerySingle<int>($"SELECT COUNT(*) FROM `osu_beatmappacks_items` WHERE pack_id = {packId}", transaction: context.Transaction);
-
-                return completed >= countForPack;
+                return MedalHelpers.UserPassedPack(context, noReductionMods, packId);
             }
         }
     }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/StarRatingMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/StarRatingMedalAwarder.cs
@@ -11,7 +11,6 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
-using Beatmap = osu.Server.Queues.ScoreStatisticsProcessor.Models.Beatmap;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
 {
@@ -38,17 +37,16 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
             if (context.Score.RulesetID == 3 && mods.Any(isManiaDisallowedMod))
                 yield break;
 
-            Beatmap? beatmap = await context.BeatmapStore.GetBeatmapAsync((uint)context.Score.BeatmapID, context.Connection, context.Transaction);
+            var beatmap = context.Score.Beatmap;
             if (beatmap == null)
                 yield break;
 
             // Make sure the map isn't Qualified or Loved, as those maps may occasionally have SR-breaking/aspire aspects
-            if (beatmap.approved == BeatmapOnlineStatus.Qualified || beatmap.approved == BeatmapOnlineStatus.Loved)
+            if (beatmap.Status == BeatmapOnlineStatus.Qualified || beatmap.Status == BeatmapOnlineStatus.Loved)
                 yield break;
 
             // Get map star rating (including mods)
-            APIBeatmap apiBeatmap = beatmap.ToAPIBeatmap();
-            DifficultyAttributes? difficultyAttributes = await context.BeatmapStore.GetDifficultyAttributesAsync(apiBeatmap, ruleset, mods, context.Connection, context.Transaction);
+            DifficultyAttributes? difficultyAttributes = await context.BeatmapStore.GetDifficultyAttributesAsync(beatmap, ruleset, mods, context.Connection, context.Transaction);
 
             if (difficultyAttributes == null)
                 yield break;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -124,7 +124,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
             try
             {
-                Beatmap? beatmap = await beatmapStore.GetBeatmapAsync((uint)score.BeatmapID, connection, transaction);
+                var beatmap = score.Beatmap;
 
                 if (beatmap == null)
                     return;
@@ -138,8 +138,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 if (!AllModsValidForPerformance(score, mods))
                     return;
 
-                APIBeatmap apiBeatmap = beatmap.ToAPIBeatmap();
-                DifficultyAttributes? difficultyAttributes = await beatmapStore.GetDifficultyAttributesAsync(apiBeatmap, ruleset, mods, connection, transaction);
+                DifficultyAttributes? difficultyAttributes = await beatmapStore.GetDifficultyAttributesAsync(beatmap, ruleset, mods, connection, transaction);
 
                 // Performance needs to be allowed for the build.
                 // legacy scores don't need a build id
@@ -149,7 +148,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 if (difficultyAttributes == null)
                     return;
 
-                ScoreInfo scoreInfo = score.ToScoreInfo(mods, apiBeatmap);
+                ScoreInfo scoreInfo = score.ToScoreInfo(mods, beatmap);
                 PerformanceAttributes? performanceAttributes = ruleset.CreatePerformanceCalculator()?.Calculate(scoreInfo, difficultyAttributes);
 
                 if (performanceAttributes == null)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
@@ -181,6 +181,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
                     {
                         BeatmapId = score.BeatmapID
                     })?.ToAPIBeatmap();
+                    score.BeatmapSet = conn.QuerySingleOrDefault<BeatmapSet>("SELECT * FROM `osu_beatmapsets` WHERE `beatmapset_id` = @BeatmapSetId", new
+                    {
+                        BeatmapSetId = score.Beatmap!.OnlineBeatmapSetID
+                    })?.ToAPIBeatmapSet();
 
                     using (var transaction = conn.BeginTransaction(IsolationLevel.ReadCommitted))
                     {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BeatmapStore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BeatmapStore.cs
@@ -150,12 +150,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
         /// </summary>
         /// <param name="beatmap">The beatmap.</param>
         /// <param name="rulesetId">The ruleset.</param>
-        public bool IsBeatmapValidForPerformance(Beatmap beatmap, uint rulesetId)
+        public bool IsBeatmapValidForPerformance(APIBeatmap beatmap, uint rulesetId)
         {
-            if (blacklist.ContainsKey(new BlacklistEntry(beatmap.beatmap_id, rulesetId)))
+            if (blacklist.ContainsKey(new BlacklistEntry((uint)beatmap.OnlineID, rulesetId)))
                 return false;
 
-            switch (beatmap.approved)
+            switch (beatmap.Status)
             {
                 case BeatmapOnlineStatus.Ranked:
                 case BeatmapOnlineStatus.Approved:


### PR DESCRIPTION
The title of this PR is intentionally vague for _reasons_. This diff is a grab bag of various small changes I didn't want to open 8 separate PRs for. Recommend reviewing commits in isolation, although the full diff shouldn't be too bad either.

Most important commits first, least important last.

## Major

### [Remove redundant BeatmapStore lookups](https://github.com/ppy/osu-queue-score-statistics/commit/bf7f19ff41017c569fb817eec7b697273479482e)

The `APIBeatmap` was already available under `Score`, so refetching it again appears to only incur extra database queries for zero benefit.

### [Retrieve additional info about beatmaps and beatmap sets when processing scores](https://github.com/ppy/osu-queue-score-statistics/commit/33df310f3d34a56d38a3b354d91adf61c2b53ad4)

For future use elsewhere.

Note that this adds an extra query for retrieving the beatmap set for every score.

## Minor

### [Extract no mod check to helper method](https://github.com/ppy/osu-queue-score-statistics/commit/7a6aa3abceaf37349febe86781f0ebb0ef575636)

For future use elsewhere.

### [Extract pack pass logic to helper for reuse](https://github.com/ppy/osu-queue-score-statistics/commit/f8de92f804bddb4ae4ce5fd31bf251b4efb3cb8b)

For future use elsewhere.

## Test-only

### [Remove duplicated private addMedal() method](https://github.com/ppy/osu-queue-score-statistics/commit/bce45a740aae33f72d06de8b17a812d0c536f237)

Just a straight-up test code quality improvement. This was extracted out to the superclass previously but must have returned following a botched merge or something.

### [Extract AddPackMedal() helper to superclass](https://github.com/ppy/osu-queue-score-statistics/commit/c6d0b67d4cfc3169dd4c0365d165a62759bd79d3)

For future use elsewhere.

### [Truncate user stats tables for all rulesets](https://github.com/ppy/osu-queue-score-statistics/commit/3bd83d5d04cc6ab862fba71c50e2292566c16865)

Helpful when wanting to write tests on taiko and catch scores.

### [Increase database test timeout to fix occasional failures](https://github.com/ppy/osu-queue-score-statistics/commit/ff0a6b1b6d901058e666e6eb2a17c6aa089262b5)

I dunno why this isn't an issue on CI, but locally even already on `master` a few tests are dog slow to the point of timing out at 10 seconds just because they're not quite done with all of the queries yet. This is just a precautionary increase to reduce the likelihood of that happening.