### PR TITLE
Use manual connection pooling for score reprocessing

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
@@ -74,6 +74,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
             {
                 sw.Restart();
 
+                handleInput();
+
                 if (CheckSlaveLatency)
                 {
                     using (var connection = DatabaseAccess.GetConnection())
@@ -137,6 +139,58 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
             }
 
             return 0;
+        }
+
+        private void handleInput()
+        {
+            if (!Console.KeyAvailable) return;
+
+            ConsoleKeyInfo key = Console.ReadKey(true);
+
+            switch (key.Key)
+            {
+                case ConsoleKey.A:
+                {
+                    int before = BatchSize;
+                    BatchSize = Math.Max(500, BatchSize - 500);
+                    Console.WriteLine($"!! DECREASING BATCH SIZE {before} => {BatchSize}");
+                    break;
+                }
+
+                case ConsoleKey.S:
+                {
+                    int before = BatchSize;
+                    BatchSize += 500;
+                    Console.WriteLine($"!! INCREASING BATCH SIZE {before} => {BatchSize}");
+                    break;
+                }
+
+                case ConsoleKey.Z:
+                {
+                    int before = Threads;
+                    Threads = Math.Max(1, Threads - 2);
+                    Console.WriteLine($"!! DECREASING THREAD COUNT {before} => {Threads}");
+
+                    for (int i = 0; i < 2; i++)
+                    {
+                        connections.TryDequeue(out var connection);
+                        connection!.Dispose();
+                    }
+
+                    break;
+                }
+
+                case ConsoleKey.X:
+                {
+                    int before = Threads;
+                    Threads += 2;
+                    Console.WriteLine($"!! INCREASING THREAD COUNT {before} => {Threads}");
+
+                    for (int i = 0; i < 2; i++)
+                        connections.Enqueue(DatabaseAccess.GetConnection());
+                    break;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
A bit of a local optimisation for now.

Without:

```
caches: [beatmap 4,071 +42] [attrib 20,969 +110]
processed up to: 2430329 changed: 0 0.1% 37,869/s
```

With:

```
caches: [beatmap 4,071 +231] [attrib 20,956 +287]
processed up to: 2430329 changed: 0 0.1% 79,678/s
```

Also adds the ability to adjust settings on the fly.

FWIW I already looked into the mysql connector to make sure there's not a more efficient path to getting connections from a pool. There unfortunately doesn't seem to be. The overheads just get high at the rate of connections we're using (running with 96 threads at the moment for highest throughput).