### PR TITLE
Fix console on non-user-interactive sessions

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
@@ -143,7 +143,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
 
         private void handleInput()
         {
-            if (!Console.KeyAvailable) return;
+            if (!Environment.UserInteractive || Console.IsInputRedirected)
+                return;
+
+            if (!Console.KeyAvailable)
+                return;
 
             ConsoleKeyInfo key = Console.ReadKey(true);
 


### PR DESCRIPTION
https://github.com/ppy/osu/actions/runs/11627419099/job/32380757841

```
2024-11-01T10:14:21.7694053Z ppcalc-1     | Processing all scores up to 3728268118, starting from 0
2024-11-01T10:14:21.7899436Z ppcalc-1     | Unhandled exception. System.InvalidOperationException: Cannot see if a key has been pressed when either application does not have a console or when console input has been redirected from a file. Try Console.In.Peek.
2024-11-01T10:14:21.7901136Z ppcalc-1     |    at System.Console.get_KeyAvailable()
2024-11-01T10:14:21.7903328Z ppcalc-1     |    at osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores.UpdateAllScoresCommand.handleInput() in /tmp/tmp.HkPQkGiFzg/osu-queue-score-statistics/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs:line 146
2024-11-01T10:14:21.7907228Z ppcalc-1     |    at osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores.UpdateAllScoresCommand.ExecuteAsync(CancellationToken cancellationToken) in /tmp/tmp.HkPQkGiFzg/osu-queue-score-statistics/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs:line 77
2024-11-01T10:14:21.7911118Z ppcalc-1     |    at osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.PerformanceCommand.OnExecuteAsync(CancellationToken cancellationToken) in /tmp/tmp.HkPQkGiFzg/osu-queue-score-statistics/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/PerformanceCommand.cs:line 34
2024-11-01T10:14:21.7914099Z ppcalc-1     |    at McMaster.Extensions.CommandLineUtils.Conventions.ExecuteMethodConvention.InvokeAsync(MethodInfo method, Object instance, Object[] arguments)
2024-11-01T10:14:21.7916137Z ppcalc-1     |    at McMaster.Extensions.CommandLineUtils.Conventions.ExecuteMethodConvention.OnExecute(ConventionContext context, CancellationToken cancellationToken)
2024-11-01T10:14:21.7951636Z ppcalc-1     |    at McMaster.Extensions.CommandLineUtils.Conventions.ExecuteMethodConvention.<>c__DisplayClass0_0.<<Apply>b__0>d.MoveNext()
2024-11-01T10:14:21.7953295Z ppcalc-1     | --- End of stack trace from previous location ---
2024-11-01T10:14:21.7955034Z ppcalc-1     |    at McMaster.Extensions.CommandLineUtils.CommandLineApplication.ExecuteAsync(String[] args, CancellationToken cancellationToken)
2024-11-01T10:14:21.7956922Z ppcalc-1     |    at McMaster.Extensions.CommandLineUtils.CommandLineApplication.ExecuteAsync[TApp](CommandLineContext context, CancellationToken cancellationToken)
2024-11-01T10:14:21.7959087Z ppcalc-1     |    at osu.Server.Queues.ScoreStatisticsProcessor.Program.Main(String[] args) in /tmp/tmp.HkPQkGiFzg/osu-queue-score-statistics/osu.Server.Queues.ScoreStatisticsProcessor/Program.cs:line 27
2024-11-01T10:14:21.7960950Z ppcalc-1     |    at osu.Server.Queues.ScoreStatisticsProcessor.Program.<Main>(String[] args)
```