### PR TITLE
Fix various content type issues on LIO request helpers

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/LegacyDatabaseHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/LegacyDatabaseHelper.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -120,7 +121,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
                 {
                     case string postString:
                         httpRequestMessage.Content = new StringContent(postString);
-                        httpRequestMessage.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("plain/text");
+                        break;
+
+                    case IEnumerable<KeyValuePair<string, string>> formKeyValuePairs:
+                        httpRequestMessage.Content = new FormUrlEncodedContent(formKeyValuePairs);
                         break;
 
                     default:

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
@@ -2,7 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using Dapper;
 using JetBrains.Annotations;
 using MySqlConnector;
@@ -112,7 +114,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
                 // Reindex beatmap occasionally.
                 if (RNG.Next(0, 10) == 0)
-                    LegacyDatabaseHelper.RunLegacyIO("indexing/bulk", "POST", $"beatmapset[]={score.beatmap.beatmapset_id}");
+                    LegacyDatabaseHelper.RunLegacyIO("indexing/bulk", "POST", new[] { new KeyValuePair<string, string>("beatmapset[]", score.beatmap.beatmapset_id.ToString(CultureInfo.InvariantCulture)) });
 
                 // TODO: announce playcount milestones
                 // const int notify_amount = 1000000;


### PR DESCRIPTION
As [pointed out internally](https://discord.com/channels/90072389919997952/983550677794050108/1306327452364177418).

- `plain/text` is exactly backwards; [it's actually `text/plain`](https://developer.mozilla.org/en-US/docs/Web/HTTP/MIME_types#textplain).
- The MIME type spec is redundant there anyways. [`StringContent` implicitly means `text/plain` by default until specified otherwise.](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.stringcontent.-ctor?view=net-8.0#system-net-http-stringcontent-ctor(system-string))
- And the only place that used the `StringContent` path was wrong anyway, it was supposed to be doing `application/x-www-form-urlencoded`. [Which `FormUrlEncodedContent` is for, and is now used in the relevant context.](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.formurlencodedcontent?view=net-8.0)

Mind you, all this seems to have absolutely no impact on anything whatsoever and be 100% academical, because as far as I can see, on local environment the web LIO endpoint just responds with 204 anyways, with or without this PR. I'd expect 415 if it didn't like anything above, so I'm wagering it just didn't care or check and all of this had an impact of exactly none whatsoever.