### PR TITLE
Allow medal awarders to process stable scores

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
@@ -103,6 +103,32 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         }
 
         /// <summary>
+        /// The pack awarder should skip scores that are set on stable.
+        /// </summary>
+        /// <remarks>
+        /// This applies to most other awarders and is really just a representative to check that the flag is working fine.
+        /// At some point all awarders will probably switched on and web-10 medal logic will be decommissioned.
+        /// </remarks>
+        [Theory]
+        [MemberData(nameof(MEDAL_PACK_IDS))]
+        public void TestDoesNotAwardOnLegacyScores(int medalId, int packId)
+        {
+            var beatmap = AddBeatmap();
+
+            AddPackMedal(medalId, packId, new[] { beatmap });
+
+            AssertNoMedalsAwarded();
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.passed = s.Score.preserve = true;
+                s.Score.legacy_score_id = 1234;
+                s.Score.build_id = TestBuildID;
+            });
+
+            AssertNoMedalsAwarded();
+        }
+
+        /// <summary>
         /// The pack awarder should skip scores that are failed.
         /// </summary>
         [Theory]

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/IMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/IMedalAwarder.cs
@@ -19,6 +19,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         bool RunOnFailedScores { get; }
 
         /// <summary>
+        /// Whether this awarder should be run on legacy (stable) scores.
+        /// </summary>
+        bool RunOnLegacyScores { get; }
+
+        /// <summary>
         /// For a given score and collection of valid medals, check which should be awarded (if any).
         /// </summary>
         /// <param name="medals">All medals available for potential awarding.</param>

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/ModIntroductionMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/ModIntroductionMedalAwarder.cs
@@ -14,6 +14,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
     {
         public bool RunOnFailedScores => false;
 
+        public bool RunOnLegacyScores => false; // Legacy scores are handled by web-10.
+
         public IEnumerable<Medal> Check(IEnumerable<Medal> medals, MedalAwarderContext context)
         {
             Ruleset ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(context.Score.ruleset_id);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/PackMedalAwarder.cs
@@ -15,6 +15,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
     {
         public bool RunOnFailedScores => false;
 
+        public bool RunOnLegacyScores => false; // Legacy scores are handled by web-10.
+
         public IEnumerable<Medal> Check(IEnumerable<Medal> medals, MedalAwarderContext context)
         {
             // Do a global check to see if this beatmapset is contained in *any* pack.

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/RankMilestoneMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/RankMilestoneMedalAwarder.cs
@@ -12,6 +12,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
     {
         public bool RunOnFailedScores => false;
 
+        public bool RunOnLegacyScores => false; // Legacy scores are handled by web-10.
+
         public IEnumerable<Medal> Check(IEnumerable<Medal> medals, MedalAwarderContext context)
         {
             foreach (var medal in medals)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/StarRatingMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/StarRatingMedalAwarder.cs
@@ -18,6 +18,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
     {
         public bool RunOnFailedScores => false;
 
+        public bool RunOnLegacyScores => false; // Legacy scores are handled by web-10.
+
         public IEnumerable<Medal> Check(IEnumerable<Medal> medals, MedalAwarderContext context)
         {
             return checkAsync(medals, context).ToBlockingEnumerable();

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/StatisticsMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/StatisticsMedalAwarder.cs
@@ -12,6 +12,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
     {
         public bool RunOnFailedScores => false;
 
+        public bool RunOnLegacyScores => false; // Legacy scores are handled by web-10.
+
         public IEnumerable<Medal> Check(IEnumerable<Medal> medals, MedalAwarderContext context)
         {
             foreach (var medal in medals)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
@@ -46,7 +46,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnFailedScores => true; // This is handled by each awarder.
 
-        public bool RunOnLegacyScores => false;
+        public bool RunOnLegacyScores => true; // This is handled by each awarder.
 
         // This processor needs to run after the play count and hit statistics have been applied, at very least.
         public int Order => int.MaxValue;
@@ -76,6 +76,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             foreach (var awarder in medal_awarders)
             {
                 if (!score.passed && !awarder.RunOnFailedScores)
+                    continue;
+
+                if (score.is_legacy_score && !awarder.RunOnLegacyScores)
                     continue;
 
                 foreach (var awardedMedal in awarder.Check(availableMedalsForUser, context))


### PR DESCRIPTION
The goal of this change is to stop touching medal logic in osu-web-10, whether it be for any new medals going forward, or for fixes of existing medals that may have broken for one reason or another.