### PR TITLE
Pass `Difficulty` beatmap info property for `SoloScore` objects

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs
@@ -87,7 +87,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
             var beatmapInfo = new LightweightBeatmapInfo
             {
                 OnlineID = (int)beatmap_id,
-                Ruleset = new RulesetInfo { OnlineID = beatmap!.playmode }
+                Ruleset = new RulesetInfo { OnlineID = beatmap!.playmode },
+                Difficulty = new BeatmapDifficulty(beatmap.GetLegacyBeatmapConversionDifficultyInfo())
             };
 
             return new LightweightScoreInfo


### PR DESCRIPTION
See https://github.com/ppy/osu/pull/31595#discussion_r1923336441. Will confidently verify behaviour with a difficulty calculation sheet on the osu-side PR.