### PR TITLE
Split domain to which LIO requests are directed to envvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,19 @@ Defaults to `localhost`.
 
 Enables DataDog origin detection when running in a container. See [DataDog documentation](https://docs.datadoghq.com/developers/dogstatsd/?tab=kubernetes&code-lang=dotnet#origin-detection-over-udp).
 
+### LEGACY_IO_DOMAIN
+
+Root domain to which LegacyIO requests should be directed.
+
+- In Debug configuration, this parameter is not required; when missing, all LIO requests are no-ops.
+- In Release configuration, this parameter is required; all LIO requests will hard-fail with an exception if missing.
+
 ### SHARED_INTEROP_SECRET
 
 Secret key used to sign LegacyIO requests to osu-web. Required to award medals.
+
+- In Debug configuration, this parameter is not required; when missing, all LIO requests are no-ops.
+- In Release configuration, this parameter is required; all LIO requests will hard-fail with an exception if missing.
 
 ### PROCESS_USER_MEDALS
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/LegacyDatabaseHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/LegacyDatabaseHelper.cs
@@ -75,12 +75,21 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
             }
         }
 
-        private static readonly string shared_interop_secret = Environment.GetEnvironmentVariable("SHARED_INTEROP_SECRET") ?? string.Empty;
+        private static readonly string? legacy_io_domain = Environment.GetEnvironmentVariable("LEGACY_IO_DOMAIN");
+        private static readonly string? shared_interop_secret = Environment.GetEnvironmentVariable("SHARED_INTEROP_SECRET");
 
         private static readonly HttpClient http = new HttpClient();
 
         public static HttpResponseMessage RunLegacyIO(string command, string method = "GET", dynamic? postObject = null)
         {
+            if (string.IsNullOrEmpty(legacy_io_domain))
+            {
+#if !DEBUG
+                throw new InvalidOperationException($"Attempted legacy IO call without target domain specified ({command})");
+#endif
+                return null!;
+            }
+
             if (string.IsNullOrEmpty(shared_interop_secret))
             {
 #if !DEBUG
@@ -97,7 +106,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
             {
                 long time = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 
-                string url = $"https://osu.ppy.sh/_lio/{command}{(command.Contains('?') ? "&" : "?")}timestamp={time}";
+                string url = $"{legacy_io_domain}/_lio/{command}{(command.Contains('?') ? "&" : "?")}timestamp={time}";
                 string signature = hmacEncode(url, Encoding.UTF8.GetBytes(shared_interop_secret));
 
 #pragma warning disable SYSLIB0014


### PR DESCRIPTION
On several occasions, I've tried to test something involving LIO full-stack and forgot that the LIO helper hardcodes production. Thankfully I never did damage due to the interop secret check, but it's a bit bone-chilling every time. Additionally I believe this situation can't be correct as far as staging is involved, either.

The envvar is `LEGACY_IO_DOMAIN` (open to alternative naming suggestions). Same as the shared interop secret, this envvar is optional in debug (and it missing causes LIO to become a no-op), and required with no default and hard-fail on missing in release.

cc @ThePooN as requested (for presumed deployment config updates)