### PR TITLE
Count tick hits into hit/miss counts in catch plays

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/HitStatisticsProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/HitStatisticsProcessor.cs
@@ -45,15 +45,18 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 switch (result)
                 {
                     case HitResult.Miss:
+                    case HitResult.LargeTickMiss when score.ruleset_id == 2:
                         userStats.countMiss += multiplier * count;
                         break;
 
                     case HitResult.Meh:
+                    case HitResult.SmallTickHit when score.ruleset_id == 2:
                         userStats.count50 += multiplier * count;
                         break;
 
                     case HitResult.Ok:
                     case HitResult.Good:
+                    case HitResult.LargeTickHit when score.ruleset_id == 2:
                         userStats.count100 += multiplier * count;
                         break;
 


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/29328.

Readers could recall that [there is a set of helpers for this sort of thing game-side](https://github.com/ppy/osu/blob/ea94f903c1ef72ef79dff19d923fdbd4bfcf2357/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs#L67-L215) and then rightly ask why I'm not using that? Well, the answer is that this would be incorrect for mania.

What do I mean? While yes, using these helpers would correctly alias large tick hits to `count100` and small tick hits to `count50` in catch, it would also alias `HitResult.Perfect` to... `countGeki` in mania, and `HitResult.Good` to `countKatu`.

In mania specifically, web-10 would add `countGeki` to `count300` and `countKatu` to `count100` to account for this. Thus, a complete local copy of the relevant catch logic is used instead, because I can't use the osu!-side helpers directly, and would have to hardcode the mania exception anyway - so at that point might as well just skip reuse of something that doesn't really fully fit anyway.