### PR TITLE
Enable user rank processor on legacy scores

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
@@ -18,7 +18,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
     {
         public bool RunOnFailedScores => false;
 
-        public bool RunOnLegacyScores => false;
+        public bool RunOnLegacyScores => true;
 
         public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction)
         {


### PR DESCRIPTION
A step towards sanity, with a hope of resolving https://github.com/ppy/osu-web/issues/8443. Will be deployed alongside https://github.com/peppy/osu-web-10/commit/0233c980bd2f201448781068d842908c04a28e18.