### PR TITLE
Fix pack pass check considering converted plays when pack is not associated with a ruleset

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
@@ -136,6 +136,47 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             AssertNoMedalsAwarded();
         }
 
+        [Theory]
+        [MemberData(nameof(MEDAL_PACK_IDS))]
+        public void TestConvertsNotAllowedForPackMedals(int medalId, int packId)
+        {
+            var firstBeatmap = AddBeatmap(b =>
+            {
+                b.beatmap_id = 1234;
+                b.playmode = 0;
+            }, s => s.beatmapset_id = 4321);
+            var secondBeatmap = AddBeatmap(b =>
+            {
+                b.beatmap_id = 5678;
+                b.playmode = 0;
+            }, s => s.beatmapset_id = 8765);
+
+            AddPackMedal(medalId, packId, [firstBeatmap, secondBeatmap]);
+            setUpBeatmapsForPackMedal([firstBeatmap, secondBeatmap]);
+
+            AssertNoMedalsAwarded();
+
+            SetScoreForBeatmap(firstBeatmap.beatmap_id, s =>
+            {
+                s.Score.passed = true;
+                s.Score.preserve = true;
+                s.Score.build_id = TestBuildID;
+                s.Score.ruleset_id = 3;
+                s.Score.pp = 10;
+            });
+            AssertNoMedalsAwarded();
+
+            SetScoreForBeatmap(secondBeatmap.beatmap_id, s =>
+            {
+                s.Score.passed = true;
+                s.Score.preserve = true;
+                s.Score.build_id = TestBuildID;
+                s.Score.ruleset_id = 0;
+                s.Score.pp = 10;
+            });
+            AssertNoMedalsAwarded();
+        }
+
         /// <summary>
         /// This tests the simplest case of a medal being awarded for completing a pack.
         /// This mimics the "video game" pack, but is intended to test the process rather than the

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/MedalHelpers.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/MedalHelpers.cs
@@ -58,7 +58,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
         public static bool UserPassedPack(MedalAwarderContext context, bool noReductionMods, int packId)
         {
             string modsCriteria = string.Empty;
-            string rulesetCriteria = string.Empty;
+            string rulesetCriteria;
 
             if (noReductionMods)
             {
@@ -82,6 +82,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
                     return false;
 
                 rulesetCriteria = $"AND ruleset_id = {packRulesetId}";
+            }
+            else
+            {
+                rulesetCriteria = "AND `s`.`ruleset_id` = `b`.`playmode`";
             }
 
             // TODO: no index on (beatmap_id, user_id) may mean this is too slow.


### PR DESCRIPTION
Reported privately.

The corresponding web-10 query looks like this (somewhat abridged):

```sql
SELECT COUNT(*) FROM (
SELECT p.beatmapset_id FROM osu_beatmappacks_items p JOIN osu_beatmaps b USING (beatmapset_id) JOIN osu_scores_high s USING (beatmap_id) WHERE s.user_id = @userId AND b.playmode = 0 AND pack_id = @packId UNION DISTINCT
SELECT p.beatmapset_id FROM osu_beatmappacks_items p JOIN osu_beatmaps b USING (beatmapset_id) JOIN osu_scores_taiko_high s USING (beatmap_id) WHERE s.user_id = @userId AND b.playmode = 1 AND pack_id = @packId UNION DISTINCT
SELECT p.beatmapset_id FROM osu_beatmappacks_items p JOIN osu_beatmaps b USING (beatmapset_id) JOIN osu_scores_fruits_high s USING (beatmap_id) WHERE s.user_id = @userId AND b.playmode = 2 AND pack_id = @packId UNION DISTINCT
SELECT p.beatmapset_id FROM osu_beatmappacks_items p JOIN osu_beatmaps b USING (beatmapset_id) JOIN osu_scores_mania_high s USING (beatmap_id) WHERE s.user_id =  @userId} AND b.playmode = 3 AND pack_id = @packId) a
```

If it is not immediately clear why the above disallows converts, then to spell it out: it is the part that the query is split into four `UNION`'d parts, each of which queries only one `scores_high` table for each of the rulesets, and only includes the beatmaps in the pack which have the same `playmode`.

For profiling purposes, here are two examples of query shapes after this change, taken from the test (params may need tweaking appropriately):

```sql
SELECT COUNT(distinct p.beatmapset_id)
FROM osu_beatmappacks_items p
JOIN osu_beatmaps b USING (beatmapset_id)
JOIN scores s USING (beatmap_id)
WHERE s.user_id = 2 AND s.passed = 1 AND s.preserve = 1 AND pack_id = 40 AND `s`.`ruleset_id` = `b`.`playmode`
```

```sql
SELECT COUNT(distinct p.beatmapset_id)
FROM osu_beatmappacks_items p
JOIN osu_beatmaps b USING (beatmapset_id)
JOIN scores s USING (beatmap_id)
WHERE s.user_id = 2 AND s.passed = 1 AND s.preserve = 1 AND pack_id = 2036 AND `s`.`ruleset_id` = `b`.`playmode`
AND json_search(data, 'one', 'EZ', null, '$.mods[*].acronym') IS NULL
AND json_search(data, 'one', 'NF', null, '$.mods[*].acronym') IS NULL
AND json_search(data, 'one', 'HT', null, '$.mods[*].acronym') IS NULL
AND json_search(data, 'one', 'DC', null, '$.mods[*].acronym') IS NULL
AND json_search(data, 'one', 'SO', null, '$.mods[*].acronym') IS NULL
AND s.pp IS NOT NULL
```