### PR TITLE
Adjust LIO request helper further

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/LegacyDatabaseHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/LegacyDatabaseHelper.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -117,20 +116,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
                     },
                 };
 
-                switch (postObject)
+                if (postObject != null)
                 {
-                    case string postString:
-                        httpRequestMessage.Content = new StringContent(postString);
-                        break;
-
-                    case IEnumerable<KeyValuePair<string, string>> formKeyValuePairs:
-                        httpRequestMessage.Content = new FormUrlEncodedContent(formKeyValuePairs);
-                        break;
-
-                    default:
-                        httpRequestMessage.Content = new ByteArrayContent(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(postObject)));
-                        httpRequestMessage.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-                        break;
+                    httpRequestMessage.Content = new ByteArrayContent(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(postObject)));
+                    httpRequestMessage.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
                 }
 
                 var response = http.SendAsync(httpRequestMessage).Result;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
@@ -2,9 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using Dapper;
 using JetBrains.Annotations;
 using MySqlConnector;
@@ -114,7 +112,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
                 // Reindex beatmap occasionally.
                 if (RNG.Next(0, 10) == 0)
-                    LegacyDatabaseHelper.RunLegacyIO("indexing/bulk", "POST", new[] { new KeyValuePair<string, string>("beatmapset[]", score.beatmap.beatmapset_id.ToString(CultureInfo.InvariantCulture)) });
+                    LegacyDatabaseHelper.RunLegacyIO("indexing/bulk", "POST", new { beatmapset = new[] { score.beatmap.beatmapset_id } });
 
                 // TODO: announce playcount milestones
                 // const int notify_amount = 1000000;


### PR DESCRIPTION
Follow up from https://github.com/ppy/osu-queue-score-statistics/pull/297

- Removed support for both `text/plain` (completely unnecessary ever, web can't do that) and `application/x-www-form-urlencoded` (web _can_ do that but why leave 2 formats in when 1 can work), leaving only `application/json`
- If the request is made with a null payload object, do not set `Content-Type`