### PR TITLE
Decouple score processor from `SoloScoreInfo` model

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalAwarderTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalAwarderTest.cs
@@ -83,7 +83,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             // Usually osu-web would do this.
             using (var db = Processor.GetDatabaseConnection())
             {
-                db.Execute($"INSERT INTO osu_user_achievements (achievement_id, user_id, beatmap_id) VALUES ({awarded.Medal.achievement_id}, {awarded.Score.UserID}, {awarded.Score.BeatmapID})");
+                db.Execute($"INSERT INTO osu_user_achievements (achievement_id, user_id, beatmap_id) VALUES ({awarded.Medal.achievement_id}, {awarded.Score.user_id}, {awarded.Score.beatmap_id})");
             }
         }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
@@ -9,7 +9,6 @@ using MySqlConnector;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Localisation;
 using osu.Game.Online.API;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets.Catch.Mods;
 using osu.Game.Rulesets.Mania.Mods;
 using osu.Game.Rulesets.Mods;
@@ -144,7 +143,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             };
 
             foreach (var mod in mods)
-                Assert.True(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScoreInfo(), new[] { mod }), mod.GetType().ReadableName());
+                Assert.True(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScore(), new[] { mod }), mod.GetType().ReadableName());
         }
 
         [Fact]
@@ -176,7 +175,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             };
 
             foreach (var mod in mods)
-                Assert.False(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScoreInfo(), new[] { mod }), mod.GetType().ReadableName());
+                Assert.False(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScore(), new[] { mod }), mod.GetType().ReadableName());
         }
 
         [Fact]
@@ -204,7 +203,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             };
 
             foreach (var mod in mods)
-                Assert.False(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScoreInfo(), new[] { mod }), mod.GetType().ReadableName());
+                Assert.False(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScore(), new[] { mod }), mod.GetType().ReadableName());
         }
 
         [Fact]
@@ -228,19 +227,19 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             };
 
             foreach (var mod in mods)
-                Assert.True(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScoreInfo(), new[] { mod }), mod.GetType().ReadableName());
+                Assert.True(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScore(), new[] { mod }), mod.GetType().ReadableName());
         }
 
         [Fact]
         public void ClassicAllowedOnLegacyScores()
         {
-            Assert.True(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScoreInfo { LegacyScoreId = 1 }, new Mod[] { new OsuModClassic() }));
+            Assert.True(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScore { legacy_score_id = 1 }, new Mod[] { new OsuModClassic() }));
         }
 
         [Fact]
         public void ClassicDisallowedOnNonLegacyScores()
         {
-            Assert.False(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScoreInfo(), new Mod[] { new OsuModClassic() }));
+            Assert.False(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScore(), new Mod[] { new OsuModClassic() }));
         }
 
         [Fact]
@@ -254,7 +253,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             };
 
             foreach (var mod in mods)
-                Assert.False(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScoreInfo(), new[] { mod }), mod.GetType().ReadableName());
+                Assert.False(ScorePerformanceProcessor.AllModsValidForPerformance(new SoloScore(), new[] { mod }), mod.GetType().ReadableName());
         }
 
         [Fact]

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/RankedScoreProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/RankedScoreProcessorTests.cs
@@ -3,6 +3,7 @@
 
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Scoring;
+using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using Xunit;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
@@ -44,6 +45,28 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             SetScoreForBeatmap(TEST_BEATMAP_ID);
             waitForRankedScore("osu_user_stats", 10081);
+        }
+
+        /// <summary>
+        /// This test attempts to cover ranked score accounting using the correct score conversion algorithm to classic for all of the rulesets.
+        /// Generally, the values aren't supposed to be human-explainable; the goal of this tests is to be a canary.
+        /// If the test ever starts to fail, it should be investigated as to whether the conversion algorithm has changed in some way (in which case the values can just be adjusted to match),
+        /// or if there is a possible data error that leads the queue processor to use the wrong ruleset for conversion somehow (which is a bug and should be fixed).
+        /// </summary>
+        [Theory]
+        [InlineData(0, 10081)]
+        [InlineData(1, 10554)]
+        [InlineData(2, 10005)]
+        [InlineData(3, 100000)]
+        public void TestRankedScoreConversionToClassic(ushort rulesetId, int expectedRankedScore)
+        {
+            var specifics = LegacyDatabaseHelper.GetRulesetSpecifics(rulesetId);
+
+            AddBeatmap(b => b.approved = BeatmapOnlineStatus.Ranked);
+            waitForRankedScore(specifics.UserStatsTable, 0);
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, s => s.Score.ruleset_id = rulesetId);
+            waitForRankedScore(specifics.UserStatsTable, expectedRankedScore);
         }
 
         [Fact]

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/RankedScoreProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/RankedScoreProcessorTests.cs
@@ -101,11 +101,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             SetScoreForBeatmap(TEST_BEATMAP_ID, score =>
             {
-                var scoreInfo = score.Score.ToScoreInfo();
-
-                scoreInfo.TotalScore = 50000;
-                scoreInfo.Statistics[HitResult.Perfect] = 0;
-                scoreInfo.Statistics[HitResult.Ok] = 5;
+                score.Score.total_score = 50000;
+                score.Score.ScoreData.Statistics[HitResult.Perfect] = 0;
+                score.Score.ScoreData.Statistics[HitResult.Ok] = 5;
             });
             waitForRankedScore("osu_user_stats", 10081);
         }

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/TotalScoreProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/TotalScoreProcessorTests.cs
@@ -123,7 +123,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             using (var db = Processor.GetDatabaseConnection())
             using (var transaction = await db.BeginTransactionAsync())
             {
-                var userStats = await DatabaseHelper.GetUserStatsAsync(score.Score.ToScoreInfo(), db, transaction);
+                var userStats = await DatabaseHelper.GetUserStatsAsync(score.Score, db, transaction);
 
                 Debug.Assert(userStats != null);
                 userStats.total_score = score.Score.total_score;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/PerformanceCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/PerformanceCommand.cs
@@ -39,7 +39,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance
         /// </summary>
         /// <param name="input">The input string.</param>
         /// <returns>The IDs.</returns>
-        protected static int[] ParseIntIds(string input) => input.Split(',').Select(int.Parse).ToArray();
+        protected static uint[] ParseIntIds(string input) => input.Split(',').Select(uint.Parse).ToArray();
 
         /// <summary>
         /// Parses a comma-separated list of IDs from a given input string.
@@ -48,7 +48,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance
         /// <returns>The IDs.</returns>
         protected static ulong[] ParseLongIds(string input) => input.Split(',').Select(ulong.Parse).ToArray();
 
-        protected async Task ProcessUserTotals(int[] userIds, CancellationToken cancellationToken)
+        protected async Task ProcessUserTotals(uint[] userIds, CancellationToken cancellationToken)
         {
             if (userIds.Length == 0)
             {
@@ -77,7 +77,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance
             }, cancellationToken);
         }
 
-        protected async Task ProcessUserScores(int[] userIds, CancellationToken cancellationToken)
+        protected async Task ProcessUserScores(uint[] userIds, CancellationToken cancellationToken)
         {
             if (userIds.Length == 0)
             {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
@@ -56,11 +56,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
 
             while (!cancellationToken.IsCancellationRequested)
             {
-                int[] userIds;
+                uint[] userIds;
 
                 using (var db = DatabaseAccess.GetConnection())
                 {
-                    userIds = (await db.QueryAsync<int>($"SELECT `user_id` FROM {databaseInfo.UserStatsTable} WHERE `user_id` > @UserId ORDER BY `user_id` LIMIT @Limit", new
+                    userIds = (await db.QueryAsync<uint>($"SELECT `user_id` FROM {databaseInfo.UserStatsTable} WHERE `user_id` > @UserId ORDER BY `user_id` LIMIT @Limit", new
                     {
                         UserId = currentUserId,
                         Limit = max_users_per_query

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateScoresForUsersCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateScoresForUsersCommand.cs
@@ -19,7 +19,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
 
         protected override async Task<int> ExecuteAsync(CancellationToken cancellationToken)
         {
-            int[] userIds = ParseIntIds(UsersString);
+            uint[] userIds = ParseIntIds(UsersString);
             await ProcessUserScores(userIds, cancellationToken);
             return 0;
         }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateScoresFromSqlCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateScoresFromSqlCommand.cs
@@ -22,10 +22,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
 
         protected override async Task<int> ExecuteAsync(CancellationToken cancellationToken)
         {
-            int[] userIds;
+            uint[] userIds;
 
             using (var db = DatabaseAccess.GetConnection())
-                userIds = (await db.QueryAsync<int>(Statement)).ToArray();
+                userIds = (await db.QueryAsync<uint>(Statement)).ToArray();
 
             await ProcessUserScores(userIds, cancellationToken);
             return 0;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/UserTotals/UpdateAllUserTotalsCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/UserTotals/UpdateAllUserTotalsCommand.cs
@@ -19,12 +19,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.UserTo
         {
             LegacyDatabaseHelper.RulesetDatabaseInfo databaseInfo = LegacyDatabaseHelper.GetRulesetSpecifics(RulesetId);
 
-            int[] userIds;
+            uint[] userIds;
 
             Console.WriteLine("Fetching all users...");
 
             using (var db = DatabaseAccess.GetConnection())
-                userIds = (await db.QueryAsync<int>($"SELECT `user_id` FROM {databaseInfo.UserStatsTable}")).ToArray();
+                userIds = (await db.QueryAsync<uint>($"SELECT `user_id` FROM {databaseInfo.UserStatsTable}")).ToArray();
 
             Console.WriteLine($"Fetched {userIds.Length} users");
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/UserTotals/UpdateUserTotalsForUsersCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/UserTotals/UpdateUserTotalsForUsersCommand.cs
@@ -19,7 +19,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.UserTo
 
         protected override async Task<int> ExecuteAsync(CancellationToken cancellationToken)
         {
-            int[] userIds = ParseIntIds(UsersString);
+            uint[] userIds = ParseIntIds(UsersString);
             await ProcessUserTotals(userIds, cancellationToken);
             return 0;
         }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/UserTotals/UpdateUserTotalsFromSqlCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/UserTotals/UpdateUserTotalsFromSqlCommand.cs
@@ -30,7 +30,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.UserTo
 
             Console.WriteLine($"Fetching scoped users ({Query})...");
 
-            int[] userIds = (await db.QueryAsync<int>($"SELECT `user_id` FROM {databaseInfo.UserStatsTable} WHERE {Query}")).ToArray();
+            uint[] userIds = (await db.QueryAsync<uint>($"SELECT `user_id` FROM {databaseInfo.UserStatsTable} WHERE {Query}")).ToArray();
 
             Console.WriteLine($"Fetched {userIds.Length} users");
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs
@@ -381,7 +381,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Queue
                     BeatmapId = beatmapId
                 });
 
-                return difficulty_info_cache[beatmapId] = LegacyBeatmapConversionDifficultyInfo.FromAPIBeatmap(beatmap.ToAPIBeatmap());
+                return difficulty_info_cache[beatmapId] = beatmap.GetLegacyBeatmapConversionDifficultyInfo();
             }
         }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/DatabaseHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/DatabaseHelper.cs
@@ -6,10 +6,8 @@ using System.Threading.Tasks;
 using Dapper;
 using Dapper.Contrib.Extensions;
 using MySqlConnector;
-using osu.Game.Beatmaps;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
-using osu.Server.Queues.ScoreStatisticsProcessor.Processors;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
 {
@@ -146,31 +144,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
                 throw new InvalidOperationException($"Unable to retrieve count '{key}'.");
 
             return res.Value;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the beatmap with the given <paramref name="beatmapId"/>
-        /// is valid to be included in ranked counts, such as total ranked score and user rank (grade) counts.
-        /// </summary>
-        /// <seealso cref="RankedScoreProcessor"/>
-        /// <seealso cref="UserRankCountProcessor"/>
-        /// <param name="beatmapId">The ID of the beatmap to check.</param>
-        /// <param name="conn">The <see cref="MySqlConnection"/>.</param>
-        /// <param name="transaction">The current transaction, if applicable.</param>
-        /// <exception cref="InvalidOperationException">The beatmap with the supplied <paramref name="beatmapId"/> could not be found.</exception>
-        public static bool IsBeatmapValidForRankedCounts(uint beatmapId, MySqlConnection conn, MySqlTransaction? transaction = null)
-        {
-            var status = conn.QuerySingleOrDefault<BeatmapOnlineStatus?>("SELECT `approved` FROM osu_beatmaps WHERE `beatmap_id` = @beatmap_id",
-                new { beatmap_id = beatmapId },
-                transaction);
-
-            if (status == null)
-                throw new InvalidOperationException($"Cannot find beatmap with ID = {beatmapId} in database.");
-
-            // see https://osu.ppy.sh/wiki/en/Gameplay/Score/Ranked_score
-            return status == BeatmapOnlineStatus.Ranked
-                   || status == BeatmapOnlineStatus.Approved
-                   || status == BeatmapOnlineStatus.Loved;
         }
 
         /// <summary>

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/DatabaseHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/DatabaseHelper.cs
@@ -170,7 +170,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
         /// <param name="offset">How many records to skip in the sort order.</param>
         public static SoloScore? GetUserBestScoreFor(SoloScore score, MySqlConnection conn, MySqlTransaction? transaction = null, int offset = 0)
         {
-            return conn.QueryFirstOrDefault<SoloScore?>(
+            var result = conn.QueryFirstOrDefault<SoloScore?>(
                 "SELECT * FROM scores WHERE `user_id` = @user_id "
                 + "AND `beatmap_id` = @beatmap_id "
                 + "AND `ruleset_id` = @ruleset_id "
@@ -188,6 +188,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
                     new_score_id = score.id,
                     offset = offset,
                 }, transaction);
+
+            // since the beatmaps for the two scores are the same by definition of the method,
+            // we can just copy them across without a refetch.
+            if (result != null)
+                result.beatmap = score.beatmap;
+
+            return result;
         }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/MedalHelpers.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/MedalHelpers.cs
@@ -78,7 +78,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
 
             if (packRulesetId != null)
             {
-                if (context.Score.RulesetID != packRulesetId)
+                if (context.Score.ruleset_id != packRulesetId)
                     return false;
 
                 rulesetCriteria = $"AND ruleset_id = {packRulesetId}";
@@ -91,7 +91,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
                 + "FROM osu_beatmappacks_items p "
                 + "JOIN osu_beatmaps b USING (beatmapset_id) "
                 + "JOIN scores s USING (beatmap_id)"
-                + $"WHERE s.user_id = {context.Score.UserID} AND s.passed = 1 AND s.preserve = 1 AND pack_id = {packId} {rulesetCriteria} {modsCriteria}", transaction: context.Transaction);
+                + $"WHERE s.user_id = {context.Score.user_id} AND s.passed = 1 AND s.preserve = 1 AND pack_id = {packId} {rulesetCriteria} {modsCriteria}", transaction: context.Transaction);
 
             int countForPack = context.Connection.QuerySingle<int>($"SELECT COUNT(*) FROM `osu_beatmappacks_items` WHERE pack_id = {packId}", transaction: context.Transaction);
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/PlayValidityHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/PlayValidityHelper.cs
@@ -4,10 +4,10 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 using osu.Server.Queues.ScoreStatisticsProcessor.Processors;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
@@ -21,39 +21,39 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
         /// <seealso cref="PlayTimeProcessor"/>
         /// <param name="score">The score to check.</param>
         /// <param name="lengthInSeconds">The total length of play in seconds in the supplied <paramref name="score"/>.</param>
-        public static bool IsValidForPlayTracking(this SoloScoreInfo score, out int lengthInSeconds)
+        public static bool IsValidForPlayTracking(this SoloScore score, out int lengthInSeconds)
         {
             lengthInSeconds = GetPlayLength(score);
 
-            int totalObjectsJudged = score.Statistics.Where(kv => kv.Key.IsScorable()).Sum(kv => kv.Value);
-            int totalObjects = score.MaximumStatistics.Where(kv => kv.Key.IsScorable()).Sum(kv => kv.Value);
+            int totalObjectsJudged = score.ScoreData.Statistics.Where(kv => kv.Key.IsScorable()).Sum(kv => kv.Value);
+            int totalObjects = score.ScoreData.MaximumStatistics.Where(kv => kv.Key.IsScorable()).Sum(kv => kv.Value);
 
-            return score.Passed
+            return score.passed
                    || (lengthInSeconds >= 8
-                       && score.TotalScore >= 5000
+                       && score.total_score >= 5000
                        && totalObjectsJudged >= Math.Min(0.1f * totalObjects, 20));
         }
 
         /// <summary>
         /// Returns the length of play in the given <paramref name="score"/> in seconds.
         /// </summary>
-        public static int GetPlayLength(SoloScoreInfo score)
+        public static int GetPlayLength(SoloScore score)
         {
             // to ensure sanity, first get the maximum time feasible from the beatmap's length
-            double totalLengthSeconds = score.Beatmap!.Length;
+            double totalLengthSeconds = score.beatmap!.total_length;
 
-            Ruleset ruleset = ScoreStatisticsQueueProcessor.AVAILABLE_RULESETS.Single(r => r.RulesetInfo.OnlineID == score.RulesetID);
+            Ruleset ruleset = ScoreStatisticsQueueProcessor.AVAILABLE_RULESETS.Single(r => r.RulesetInfo.OnlineID == score.ruleset_id);
 
-            var rateAdjustMods = score.Mods.Select(m => m.ToMod(ruleset)).OfType<ModRateAdjust>().ToArray();
+            var rateAdjustMods = score.ScoreData.Mods.Select(m => m.ToMod(ruleset)).OfType<ModRateAdjust>().ToArray();
 
             foreach (var mod in rateAdjustMods)
                 totalLengthSeconds /= mod.SpeedChange.Value;
 
-            Debug.Assert(score.StartedAt != null);
+            Debug.Assert(score.started_at != null);
 
             // TODO: better handle failed plays once we have incoming data.
 
-            TimeSpan realTimePassed = score.EndedAt - score.StartedAt.Value;
+            TimeSpan realTimePassed = score.ended_at - score.started_at.Value;
             return (int)Math.Min(totalLengthSeconds, realTimePassed.TotalSeconds);
         }
     }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/PlayValidityHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/PlayValidityHelper.cs
@@ -36,7 +36,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if the beatmap with the given <paramref name="beatmapId"/>
+        /// Returns <see langword="true"/> if the beatmap on which <paramref name="score"/> was set
         /// is valid to be included in ranked counts, such as total ranked score and user rank (grade) counts.
         /// </summary>
         /// <seealso cref="RankedScoreProcessor"/>

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/PlayValidityHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/PlayValidityHelper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
@@ -32,6 +33,22 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
                    || (lengthInSeconds >= 8
                        && score.total_score >= 5000
                        && totalObjectsJudged >= Math.Min(0.1f * totalObjects, 20));
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> if the beatmap with the given <paramref name="beatmapId"/>
+        /// is valid to be included in ranked counts, such as total ranked score and user rank (grade) counts.
+        /// </summary>
+        /// <seealso cref="RankedScoreProcessor"/>
+        /// <seealso cref="UserRankCountProcessor"/>
+        /// <seealso cref="ManiaKeyModeUserStatsProcessor"/>
+        public static bool BeatmapValidForRankedCounts(this SoloScore score)
+        {
+            // see https://osu.ppy.sh/wiki/en/Gameplay/Score/Ranked_score
+            var status = score.beatmap?.approved;
+            return status == BeatmapOnlineStatus.Ranked
+                   || status == BeatmapOnlineStatus.Approved
+                   || status == BeatmapOnlineStatus.Loved;
         }
 
         /// <summary>

--- a/osu.Server.Queues.ScoreStatisticsProcessor/IProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/IProcessor.cs
@@ -3,7 +3,6 @@
 
 using MySqlConnector;
 using osu.Framework.Extensions.TypeExtensions;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor
@@ -29,9 +28,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         /// </summary>
         bool RunOnLegacyScores { get; }
 
-        void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction);
+        void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction);
 
-        void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction);
+        void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction);
 
         /// <summary>
         /// Adjust any global statistics outside of the user transaction.
@@ -39,7 +38,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         /// </summary>
         /// <param name="score">The user's score.</param>
         /// <param name="conn">The database connection.</param>
-        void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn);
+        void ApplyGlobal(SoloScore score, MySqlConnection conn);
 
         string DisplayString => $"- {GetType().ReadableName()} ({GetType().Assembly.FullName})";
     }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/Beatmap.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/Beatmap.cs
@@ -6,13 +6,14 @@ using System.Diagnostics.CodeAnalysis;
 using Dapper.Contrib.Extensions;
 using osu.Game.Beatmaps;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets.Scoring.Legacy;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [Serializable]
     [Table("osu_beatmaps")]
-    public class Beatmap
+    public class Beatmap : IBeatmapOnlineInfo
     {
         [ExplicitKey]
         public uint beatmap_id { get; set; }
@@ -37,25 +38,36 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
         public uint hit_length { get; set; }
         public float bpm { get; set; }
 
-        public APIBeatmap ToAPIBeatmap() => new APIBeatmap
+        [Computed]
+        public BeatmapSet? beatmapset { get; set; }
+
+        public LegacyBeatmapConversionDifficultyInfo GetLegacyBeatmapConversionDifficultyInfo() => new LegacyBeatmapConversionDifficultyInfo
         {
-            OnlineID = (int)beatmap_id,
-            OnlineBeatmapSetID = (int)beatmapset_id,
-            AuthorID = (int)user_id,
-            CircleCount = (int)countNormal,
-            SliderCount = (int)countSlider,
-            SpinnerCount = (int)countSpinner,
+            SourceRuleset = new APIBeatmap.APIRuleset { OnlineID = playmode },
             DrainRate = diff_drain,
-            Length = total_length,
+            ApproachRate = diff_approach,
             CircleSize = diff_size,
             OverallDifficulty = diff_overall,
-            ApproachRate = diff_approach,
-            RulesetID = playmode,
-            StarRating = difficultyrating,
-            PlayCount = playcount,
-            Status = approved,
-            HitLength = hit_length,
-            BPM = bpm,
+            EndTimeObjectCount = (int)(countSlider + countSpinner),
+            TotalObjectCount = (int)countTotal,
         };
+
+        #region IBeatmapOnlineInfo
+
+        float IBeatmapOnlineInfo.ApproachRate => diff_approach;
+        float IBeatmapOnlineInfo.CircleSize => diff_size;
+        float IBeatmapOnlineInfo.DrainRate => diff_drain;
+        float IBeatmapOnlineInfo.OverallDifficulty => diff_overall;
+        int IBeatmapOnlineInfo.CircleCount => (int)countNormal;
+        int IBeatmapOnlineInfo.SliderCount => (int)countSlider;
+        int IBeatmapOnlineInfo.SpinnerCount => (int)countSpinner;
+        double IBeatmapOnlineInfo.HitLength => hit_length;
+        int IBeatmapOnlineInfo.PlayCount => playcount;
+
+        int? IBeatmapOnlineInfo.MaxCombo => throw new NotSupportedException();
+        int IBeatmapOnlineInfo.PassCount => throw new NotSupportedException();
+        APIFailTimes? IBeatmapOnlineInfo.FailTimes => throw new NotSupportedException();
+
+        #endregion
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/Beatmap.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/Beatmap.cs
@@ -66,7 +66,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 
         int? IBeatmapOnlineInfo.MaxCombo => throw new NotSupportedException();
         int IBeatmapOnlineInfo.PassCount => throw new NotSupportedException();
-        APIFailTimes? IBeatmapOnlineInfo.FailTimes => throw new NotSupportedException();
+        APIFailTimes IBeatmapOnlineInfo.FailTimes => throw new NotSupportedException();
 
         #endregion
     }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/BeatmapSet.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/BeatmapSet.cs
@@ -5,7 +5,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using Dapper.Contrib.Extensions;
 using osu.Game.Beatmaps;
-using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 {
@@ -23,16 +22,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
         public string title { get; set; } = string.Empty;
         public string creator { get; set; } = string.Empty;
         public double bpm { get; set; }
-
-        public APIBeatmapSet ToAPIBeatmapSet() => new APIBeatmapSet
-        {
-            OnlineID = beatmapset_id,
-            Artist = artist,
-            Title = title,
-            AuthorString = creator,
-            AuthorID = (int)user_id,
-            BPM = bpm,
-        };
 
         public BeatmapOnlineStatus approved { get; set; }
     }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/MedalAwarderContext.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/MedalAwarderContext.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using MySqlConnector;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Server.Queues.ScoreStatisticsProcessor.Processors;
 using osu.Server.Queues.ScoreStatisticsProcessor.Stores;
 
@@ -17,7 +16,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
     /// <param name="Connection">MySQL connection for manual retrieval from database.</param>
     /// <param name="Transaction">MySQL transaction for manual retrieval from database.</param>
     public record MedalAwarderContext(
-        SoloScoreInfo Score,
+        SoloScore Score,
         UserStats UserStats,
         BeatmapStore BeatmapStore,
         MySqlConnection Connection,

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs
@@ -67,6 +67,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
 
         public ushort? build_id { get; set; }
 
+        /// <summary>
+        /// The beatmap that this score was set on.
+        /// </summary>
+        /// <remarks>
+        /// Importantly, this is the <b>raw database row</b> corresponding to <see cref="beatmap_id"/>.
+        /// This means that all properties pertaining to difficulty or ruleset in this model <b>will use the original beatmap data, excluding potential effects
+        /// of ruleset conversion and active mods.</b>
+        /// </remarks>
         [Computed]
         public Beatmap? beatmap { get; set; }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs
@@ -93,7 +93,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
                 User = new APIUser { Id = (int)user_id },
                 BeatmapInfo = new BeatmapInfo
                 {
-                    OnlineID = (int)beatmap_id
+                    OnlineID = (int)beatmap_id,
+                    Ruleset = new RulesetInfo { OnlineID = beatmap!.playmode }
                 },
                 Ruleset = new RulesetInfo { OnlineID = ruleset_id },
                 Passed = passed,

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/UserStats.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/UserStats.cs
@@ -12,7 +12,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
     public abstract class UserStats
     {
         [ExplicitKey]
-        public int user_id { get; set; }
+        public uint user_id { get; set; }
 
         public int count300 { get; set; }
         public int count100 { get; set; }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/HitStatisticsProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/HitStatisticsProcessor.cs
@@ -3,7 +3,6 @@
 
 using JetBrains.Annotations;
 using MySqlConnector;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets.Scoring;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
@@ -19,26 +18,26 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnLegacyScores => false;
 
-        public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
             if (previousVersion >= 2)
                 adjustStatisticsFromScore(score, userStats, true);
         }
 
-        public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
         {
             adjustStatisticsFromScore(score, userStats);
         }
 
-        public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
+        public void ApplyGlobal(SoloScore score, MySqlConnection conn)
         {
         }
 
-        private static void adjustStatisticsFromScore(SoloScoreInfo score, UserStats userStats, bool revert = false)
+        private static void adjustStatisticsFromScore(SoloScore score, UserStats userStats, bool revert = false)
         {
             int multiplier = revert ? -1 : 1;
 
-            foreach ((var result, int count) in score.Statistics)
+            foreach ((var result, int count) in score.ScoreData.Statistics)
             {
                 if (count < 0)
                     return;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/LastPlayedDateProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/LastPlayedDateProcessor.cs
@@ -3,7 +3,6 @@
 
 using JetBrains.Annotations;
 using MySqlConnector;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
@@ -18,17 +17,17 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         public bool RunOnFailedScores => true;
         public bool RunOnLegacyScores => false;
 
-        public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
         }
 
-        public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
         {
-            if (userStats.last_played < score.EndedAt || userStats.playcount == 0)
-                userStats.last_played = score.EndedAt;
+            if (userStats.last_played < score.ended_at || userStats.playcount == 0)
+                userStats.last_played = score.ended_at;
         }
 
-        public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
+        public void ApplyGlobal(SoloScore score, MySqlConnection conn)
         {
         }
     }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ManiaKeyModeUserStatsProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ManiaKeyModeUserStatsProcessor.cs
@@ -113,7 +113,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         // it's a bit unfortunate but it is the only way this can implemented for now until `preserve = 0` is set on lazer scores correctly.
         private void updateRankCounts(SoloScore score, UserStatsManiaKeyCount keymodeStats, MySqlConnection conn, MySqlTransaction transaction)
         {
-            if (!DatabaseHelper.IsBeatmapValidForRankedCounts(score.beatmap_id, conn, transaction))
+            if (!score.BeatmapValidForRankedCounts())
                 return;
 
             var bestScore = DatabaseHelper.GetUserBestScoreFor(score, conn, transaction);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ManiaKeyModeUserStatsProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ManiaKeyModeUserStatsProcessor.cs
@@ -46,11 +46,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
             var existingRow = conn.QueryFirstOrDefault<UserStatsManiaKeyCount>($"SELECT * FROM `{keyCountTableName}` WHERE `user_id` = @user_id", keymodeStats, transaction);
 
-            // this should really not be necessary, but there is no real good way to expose the value of `preserve` *inside* a processor
-            // as it does not have access to the raw database row anymore...
-            bool preserve = conn.QuerySingle<bool>("SELECT `preserve` FROM `scores` WHERE `id` = @id", new { id = score.id }, transaction);
-
-            if (preserve || existingRow == null)
+            if (score.preserve || existingRow == null)
             {
                 keymodeStats = existingRow ?? keymodeStats;
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ManiaKeyModeUserStatsProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ManiaKeyModeUserStatsProcessor.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using Dapper;
 using JetBrains.Annotations;
 using MySqlConnector;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Scoring;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
@@ -22,19 +21,19 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         public bool RunOnFailedScores => false;
         public bool RunOnLegacyScores => true;
 
-        public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
         }
 
-        public void ApplyToUserStats(SoloScoreInfo score, UserStats fullRulesetStats, MySqlConnection conn, MySqlTransaction transaction)
+        public void ApplyToUserStats(SoloScore score, UserStats fullRulesetStats, MySqlConnection conn, MySqlTransaction transaction)
         {
-            if (score.RulesetID != 3)
+            if (score.ruleset_id != 3)
                 return;
 
-            if (score.Beatmap == null)
+            if (score.beatmap == null)
                 return;
 
-            int keyCount = (int)score.Beatmap.CircleSize;
+            int keyCount = (int)score.beatmap.diff_size;
             // TODO: reconsider when handling key conversion mods in the future?
             if (keyCount != 4 && keyCount != 7)
                 return;
@@ -42,14 +41,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             string keyCountTableName = $"osu_user_stats_mania_{keyCount}k";
             var keymodeStats = new UserStatsManiaKeyCount
             {
-                user_id = (uint)score.UserID
+                user_id = score.user_id
             };
 
             var existingRow = conn.QueryFirstOrDefault<UserStatsManiaKeyCount>($"SELECT * FROM `{keyCountTableName}` WHERE `user_id` = @user_id", keymodeStats, transaction);
 
             // this should really not be necessary, but there is no real good way to expose the value of `preserve` *inside* a processor
             // as it does not have access to the raw database row anymore...
-            bool preserve = conn.QuerySingle<bool>("SELECT `preserve` FROM `scores` WHERE `id` = @id", new { id = score.ID }, transaction);
+            bool preserve = conn.QuerySingle<bool>("SELECT `preserve` FROM `scores` WHERE `id` = @id", new { id = score.id }, transaction);
 
             if (preserve || existingRow == null)
             {
@@ -68,7 +67,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                     + "ORDER BY pp DESC LIMIT 1000", new
                     {
                         UserId = keymodeStats.user_id,
-                        RulesetId = score.RulesetID,
+                        RulesetId = score.ruleset_id,
                         KeyCount = keyCount,
                     }, transaction: transaction).ToList();
 
@@ -95,8 +94,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                         new
                         {
                             playcount = fullRulesetStats.playcount,
-                            userId = score.UserID,
-                            rulesetId = score.RulesetID,
+                            userId = score.user_id,
+                            rulesetId = score.ruleset_id,
                             keyCount = keyCount,
                         }, transaction) ?? 1;
 
@@ -116,24 +115,24 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         // local reimplementation of `UserRankCountProcessor` for keymodes.
         // it's a bit unfortunate but it is the only way this can implemented for now until `preserve = 0` is set on lazer scores correctly.
-        private void updateRankCounts(SoloScoreInfo score, UserStatsManiaKeyCount keymodeStats, MySqlConnection conn, MySqlTransaction transaction)
+        private void updateRankCounts(SoloScore score, UserStatsManiaKeyCount keymodeStats, MySqlConnection conn, MySqlTransaction transaction)
         {
-            if (!DatabaseHelper.IsBeatmapValidForRankedCounts(score.BeatmapID, conn, transaction))
+            if (!DatabaseHelper.IsBeatmapValidForRankedCounts(score.beatmap_id, conn, transaction))
                 return;
 
             var bestScore = DatabaseHelper.GetUserBestScoreFor(score, conn, transaction);
 
             // If there's already another higher score than this one, nothing needs to be done.
-            if (bestScore?.ID != score.ID)
+            if (bestScore?.id != score.id)
                 return;
 
             // If this score is the new best and there's a previous higher score, that score's rank should be removed before we apply the new one.
             var secondBestScore = DatabaseHelper.GetUserBestScoreFor(score, conn, transaction, offset: 1);
             if (secondBestScore != null)
-                updateRankCounts(keymodeStats, secondBestScore.Rank, revert: true);
+                updateRankCounts(keymodeStats, secondBestScore.rank, revert: true);
 
             Debug.Assert(bestScore != null);
-            updateRankCounts(keymodeStats, bestScore.Rank, revert: false);
+            updateRankCounts(keymodeStats, bestScore.rank, revert: false);
         }
 
         private static void updateRankCounts(UserStatsManiaKeyCount stats, ScoreRank rank, bool revert)
@@ -164,7 +163,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             }
         }
 
-        public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
+        public void ApplyGlobal(SoloScore score, MySqlConnection conn)
         {
         }
     }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MaxComboProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MaxComboProcessor.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using JetBrains.Annotations;
 using MySqlConnector;
 using osu.Game.Beatmaps;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
@@ -23,27 +22,27 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnLegacyScores => false;
 
-        public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
             // TODO: this will require access to stable scores to be implemented correctly.
         }
 
-        public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
         {
-            Ruleset ruleset = ScoreStatisticsQueueProcessor.AVAILABLE_RULESETS.Single(r => r.RulesetInfo.OnlineID == score.RulesetID);
+            Ruleset ruleset = ScoreStatisticsQueueProcessor.AVAILABLE_RULESETS.Single(r => r.RulesetInfo.OnlineID == score.ruleset_id);
 
             // Automation mods should not count towards max combo statistic.
-            if (score.Mods.Select(m => m.ToMod(ruleset)).Any(m => m.Type == ModType.Automation))
+            if (score.ScoreData.Mods.Select(m => m.ToMod(ruleset)).Any(m => m.Type == ModType.Automation))
                 return;
 
-            if (score.Beatmap == null || score.Beatmap.Status < BeatmapOnlineStatus.Ranked)
+            if (score.beatmap == null || score.beatmap.approved < BeatmapOnlineStatus.Ranked)
                 return;
 
             // TODO: assert the user's score is not higher than the max combo for the beatmap.
-            userStats.max_combo = Math.Max(userStats.max_combo, (ushort)score.MaxCombo);
+            userStats.max_combo = Math.Max(userStats.max_combo, (ushort)score.max_combo);
         }
 
-        public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
+        public void ApplyGlobal(SoloScore score, MySqlConnection conn)
         {
         }
     }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/ModIntroductionMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/ModIntroductionMedalAwarder.cs
@@ -1,5 +1,4 @@
 ﻿using JetBrains.Annotations;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;
@@ -17,10 +16,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
 
         public IEnumerable<Medal> Check(IEnumerable<Medal> medals, MedalAwarderContext context)
         {
-            Ruleset ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(context.Score.RulesetID);
+            Ruleset ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(context.Score.ruleset_id);
 
             // Select score mods, ignoring certain mods that can be included in the combination for mod introduction medals
-            Mod[] mods = context.Score.Mods.Select(m => m.ToMod(ruleset)).Where(m => !MedalHelpers.IsPermittedInNoModContext(m)).ToArray();
+            Mod[] mods = context.Score.ScoreData.Mods.Select(m => m.ToMod(ruleset)).Where(m => !MedalHelpers.IsPermittedInNoModContext(m)).ToArray();
 
             // Ensure the mod is the only one selected
             if (mods.Length != 1)
@@ -37,7 +36,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
             }
         }
 
-        private bool checkMedal(SoloScoreInfo score, Medal medal, Mod mod)
+        private bool checkMedal(SoloScore score, Medal medal, Mod mod)
         {
             switch (medal.achievement_id)
             {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
@@ -20,7 +20,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
             // Do a global check to see if this beatmapset is contained in *any* pack.
             var validPacksForBeatmapSet = context.Connection.Query<int>("SELECT pack_id FROM osu_beatmappacks_items WHERE beatmapset_id = @beatmapSetId", new
             {
-                beatmapSetId = context.Score.Beatmap!.OnlineBeatmapSetID,
+                beatmapSetId = context.Score.beatmap!.beatmapset_id,
             }, transaction: context.Transaction);
 
             foreach (var medal in medals)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/StatisticsMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/StatisticsMedalAwarder.cs
@@ -26,29 +26,29 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
             var score = context.Score;
             var stats = context.UserStats;
 
-            Ruleset ruleset = ScoreStatisticsQueueProcessor.AVAILABLE_RULESETS.Single(r => r.RulesetInfo.OnlineID == score.RulesetID);
+            Ruleset ruleset = ScoreStatisticsQueueProcessor.AVAILABLE_RULESETS.Single(r => r.RulesetInfo.OnlineID == score.ruleset_id);
 
             // Automation mods should not count towards max combo statistic.
-            bool isAutomationMod = score.Mods.Select(m => m.ToMod(ruleset)).Any(m => m.Type == ModType.Automation);
+            bool isAutomationMod = score.ScoreData.Mods.Select(m => m.ToMod(ruleset)).Any(m => m.Type == ModType.Automation);
 
             switch (medal.achievement_id)
             {
                 // osu!standard
                 // 500 Combo
                 case 1:
-                    return !isAutomationMod && score.MaxCombo >= 500;
+                    return !isAutomationMod && score.max_combo >= 500;
 
                 // 750 Combo
                 case 3:
-                    return !isAutomationMod && score.MaxCombo >= 750;
+                    return !isAutomationMod && score.max_combo >= 750;
 
                 // 1000 Combo
                 case 4:
-                    return !isAutomationMod && score.MaxCombo >= 1000;
+                    return !isAutomationMod && score.max_combo >= 1000;
 
                 // 2000 Combo
                 case 5:
-                    return !isAutomationMod && score.MaxCombo >= 2000;
+                    return !isAutomationMod && score.max_combo >= 2000;
 
                 // 5000 Plays
                 case 20:

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
@@ -8,7 +8,6 @@ using JetBrains.Annotations;
 using MySqlConnector;
 using osu.Framework.Development;
 using osu.Framework.Utils;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
@@ -26,7 +25,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnLegacyScores => false;
 
-        public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
             if (!score.IsValidForPlayTracking(out _) && previousVersion >= 10)
                 return;
@@ -41,7 +40,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             }
         }
 
-        public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
         {
             if (!score.IsValidForPlayTracking(out _))
                 return;
@@ -51,8 +50,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
             int secondsForRecentScores = conn.QuerySingleOrDefault<int?>("SELECT UNIX_TIMESTAMP(NOW()) - UNIX_TIMESTAMP(ended_at) FROM scores WHERE user_id = @user_id AND ruleset_id = @ruleset_id ORDER BY id DESC LIMIT 1 OFFSET @beatmap_count", new
             {
-                user_id = score.UserID,
-                ruleset_id = score.RulesetID,
+                user_id = score.user_id,
+                ruleset_id = score.ruleset_id,
                 beatmap_count,
             }, transaction) ?? int.MaxValue;
 
@@ -68,7 +67,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             }
         }
 
-        public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
+        public void ApplyGlobal(SoloScore score, MySqlConnection conn)
         {
         }
 
@@ -87,33 +86,33 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             }
         }
 
-        private static void adjustGlobalBeatmapPlaycount(SoloScoreInfo score, MySqlConnection conn, MySqlTransaction transaction)
+        private static void adjustGlobalBeatmapPlaycount(SoloScore score, MySqlConnection conn, MySqlTransaction transaction)
         {
             // We want to reduce database overhead here, so we only update the global beatmap playcount every n plays.
             // Note that we use a non-round number to make the display more natural.
-            int increment = score.Beatmap!.PlayCount < 1000 ? 1 : 9;
+            int increment = score.beatmap!.playcount < 1000 ? 1 : 9;
 
             if (RNG.Next(0, increment) == 0)
             {
                 conn.Execute("UPDATE osu_beatmaps SET playcount = playcount + @increment WHERE beatmap_id = @beatmapId; UPDATE osu_beatmapsets SET play_count = play_count + @increment WHERE beatmapset_id = @beatmapSetId", new
                 {
                     increment,
-                    beatmapId = score.BeatmapID,
-                    beatmapSetId = score.Beatmap.OnlineBeatmapSetID
+                    beatmapId = score.beatmap_id,
+                    beatmapSetId = score.beatmap.beatmapset_id
                 }, transaction);
 
-                if (score.Passed)
+                if (score.passed)
                 {
                     conn.Execute("UPDATE osu_beatmaps SET passcount = passcount + @increment WHERE beatmap_id = @beatmapId", new
                     {
                         increment,
-                        beatmapId = score.BeatmapID
+                        beatmapId = score.beatmap_id
                     }, transaction);
                 }
 
                 // Reindex beatmap occasionally.
                 if (RNG.Next(0, 10) == 0)
-                    LegacyDatabaseHelper.RunLegacyIO("indexing/bulk", "POST", $"beatmapset[]={score.Beatmap.OnlineBeatmapSetID}");
+                    LegacyDatabaseHelper.RunLegacyIO("indexing/bulk", "POST", $"beatmapset[]={score.beatmap.beatmapset_id}");
 
                 // TODO: announce playcount milestones
                 // const int notify_amount = 1000000;
@@ -122,21 +121,21 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             }
         }
 
-        private static void adjustUserBeatmapPlaycount(SoloScoreInfo score, MySqlConnection conn, MySqlTransaction transaction, bool revert = false)
+        private static void adjustUserBeatmapPlaycount(SoloScore score, MySqlConnection conn, MySqlTransaction transaction, bool revert = false)
         {
             conn.Execute(
                 "INSERT INTO osu_user_beatmap_playcount (beatmap_id, user_id, playcount) VALUES (@beatmap_id, @user_id, @add) ON DUPLICATE KEY UPDATE playcount = GREATEST(0, playcount + @adjust)", new
                 {
-                    beatmap_id = score.BeatmapID,
-                    user_id = score.UserID,
+                    beatmap_id = score.beatmap_id,
+                    user_id = score.user_id,
                     add = revert ? 0 : 1,
                     adjust = revert ? -1 : 1,
                 }, transaction);
         }
 
-        private static void adjustUserMonthlyPlaycount(SoloScoreInfo score, MySqlConnection conn, MySqlTransaction transaction, bool revert = false)
+        private static void adjustUserMonthlyPlaycount(SoloScore score, MySqlConnection conn, MySqlTransaction transaction, bool revert = false)
         {
-            DateTimeOffset? date = score.StartedAt ?? score.EndedAt;
+            DateTimeOffset? date = score.started_at ?? score.ended_at;
 
             Debug.Assert(date != null);
 
@@ -144,7 +143,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 "INSERT INTO osu_user_month_playcount (`year_month`, user_id, playcount) VALUES (@yearmonth, @user_id, @add) ON DUPLICATE KEY UPDATE playcount = GREATEST(0, playcount + @adjust)", new
                 {
                     yearmonth = date.Value.ToString("yyMM"),
-                    user_id = score.UserID,
+                    user_id = score.user_id,
                     add = revert ? 0 : 1,
                     adjust = revert ? -1 : 1,
                 }, transaction);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
@@ -3,7 +3,6 @@
 
 using JetBrains.Annotations;
 using MySqlConnector;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
@@ -19,7 +18,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnLegacyScores => false;
 
-        public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
             if (!score.IsValidForPlayTracking(out int lengthInSeconds) && previousVersion >= 10)
                 return;
@@ -28,7 +27,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 userStats.total_seconds_played -= lengthInSeconds;
         }
 
-        public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
         {
             if (!score.IsValidForPlayTracking(out int lengthInSeconds))
                 return;
@@ -36,7 +35,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             userStats.total_seconds_played += lengthInSeconds;
         }
 
-        public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
+        public void ApplyGlobal(SoloScore score, MySqlConnection conn)
         {
         }
     }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/RankedScoreProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/RankedScoreProcessor.cs
@@ -20,7 +20,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
-            if (!DatabaseHelper.IsBeatmapValidForRankedCounts(score.beatmap_id, conn, transaction))
+            if (!score.BeatmapValidForRankedCounts())
                 return;
 
             if (previousVersion >= 9)
@@ -45,7 +45,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
         {
-            if (!DatabaseHelper.IsBeatmapValidForRankedCounts(score.beatmap_id, conn, transaction))
+            if (!score.BeatmapValidForRankedCounts())
                 return;
 
             // Note that most of the below code relies on the fact that classic scoring mode

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
 using MySqlConnector;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
@@ -38,16 +37,16 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         private static readonly bool write_legacy_score_pp = Environment.GetEnvironmentVariable("WRITE_LEGACY_SCORE_PP") != "0";
 
-        public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
         }
 
-        public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
         {
             ProcessScoreAsync(score, conn, transaction).Wait();
         }
 
-        public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
+        public void ApplyGlobal(SoloScore score, MySqlConnection conn)
         {
         }
 
@@ -58,7 +57,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         /// <param name="rulesetId">The ruleset for which scores should be processed.</param>
         /// <param name="connection">The <see cref="MySqlConnection"/>.</param>
         /// <param name="transaction">An existing transaction.</param>
-        public async Task ProcessUserScoresAsync(int userId, int rulesetId, MySqlConnection connection, MySqlTransaction? transaction = null)
+        public async Task ProcessUserScoresAsync(uint userId, int rulesetId, MySqlConnection connection, MySqlTransaction? transaction = null)
         {
             var scores = (await connection.QueryAsync<SoloScore>("SELECT * FROM scores WHERE `user_id` = @UserId AND `ruleset_id` = @RulesetId", new
             {
@@ -98,18 +97,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         /// <param name="score">The score to process.</param>
         /// <param name="connection">The <see cref="MySqlConnection"/>.</param>
         /// <param name="transaction">An existing transaction.</param>
-        public Task ProcessScoreAsync(SoloScore score, MySqlConnection connection, MySqlTransaction? transaction = null) => ProcessScoreAsync(score.ToScoreInfo(), connection, transaction);
-
-        /// <summary>
-        /// Processes the raw PP value of a given score.
-        /// </summary>
-        /// <param name="score">The score to process.</param>
-        /// <param name="connection">The <see cref="MySqlConnection"/>.</param>
-        /// <param name="transaction">An existing transaction.</param>
-        public async Task ProcessScoreAsync(SoloScoreInfo score, MySqlConnection connection, MySqlTransaction? transaction = null)
+        public async Task ProcessScoreAsync(SoloScore score, MySqlConnection connection, MySqlTransaction? transaction = null)
         {
             // Usually checked via "RunOnFailedScores", but this method is also used by the CLI batch processor.
-            if (!score.Passed)
+            if (!score.passed)
                 return;
 
             long currentTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
@@ -124,16 +115,16 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
             try
             {
-                score.Beatmap ??= (await beatmapStore.GetBeatmapAsync((uint)score.BeatmapID, connection, transaction))?.ToAPIBeatmap();
+                score.beatmap ??= (await beatmapStore.GetBeatmapAsync(score.beatmap_id, connection, transaction));
 
-                if (score.Beatmap is not APIBeatmap beatmap)
+                if (score.beatmap is not Beatmap beatmap)
                     return;
 
-                if (!beatmapStore.IsBeatmapValidForPerformance(beatmap, (uint)score.RulesetID))
+                if (!beatmapStore.IsBeatmapValidForPerformance(beatmap, score.ruleset_id))
                     return;
 
-                Ruleset ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(score.RulesetID);
-                Mod[] mods = score.Mods.Select(m => m.ToMod(ruleset)).ToArray();
+                Ruleset ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(score.ruleset_id);
+                Mod[] mods = score.ScoreData.Mods.Select(m => m.ToMod(ruleset)).ToArray();
 
                 if (!AllModsValidForPerformance(score, mods))
                     return;
@@ -142,13 +133,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
                 // Performance needs to be allowed for the build.
                 // legacy scores don't need a build id
-                if (score.LegacyScoreId == null && (score.BuildID == null || buildStore.GetBuild(score.BuildID.Value)?.allow_performance != true))
+                if (score.legacy_score_id == null && (score.build_id == null || buildStore.GetBuild(score.build_id.Value)?.allow_performance != true))
                     return;
 
                 if (difficultyAttributes == null)
                     return;
 
-                ScoreInfo scoreInfo = score.ToScoreInfo(mods, beatmap);
+                ScoreInfo scoreInfo = score.ToScoreInfo();
                 PerformanceAttributes? performanceAttributes = ruleset.CreatePerformanceCalculator()?.Calculate(scoreInfo, difficultyAttributes);
 
                 if (performanceAttributes == null)
@@ -156,36 +147,36 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
                 await connection.ExecuteAsync("UPDATE scores SET pp = @Pp WHERE id = @ScoreId", new
                 {
-                    ScoreId = score.ID,
+                    ScoreId = score.id,
                     Pp = performanceAttributes.Total
                 }, transaction: transaction);
 
                 // for the following code to take effect, `RunOnLegacyScores` must also be true (currently is false).
-                if (score.IsLegacyScore && write_legacy_score_pp)
+                if (score.is_legacy_score && write_legacy_score_pp)
                 {
-                    var helper = LegacyDatabaseHelper.GetRulesetSpecifics(score.RulesetID);
+                    var helper = LegacyDatabaseHelper.GetRulesetSpecifics(score.ruleset_id);
                     await connection.ExecuteAsync($"UPDATE {helper.HighScoreTable} SET pp = @Pp WHERE score_id = @LegacyScoreId", new
                     {
-                        LegacyScoreId = score.LegacyScoreId,
+                        LegacyScoreId = score.legacy_score_id,
                         Pp = performanceAttributes.Total,
                     }, transaction: transaction);
                 }
             }
             catch (Exception ex)
             {
-                await Console.Error.WriteLineAsync($"{score.ID} failed with: {ex}");
+                await Console.Error.WriteLineAsync($"{score.id} failed with: {ex}");
             }
         }
 
         /// <summary>
         /// Checks whether all mods in a given array are valid to give PP for.
         /// </summary>
-        public static bool AllModsValidForPerformance(SoloScoreInfo score, Mod[] mods)
+        public static bool AllModsValidForPerformance(SoloScore score, Mod[] mods)
         {
             IEnumerable<Mod> modsToCheck = mods;
 
             // Classic mod is only allowed on legacy scores.
-            if (score.IsLegacyScore)
+            if (score.is_legacy_score)
                 modsToCheck = mods.Where(mod => mod is not ModClassic);
 
             return modsToCheck.All(m => m.Ranked);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
@@ -22,7 +22,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
-            if (!DatabaseHelper.IsBeatmapValidForRankedCounts(score.beatmap_id, conn, transaction))
+            if (!score.BeatmapValidForRankedCounts())
                 return;
 
             if (previousVersion >= 7)
@@ -47,7 +47,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
         {
-            if (!DatabaseHelper.IsBeatmapValidForRankedCounts(score.beatmap_id, conn, transaction))
+            if (!score.BeatmapValidForRankedCounts())
                 return;
 
             var bestScore = DatabaseHelper.GetUserBestScoreFor(score, conn, transaction);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
 using MySqlConnector;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
@@ -24,13 +23,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnLegacyScores => true;
 
-        public void RevertFromUserStats(SoloScoreInfo score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
         }
 
-        public void ApplyToUserStats(SoloScoreInfo score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction)
         {
-            var dbInfo = LegacyDatabaseHelper.GetRulesetSpecifics(score.RulesetID);
+            var dbInfo = LegacyDatabaseHelper.GetRulesetSpecifics(score.ruleset_id);
 
             int warnings = conn.QuerySingleOrDefault<int>($"SELECT `user_warnings` FROM {dbInfo.UsersTable} WHERE `user_id` = @UserId", new
             {
@@ -40,10 +39,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             if (warnings > 0)
                 return;
 
-            UpdateUserStatsAsync(userStats, score.RulesetID, conn, transaction).Wait();
+            UpdateUserStatsAsync(userStats, score.ruleset_id, conn, transaction).Wait();
         }
 
-        public void ApplyGlobal(SoloScoreInfo score, MySqlConnection conn)
+        public void ApplyGlobal(SoloScore score, MySqlConnection conn)
         {
         }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
@@ -12,7 +12,6 @@ using Dapper;
 using Dapper.Contrib.Extensions;
 using MySqlConnector;
 using osu.Framework.Extensions.TypeExtensions;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 using osu.Server.QueueProcessor;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
@@ -174,17 +173,16 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
 
                 using (var conn = GetDatabaseConnection())
                 {
-                    var scoreRow = item.Score;
-                    var score = scoreRow.ToScoreInfo();
+                    var score = item.Score;
 
-                    score.Beatmap = conn.QuerySingleOrDefault<Beatmap>("SELECT * FROM osu_beatmaps WHERE `beatmap_id` = @BeatmapId", new
+                    score.beatmap = conn.QuerySingleOrDefault<Beatmap>("SELECT * FROM osu_beatmaps WHERE `beatmap_id` = @BeatmapId", new
                     {
-                        BeatmapId = score.BeatmapID
-                    })?.ToAPIBeatmap();
-                    score.BeatmapSet = conn.QuerySingleOrDefault<BeatmapSet>("SELECT * FROM `osu_beatmapsets` WHERE `beatmapset_id` = @BeatmapSetId", new
+                        BeatmapId = score.beatmap_id
+                    });
+                    score.beatmap!.beatmapset = conn.QuerySingleOrDefault<BeatmapSet>("SELECT * FROM `osu_beatmapsets` WHERE `beatmapset_id` = @BeatmapSetId", new
                     {
-                        BeatmapSetId = score.Beatmap!.OnlineBeatmapSetID
-                    })?.ToAPIBeatmapSet();
+                        BeatmapSetId = score.beatmap.beatmapset_id
+                    });
 
                     using (var transaction = conn.BeginTransaction(IsolationLevel.ReadCommitted))
                     {
@@ -231,10 +229,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
                     // TODO: this can be removed after https://github.com/ppy/osu-web/issues/10942 is closed out.
                     // Intentionally not part of the transaction to avoid deadlocks.
                     // See https://discord.com/channels/90072389919997952/983550677794050108/1199725169573380136
-                    if (score.Passed)
+                    if (score.passed)
                     {
                         // For now, just assume all passing scores are to be preserved.
-                        conn.Execute("UPDATE scores SET preserve = 1 WHERE id = @Id", new { Id = score.ID });
+                        conn.Execute("UPDATE scores SET preserve = 1 WHERE id = @Id", new { Id = score.id });
                     }
 
                     foreach (var p in enumerateValidProcessors(score))
@@ -258,14 +256,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
             }
         }
 
-        private IEnumerable<IProcessor> enumerateValidProcessors(SoloScoreInfo score)
+        private IEnumerable<IProcessor> enumerateValidProcessors(SoloScore score)
         {
             IEnumerable<IProcessor> result = processors;
 
-            if (!score.Passed)
+            if (!score.passed)
                 result = result.Where(p => p.RunOnFailedScores);
 
-            if (score.IsLegacyScore)
+            if (score.is_legacy_score)
                 result = result.Where(p => p.RunOnLegacyScores);
 
             return result;


### PR DESCRIPTION
RFC. PRing early as draft to not invest more time into this rabbit-hole before I get buy-in. Nerd essay incoming, please bear with me as I attempt to explain myself.

Where do I even begin... This is a result of several layers of yak-shaving.

- Yak level 0: I want to start on https://github.com/ppy/osu/issues/16480. I go to the client code and I see the absolute mess that is the results screen data structure juggling across different paths (multiplayer/playlists/solo/local scores) with different things using different models and relying on things being there that aren't necessarily always there, and I decide that the results screen hierarchy should use `IScoreInfo`.
- Yak level 1: I look at what it takes to move things to `IScoreInfo`. The answer is: a lot, but a low-hanging fruit was to add `(Maximum)Statistics` to that interface, because it exists already on both implementations (`ScoreInfo` and `SoloScoreInfo`). Things go relatively smoothly until I notice [these two helpers](https://github.com/ppy/osu/blob/61350ebf6ea89605997d91a71e9de14540aad9cd/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs#L17-L21).
 
  It would seem that these can use `IScoreInfo` now, but knowing that the second method is used server-side in this repository, I go to check server code, and come to the horrifying realisation that they cannot, because on `SoloScoreInfo` in this repository it can actually hold that `soloScoreInfo.RulesetID != soloScoreInfo.Ruleset.OnlineID`, because the former is the _actual_ ID of the ruleset that the score was set on, and the second [actually silently will go through the beatmap](https://github.com/ppy/osu/blob/61350ebf6ea89605997d91a71e9de14540aad9cd/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs#L152) and [server-side we set the beatmap to this](https://github.com/ppy/osu-queue-score-statistics/blob/b3887b3456de2f04b362f5ae822f39e8e0ad4b97/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs#L180-L183), which is actually the raw database row underneath and will have the ruleset ID _before_ conversion. I decide that this is completely pants on head bonkers and decide to change it.
- Yak level 2: We are here.

Generally I find that the `SoloScoreInfo` convertery probably made more sense before https://github.com/ppy/osu-queue-score-statistics/pull/198, as it made sense to just put the json where the json need to go verbatim in the same format as client deserialised it, but now it's pretty much not that helpful in that respect and makes it actively way too difficult to make any changes client-side as you have to remember that Thing X is used in Place Y and if you forget about it you silently break things whenever the next game package bump happens and now you have a whole new mystery to unravel.

I find myself leaning towards this diff being a Good Thing but I want to get second opinions before I commit too hard. Note that this will also mean that I will have to update the already-merged hush-hush medal stuff to update to this (which is probably going to be _fun_ to both do _and_ review), so this is _not_ all of the changes required yet.

Probably the actual best tangible argument in favour of this change is that it makes https://github.com/ppy/osu-queue-score-statistics/commit/121f3023f114c83522dd949ead8aa4d1227db0c3 possible. https://github.com/ppy/osu-queue-score-statistics/commit/b03b4f35a309089cf572e16df856228466b9a76c is also nice but I believe it could be applied on `master` already in an altered form, I just noticed that it was stupid while doing the rest of this.

This probably needs more testing / scrutiny in the weird parts that still have to interface with game code (namely `SoloScore.ToScoreInfo()` and the implementation of `IBeatmapOnlineInfo` / `GetLegacyBeatmapConversionDifficultyInfo()` in `Beatmap`). I only checked that this passes tests. Again, before I commit more time into this, I want at least an acknowledgement that we do want to go this way.