### PR TITLE
Add partition cache for `user_rank_index` updates

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ManiaKeyModeUserStatsProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ManiaKeyModeUserStatsProcessor.cs
@@ -69,6 +69,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
                 (keymodeStats.rank_score, keymodeStats.accuracy_new) = UserTotalPerformanceAggregateHelper.CalculateUserTotalPerformanceAggregates(scores);
 
+                // TODO: partitioned caching similar to UserTotalPerformanceProcessor.
                 keymodeStats.rank_score_index = conn.QuerySingle<int>($"SELECT COUNT(*) FROM {keyCountTableName} WHERE rank_score > {keymodeStats.rank_score}", transaction: transaction) + 1;
 
                 if (existingRow != null)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -148,7 +148,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 new { cutoff }, transaction: transaction));
 
             int remainingCount = await connection.QuerySingleAsync<int>(
-                $"SELECT COUNT(*) FROM {dbInfo.UserStatsTable} WHERE rank_score BETWEEN @rankScoreCutoff AND @partitionCutoff AND user_id != @userId",
+                $"SELECT COUNT(*) FROM {dbInfo.UserStatsTable} WHERE rank_score > @rankScoreCutoff AND rank_score <= @partitionCutoff AND user_id != @userId",
                 new
                 {
                     userId = userStats.user_id,

--- a/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
@@ -13,6 +13,7 @@
         <PackageReference Include="Dapper" Version="2.1.44" />
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
         <PackageReference Include="ppy.osu.Game" Version="2024.412.1" />
         <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.412.1" />
         <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.412.1" />


### PR DESCRIPTION
Similar to what is done in web-10.

- [x] Add a few more tests which better test new cache (current coverage is only for a single entry in `user_stats`)