### PR TITLE
Improve throughput of other commands using `ProcessPartitioned` by allowing transaction and connection sharing

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/PerformanceCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/PerformanceCommand.cs
@@ -69,8 +69,16 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance
                 if (userStats == null)
                     return;
 
+                double rankScoreBefore = userStats.rank_score;
+                double accBefore = userStats.accuracy_new;
+
                 await TotalProcessor.UpdateUserStatsAsync(userStats, RulesetId, db, transaction, updateIndex: false);
-                await DatabaseHelper.UpdateUserStatsAsync(userStats, db, transaction);
+
+                if (Math.Abs(rankScoreBefore - userStats.rank_score) > 0.1 ||
+                    Math.Abs(accBefore - userStats.accuracy_new) > 0.1)
+                {
+                    await DatabaseHelper.UpdateUserStatsAsync(userStats, db, transaction);
+                }
 
                 Console.WriteLine($"Processed {Interlocked.Increment(ref processedCount)} of {userIds.Length}");
             }, cancellationToken);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresByUserCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresByUserCommand.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Data;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -78,14 +77,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
                 if (userIds.Length == 0)
                     break;
 
-                await ProcessPartitioned(userIds, async userId =>
+                await ProcessPartitioned(userIds, async (conn, transaction, userId) =>
                 {
-                    using (var partitionDb = DatabaseAccess.GetConnection())
-                    using (var transaction = await partitionDb.BeginTransactionAsync(IsolationLevel.ReadUncommitted, cancellationToken))
-                    {
-                        Interlocked.Add(ref totalScores, (ulong)await ScoreProcessor.ProcessUserScoresAsync(userId, RulesetId, db, transaction, cancellationToken));
-                        await transaction.CommitAsync(cancellationToken);
-                    }
+                    Interlocked.Add(ref totalScores, (ulong)await ScoreProcessor.ProcessUserScoresAsync(userId, RulesetId, conn, transaction, cancellationToken));
+                    await transaction.CommitAsync(cancellationToken);
                 }, cancellationToken);
 
                 currentUserId = userIds.Max();

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresByUserCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresByUserCommand.cs
@@ -80,7 +80,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
                 await ProcessPartitioned(userIds, async (conn, transaction, userId) =>
                 {
                     Interlocked.Add(ref totalScores, (ulong)await ScoreProcessor.ProcessUserScoresAsync(userId, RulesetId, conn, transaction, cancellationToken));
-                    await transaction.CommitAsync(cancellationToken);
                 }, cancellationToken);
 
                 currentUserId = userIds.Max();

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateScoresFromListCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateScoresFromListCommand.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
-using osu.Server.QueueProcessor;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
 {
@@ -27,10 +26,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
 
             int processedCount = 0;
 
-            await ProcessPartitioned(scoreIds, async id =>
+            await ProcessPartitioned(scoreIds, async (conn, transaction, id) =>
             {
-                using (var db = DatabaseAccess.GetConnection())
-                    await ScoreProcessor.ProcessScoreAsync(id, db);
+                await ScoreProcessor.ProcessScoreAsync(id, conn, transaction);
                 Console.WriteLine($"Processed {Interlocked.Increment(ref processedCount)} of {scoreIds.Length}");
             }, cancellationToken);
 


### PR DESCRIPTION
Some more optimisations I made in order to make updating user totals as a batch more efficient.

More details in some commit messages.