### PR TITLE
Fix faulty production check in database test setup

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -62,7 +62,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             {
                 // just a safety measure for now to ensure we don't hit production. since i was running on production until now.
                 // will throw if not on test database.
-                if (db.QueryFirstOrDefault<int?>("SELECT * FROM osu_counts WHERE name = 'is_production'") != null)
+                if (db.QueryFirstOrDefault<int?>("SELECT `count` FROM `osu_counts` WHERE `name` = 'is_production'") != null)
                     throw new InvalidOperationException("You are trying to do something very silly.");
 
                 db.Execute("TRUNCATE TABLE osu_user_stats");


### PR DESCRIPTION
The check *works*, but it dies a little harder than it should. Selecting `*` when the type param in the `QueryFirstOrDefault<>()` invocation is `int?` is going to die, because dapper can't map 2 columns to one `int?`.

By chance this would work correctly on *non*-production databases, because if the row isn't there, then dapper just does the default part of `QueryFirstOrDefault<>()` which is `null`.

Also added quotes to the object names for safety.

Discovered when porting this to https://github.com/ppy/osu-server-beatmap-submission/pull/1.