### PR TITLE
Fix `maintenance delete-high-scores` command not working

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/DeleteImportedHighScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/DeleteImportedHighScoresCommand.cs
@@ -91,8 +91,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                             Console.WriteLine($"Queued {elasticItems.Count} items for indexing");
                         }
 
-                        lastId = highScores.Max(s => s.id);
+                        lastId = highScores.Max(s => s.id) + 1;
                         Console.WriteLine($"Processed up to {lastId} ({deleted} deleted)");
+
+                        await transaction.CommitAsync(cancellationToken);
                     }
                 }
             }


### PR DESCRIPTION
Noticed that this exists and wanted to use it for local clean-up but then it turned out that it didn't work.

- When determining the new value of `lastId` after a batch by taking the max row ID from the batch, `+ 1` was not added, which then combined with the `id >= @lastId` clause used for querying the next batch meant that the deletion would be stuck until the end of time (or a ^C) on the very last row.

- The transactions opened by this command were never committed, which meant that scores would be de-indexed from elastic, but the rows would still exist in database.