### PR TITLE
Reduce verbosity of `verify-imported-scores` command

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
@@ -37,6 +37,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
         [Option(CommandOptionType.SingleOrNoValue, Template = "-v|--verbose", Description = "Output when a score is preserved too.")]
         public bool Verbose { get; set; }
 
+        [Option(CommandOptionType.SingleOrNoValue, Template = "-q|--quiet", Description = "Reduces output.")]
+        public bool Quiet { get; set; }
+
         /// <summary>
         /// The number of scores to run in each batch. Setting this higher will cause larger SQL statements for insert.
         /// </summary>
@@ -244,14 +247,19 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                     }
                 }
 
-                Console.Write($"Processed up to {importedScores.Max(s => s.id)} ({deleted} deleted {fail} failed)");
-                Console.SetCursorPosition(0, Console.GetCursorPosition().Top);
+                if (!Quiet)
+                {
+                    Console.Write($"Processed up to {importedScores.Max(s => s.id)} ({deleted} deleted {fail} failed)");
+                    Console.SetCursorPosition(0, Console.GetCursorPosition().Top);
+                }
 
                 lastId += (ulong)BatchSize;
                 flush(conn);
             }
 
             flush(conn, true);
+
+            Console.WriteLine($"Finished ({deleted} deleted {fail} failed)");
 
             return 0;
         }


### PR DESCRIPTION
The cursor trick doesn't work on docker/etc, making this command very spammy: https://github.com/ppy/osu/actions/runs/9298230620/job/25589772915

In this case, I'll set the `--quiet` flag and live with the single line of output at the end.