### PR TITLE
Score processing command updates for upcoming (and future PP deploys)

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/PerformanceCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/PerformanceCommand.cs
@@ -103,7 +103,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance
             await Task.WhenAll(Partitioner
                                .Create(values)
                                .GetPartitions(Threads)
-                               .AsParallel()
                                .Select(processPartition));
 
             async Task processPartition(IEnumerator<T> partition)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/PerformanceCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/PerformanceCommand.cs
@@ -92,7 +92,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance
             await ProcessPartitioned(userIds, async userId =>
             {
                 using (var db = DatabaseAccess.GetConnection())
-                    await ScoreProcessor.ProcessUserScoresAsync(userId, RulesetId, db);
+                    await ScoreProcessor.ProcessUserScoresAsync(userId, RulesetId, db, cancellationToken: cancellationToken);
 
                 Console.WriteLine($"Processed {Interlocked.Increment(ref processedCount)} of {userIds.Length}");
             }, cancellationToken);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresByUserCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresByUserCommand.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Data;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -81,7 +82,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
                 await ProcessPartitioned(userIds, async userId =>
                 {
                     using (var db = DatabaseAccess.GetConnection())
-                    using (var transaction = await db.BeginTransactionAsync(cancellationToken))
+                    using (var transaction = await db.BeginTransactionAsync(IsolationLevel.ReadUncommitted, cancellationToken))
                     {
                         Interlocked.Add(ref totalScores, (ulong)await ScoreProcessor.ProcessUserScoresAsync(userId, RulesetId, db, transaction, cancellationToken));
                         await transaction.CommitAsync(cancellationToken);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresByUserCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresByUserCommand.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,7 +16,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
     [Command(Name = "all-users", Description = "Computes pp of all scores from all users.")]
     public class UpdateAllScoresByUserCommand : PerformanceCommand
     {
-        private const int max_users_per_query = 10000;
+        private const int max_users_per_query = 1000;
 
         [Option(Description = "Continue where a previously aborted 'all' run left off.")]
         public bool Continue { get; set; }
@@ -37,26 +38,32 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
                 }
             }
 
-            ulong? totalUsers = 0;
+            ulong? totalUsers;
             ulong totalScores = 0;
+            double rate = 0;
+            Stopwatch sw = new Stopwatch();
+
+            Console.WriteLine("Fetching users all users...");
 
             using (var db = DatabaseAccess.GetConnection())
             {
                 totalUsers = await db.QuerySingleAsync<ulong?>($"SELECT COUNT(`user_id`) FROM {databaseInfo.UserStatsTable} WHERE `user_id` >= @UserId", new
                 {
                     UserId = currentUserId
-                });
+                }, commandTimeout: 300000);
 
                 if (totalUsers == null)
                     throw new InvalidOperationException("Could not find user ID count.");
             }
 
-            Console.WriteLine($"Processing all users starting from UserID {currentUserId}");
+            Console.WriteLine($"Processing all {totalUsers:N0} users starting from UserID {currentUserId:N0}");
 
             int processedUsers = 0;
 
             while (!cancellationToken.IsCancellationRequested)
             {
+                sw.Restart();
+
                 uint[] userIds;
 
                 using (var db = DatabaseAccess.GetConnection())
@@ -74,13 +81,23 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
                 await ProcessPartitioned(userIds, async userId =>
                 {
                     using (var db = DatabaseAccess.GetConnection())
-                        Interlocked.Add(ref totalScores, (ulong)(await ScoreProcessor.ProcessUserScoresAsync(userId, RulesetId, db, cancellationToken: cancellationToken)));
-
-                    if (Interlocked.Increment(ref processedUsers) % 1000 == 0)
-                        Console.WriteLine($"Processed {processedUsers:N0} of {totalUsers:N0} ({totalScores:N0} scores)");
+                    using (var transaction = await db.BeginTransactionAsync(cancellationToken))
+                    {
+                        Interlocked.Add(ref totalScores, (ulong)await ScoreProcessor.ProcessUserScoresAsync(userId, RulesetId, db, transaction, cancellationToken));
+                        await transaction.CommitAsync(cancellationToken);
+                    }
                 }, cancellationToken);
 
                 currentUserId = userIds.Max();
+                processedUsers += userIds.Length;
+
+                if (rate == 0)
+                    rate = ((double)userIds.Length / sw.ElapsedMilliseconds * 1000);
+                else
+                    rate = rate * 0.95 + 0.05 * ((double)userIds.Length / sw.ElapsedMilliseconds * 1000);
+
+                Console.WriteLine(ScoreProcessor.BeatmapStore?.GetCacheStats());
+                Console.WriteLine($"id: {currentUserId:N0} changed scores: {totalScores:N0} ({processedUsers:N0} of {totalUsers:N0} {(float)processedUsers / totalUsers:P1}) {rate:N0}/s");
 
                 using (var db = DatabaseAccess.GetConnection())
                     await DatabaseHelper.SetCountAsync(databaseInfo.LastProcessedPpUserCount, currentUserId, db);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresByUserCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresByUserCommand.cs
@@ -12,7 +12,7 @@ using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
 {
-    [Command(Name = "all", Description = "Computes pp of all scores from all users.")]
+    [Command(Name = "all-users", Description = "Computes pp of all scores from all users.")]
     public class UpdateAllScoresByUserCommand : PerformanceCommand
     {
         private const int max_users_per_query = 10000;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresByUserCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresByUserCommand.cs
@@ -73,7 +73,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
                 await ProcessPartitioned(userIds, async userId =>
                 {
                     using (var db = DatabaseAccess.GetConnection())
-                        await ScoreProcessor.ProcessUserScoresAsync(userId, RulesetId, db);
+                        await ScoreProcessor.ProcessUserScoresAsync(userId, RulesetId, db, cancellationToken: cancellationToken);
 
                     Console.WriteLine($"Processed {Interlocked.Increment(ref processedCount)} of {totalCount}");
                 }, cancellationToken);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresByUserCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresByUserCommand.cs
@@ -75,7 +75,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
                     using (var db = DatabaseAccess.GetConnection())
                         await ScoreProcessor.ProcessUserScoresAsync(userId, RulesetId, db, cancellationToken: cancellationToken);
 
-                    Console.WriteLine($"Processed {Interlocked.Increment(ref processedCount)} of {totalCount}");
+                    if (Interlocked.Increment(ref processedCount) % 1000 == 0)
+                        Console.WriteLine($"Processed {processedCount} of {totalCount}");
                 }, cancellationToken);
 
                 currentUserId = userIds.Max();

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresByUserCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresByUserCommand.cs
@@ -22,40 +22,41 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
         [Option(Description = "Continue where a previously aborted 'all' run left off.")]
         public bool Continue { get; set; }
 
+        /// <summary>
+        /// Whether to adjust processing rate based on slave latency. Defaults to <c>false</c>.
+        /// </summary>
+        [Option(CommandOptionType.SingleOrNoValue, Template = "--check-slave-latency")]
+        public bool CheckSlaveLatency { get; set; }
+
         protected override async Task<int> ExecuteAsync(CancellationToken cancellationToken)
         {
+            using var db = DatabaseAccess.GetConnection();
+
             LegacyDatabaseHelper.RulesetDatabaseInfo databaseInfo = LegacyDatabaseHelper.GetRulesetSpecifics(RulesetId);
 
             long currentUserId;
 
-            using (var db = DatabaseAccess.GetConnection())
+            if (Continue)
+                currentUserId = await DatabaseHelper.GetCountAsync(databaseInfo.LastProcessedPpUserCount, db);
+            else
             {
-                if (Continue)
-                    currentUserId = await DatabaseHelper.GetCountAsync(databaseInfo.LastProcessedPpUserCount, db);
-                else
-                {
-                    currentUserId = 0;
-                    await DatabaseHelper.SetCountAsync(databaseInfo.LastProcessedPpUserCount, 0, db);
-                }
+                currentUserId = 0;
+                await DatabaseHelper.SetCountAsync(databaseInfo.LastProcessedPpUserCount, 0, db);
             }
 
-            ulong? totalUsers;
             ulong totalScores = 0;
             double rate = 0;
             Stopwatch sw = new Stopwatch();
 
             Console.WriteLine("Fetching users all users...");
 
-            using (var db = DatabaseAccess.GetConnection())
+            ulong? totalUsers = await db.QuerySingleAsync<ulong?>($"SELECT COUNT(`user_id`) FROM {databaseInfo.UserStatsTable} WHERE `user_id` >= @UserId", new
             {
-                totalUsers = await db.QuerySingleAsync<ulong?>($"SELECT COUNT(`user_id`) FROM {databaseInfo.UserStatsTable} WHERE `user_id` >= @UserId", new
-                {
-                    UserId = currentUserId
-                }, commandTimeout: 300000);
+                UserId = currentUserId
+            }, commandTimeout: 300000);
 
-                if (totalUsers == null)
-                    throw new InvalidOperationException("Could not find user ID count.");
-            }
+            if (totalUsers == null)
+                throw new InvalidOperationException("Could not find user ID count.");
 
             Console.WriteLine($"Processing all {totalUsers:N0} users starting from UserID {currentUserId:N0}");
 
@@ -63,26 +64,24 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
 
             while (!cancellationToken.IsCancellationRequested)
             {
+                if (CheckSlaveLatency)
+                    await SlaveLatencyChecker.CheckSlaveLatency(db, cancellationToken);
+
                 sw.Restart();
 
-                uint[] userIds;
-
-                using (var db = DatabaseAccess.GetConnection())
+                uint[] userIds = (await db.QueryAsync<uint>($"SELECT `user_id` FROM {databaseInfo.UserStatsTable} WHERE `user_id` > @UserId ORDER BY `user_id` LIMIT @Limit", new
                 {
-                    userIds = (await db.QueryAsync<uint>($"SELECT `user_id` FROM {databaseInfo.UserStatsTable} WHERE `user_id` > @UserId ORDER BY `user_id` LIMIT @Limit", new
-                    {
-                        UserId = currentUserId,
-                        Limit = max_users_per_query
-                    })).ToArray();
-                }
+                    UserId = currentUserId,
+                    Limit = max_users_per_query
+                })).ToArray();
 
                 if (userIds.Length == 0)
                     break;
 
                 await ProcessPartitioned(userIds, async userId =>
                 {
-                    using (var db = DatabaseAccess.GetConnection())
-                    using (var transaction = await db.BeginTransactionAsync(IsolationLevel.ReadUncommitted, cancellationToken))
+                    using (var partitionDb = DatabaseAccess.GetConnection())
+                    using (var transaction = await partitionDb.BeginTransactionAsync(IsolationLevel.ReadUncommitted, cancellationToken))
                     {
                         Interlocked.Add(ref totalScores, (ulong)await ScoreProcessor.ProcessUserScoresAsync(userId, RulesetId, db, transaction, cancellationToken));
                         await transaction.CommitAsync(cancellationToken);
@@ -100,8 +99,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
                 Console.WriteLine(ScoreProcessor.BeatmapStore?.GetCacheStats());
                 Console.WriteLine($"id: {currentUserId:N0} changed scores: {totalScores:N0} ({processedUsers:N0} of {totalUsers:N0} {(float)processedUsers / totalUsers:P1}) {rate:N0}/s");
 
-                using (var db = DatabaseAccess.GetConnection())
-                    await DatabaseHelper.SetCountAsync(databaseInfo.LastProcessedPpUserCount, currentUserId, db);
+                await DatabaseHelper.SetCountAsync(databaseInfo.LastProcessedPpUserCount, currentUserId, db);
             }
 
             return 0;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
@@ -106,9 +106,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
 
             Task<List<SoloScore>> getNextScores() => Task.Run(() =>
             {
-                List<SoloScore> scores = new List<SoloScore>();
-
-                scores.Clear();
+                List<SoloScore> scores = new List<SoloScore>(max_scores_per_query);
 
                 for (int i = 0; i < max_scores_per_query && scoresEnum.MoveNext(); i++)
                     scores.Add(scoresEnum.Current);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
@@ -1,0 +1,70 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using McMaster.Extensions.CommandLineUtils;
+using osu.Server.QueueProcessor;
+using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
+{
+    [Command(Name = "all", Description = "Computes pp of all scores from all users.")]
+    public class UpdateAllScoresCommand : PerformanceCommand
+    {
+        private const int max_users_per_query = 10000;
+
+        [Option(Description = "Score ID to start processing from.")]
+        public ulong From { get; set; }
+
+        protected override async Task<int> ExecuteAsync(CancellationToken cancellationToken)
+        {
+            LegacyDatabaseHelper.RulesetDatabaseInfo databaseInfo = LegacyDatabaseHelper.GetRulesetSpecifics(RulesetId);
+
+            ulong? totalCount;
+            ulong currentScoreId = From;
+
+            using (var db = DatabaseAccess.GetConnection())
+            {
+                totalCount = await db.QuerySingleAsync<ulong>("SELECT MAX(id) FROM scores");
+            }
+
+            Console.WriteLine($"Processing all scores starting from {currentScoreId}");
+
+            int processedCount = 0;
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                ulong[] scoreIds;
+
+                using (var db = DatabaseAccess.GetConnection())
+                {
+                    scoreIds = (await db.QueryAsync<ulong>($"SELECT id FROM scores WHERE `id` > @ScoreId ORDER BY `id` LIMIT @Limit", new
+                    {
+                        ScoreId = currentScoreId,
+                        Limit = max_users_per_query
+                    })).ToArray();
+                }
+
+                if (scoreIds.Length == 0)
+                    break;
+
+                await ProcessPartitioned(scoreIds, async id =>
+                {
+                    using (var db = DatabaseAccess.GetConnection())
+                        await ScoreProcessor.ProcessScoreAsync(id, db);
+
+                    if (Interlocked.Increment(ref processedCount) % 1000 == 0)
+                        Console.WriteLine($"Processed {processedCount} of {totalCount}");
+                }, cancellationToken);
+
+                currentScoreId = scoreIds.Max();
+            }
+
+            return 0;
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
@@ -2,28 +2,27 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Dapper;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Server.QueueProcessor;
-using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
 {
     [Command(Name = "all", Description = "Computes pp of all scores from all users.")]
     public class UpdateAllScoresCommand : PerformanceCommand
     {
-        private const int max_users_per_query = 10000;
+        private const int max_scores_per_query = 50000;
 
         [Option(Description = "Score ID to start processing from.")]
         public ulong From { get; set; }
 
         protected override async Task<int> ExecuteAsync(CancellationToken cancellationToken)
         {
-            LegacyDatabaseHelper.RulesetDatabaseInfo databaseInfo = LegacyDatabaseHelper.GetRulesetSpecifics(RulesetId);
-
             ulong? totalCount;
             ulong currentScoreId = From;
 
@@ -32,36 +31,48 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
                 totalCount = await db.QuerySingleAsync<ulong>("SELECT MAX(id) FROM scores");
             }
 
-            Console.WriteLine($"Processing all scores starting from {currentScoreId}");
+            Console.WriteLine($"Processing all {totalCount} scores starting from {currentScoreId}");
 
             int processedCount = 0;
 
             while (!cancellationToken.IsCancellationRequested)
             {
-                ulong[] scoreIds;
+                SoloScore[] scores;
 
                 using (var db = DatabaseAccess.GetConnection())
                 {
-                    scoreIds = (await db.QueryAsync<ulong>($"SELECT id FROM scores WHERE `id` > @ScoreId ORDER BY `id` LIMIT @Limit", new
+                    scores = (await db.QueryAsync<SoloScore>("SELECT * FROM scores WHERE `id` > @ScoreId ORDER BY `id` LIMIT @Limit", new
                     {
                         ScoreId = currentScoreId,
-                        Limit = max_users_per_query
+                        Limit = max_scores_per_query
                     })).ToArray();
                 }
 
-                if (scoreIds.Length == 0)
+                if (scores.Length == 0)
                     break;
 
-                await ProcessPartitioned(scoreIds, async id =>
-                {
-                    using (var db = DatabaseAccess.GetConnection())
-                        await ScoreProcessor.ProcessScoreAsync(id, db);
+                await Task.WhenAll(Partitioner
+                                   .Create(scores)
+                                   .GetPartitions(Threads)
+                                   .Select(async partition =>
+                                   {
+                                       using (var connection = DatabaseAccess.GetConnection())
+                                       using (partition)
+                                       {
+                                           while (partition.MoveNext())
+                                           {
+                                               if (cancellationToken.IsCancellationRequested)
+                                                   return;
 
-                    if (Interlocked.Increment(ref processedCount) % 1000 == 0)
-                        Console.WriteLine($"Processed {processedCount} of {totalCount}");
-                }, cancellationToken);
+                                               await ScoreProcessor.ProcessScoreAsync(partition.Current, connection);
 
-                currentScoreId = scoreIds.Max();
+                                               if (Interlocked.Increment(ref processedCount) % 1000 == 0)
+                                                   Console.WriteLine($"Processed {processedCount} of {totalCount}");
+                                           }
+                                       }
+                                   }));
+
+                currentScoreId = scores.Last().id;
             }
 
             return 0;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
@@ -102,7 +102,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
                     rate = rate * 0.95 + 0.05 * ((double)scores.Count / sw.ElapsedMilliseconds * 1000);
 
                 Console.WriteLine(ScoreProcessor.BeatmapStore?.GetCacheStats());
-                Console.WriteLine($"id: {currentScoreId:N0} changed: {changedPp:N0} ({processedCount:N0} of {lastScoreId:N0} {(float)processedCount / lastScoreId:P1}) {rate:N0}/s");
+                Console.WriteLine($"processed up to: {currentScoreId:N0} changed: {changedPp:N0} {(float)processedCount / (lastScoreId - From):P1} {rate:N0}/s");
             }
 
             return 0;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Data;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -55,7 +56,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
                 await Task.WhenAll(Partitioner.Create(scores).GetPartitions(Threads).Select(async partition =>
                 {
                     using (var connection = DatabaseAccess.GetConnection())
-                    using (var transaction = await connection.BeginTransactionAsync(cancellationToken))
+                    using (var transaction = await connection.BeginTransactionAsync(IsolationLevel.ReadUncommitted, cancellationToken))
                     using (partition)
                     {
                         while (partition.MoveNext())

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Dapper;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Server.QueueProcessor;
+using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
@@ -23,6 +24,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
 
         [Option(Description = "Score ID to start processing from.")]
         public ulong From { get; set; }
+
+        /// <summary>
+        /// Whether to adjust processing rate based on slave latency. Defaults to <c>false</c>.
+        /// </summary>
+        [Option(CommandOptionType.SingleOrNoValue, Template = "--check-slave-latency")]
+        public bool CheckSlaveLatency { get; set; }
 
         protected override async Task<int> ExecuteAsync(CancellationToken cancellationToken)
         {
@@ -45,6 +52,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
 
             while (!cancellationToken.IsCancellationRequested)
             {
+                if (CheckSlaveLatency)
+                    await SlaveLatencyChecker.CheckSlaveLatency(db, cancellationToken);
+
                 sw.Restart();
 
                 var scores = await nextScores;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
@@ -89,6 +89,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
                     }
                 }));
 
+                if (cancellationToken.IsCancellationRequested)
+                    return -1;
+
                 Interlocked.Add(ref processedCount, (ulong)scores.Count);
 
                 currentScoreId = scores.Last().id;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/UpdateScoresCommands.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/UpdateScoresCommands.cs
@@ -9,6 +9,7 @@ using osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores;
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance
 {
     [Command("scores", Description = "Updates individual score PP values.")]
+    [Subcommand(typeof(UpdateAllScoresCommand))]
     [Subcommand(typeof(UpdateAllScoresByUserCommand))]
     [Subcommand(typeof(UpdateScoresFromListCommand))]
     [Subcommand(typeof(UpdateScoresFromSqlCommand))]

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -67,6 +67,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 RulesetId = rulesetId
             }, transaction: transaction)).ToArray();
 
+            if (!scores.Any())
+                return;
+
             Console.WriteLine($"Processing {userId} ({scores.Length} scores)...");
 
             foreach (SoloScore score in scores)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -38,6 +38,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         private static readonly bool write_legacy_score_pp = Environment.GetEnvironmentVariable("WRITE_LEGACY_SCORE_PP") != "0";
 
+        private static readonly bool refresh_stores_periodically = Environment.GetEnvironmentVariable("REFRESH_STORES_PERIODICALLY") != "0";
+
         public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {
         }
@@ -117,7 +119,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
             long currentTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
-            if (buildStore == null || BeatmapStore == null || currentTimestamp - lastStoreRefresh > 60_000)
+            if (buildStore == null || BeatmapStore == null || (refresh_stores_periodically && currentTimestamp - lastStoreRefresh > 60_000))
             {
                 buildStore = await BuildStore.CreateAsync(connection, transaction);
                 BeatmapStore = await BeatmapStore.CreateAsync(connection, transaction);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -73,8 +73,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             if (!scores.Any())
                 return 0;
 
-            Console.WriteLine($"Processing {userId} ({scores.Length} scores)...");
-
             int totalUpdated = 0;
 
             foreach (SoloScore score in scores)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -33,7 +33,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnFailedScores => false;
 
-        public bool RunOnLegacyScores => false;
+        public bool RunOnLegacyScores => true;
 
         private static readonly bool write_legacy_score_pp = Environment.GetEnvironmentVariable("WRITE_LEGACY_SCORE_PP") != "0";
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -67,6 +67,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 RulesetId = rulesetId
             }, transaction: transaction)).ToArray();
 
+            Console.WriteLine($"Processing {userId} ({scores.Length} scores)...");
+
             foreach (SoloScore score in scores)
             {
                 if (cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
This adds a new command which processes all scores in the database consecutively (based on primary key). This is more efficient for both reads and write due to the table's compression setting. In practice it's over a magnitude faster, and will replicate better.

In additions, this PR also:

- Adds better console output of the progress of ongoing operations
- Removes a stray `AsParallel()` call that didn't need to exist
- Allows cancellation during a single user processing
- Allows bypassing beatmap store refreshes for performance reasons
- Avoids database writes when the existing pp value is already correct-enough (within `0.1` as per [what the spreadsheet process currently checks for](https://discord.com/channels/90072389919997952/1083320217259749376/1296763588433674260))

Without database writes, this now processes around 120-180k scores per second with 8 threads. Increasing thread count further does not seem to help much, but this is already way faster than we can write to the database so it's fine.

With database writes,  increasing the thread count to 32 performs better (more throughput at the database end). We are still capped around 16k/s, which is about the fastest we've been able to `INSERT` to the new table. It should be fast enough for our purposes.

Only unknown is how replication will respond to the load of running a full reprocess.

Example of console output, 32 threads with writes enabled:


https://github.com/user-attachments/assets/0d86a30c-7000-49c9-b0e1-f9adddc0c3e0

