### PR TITLE
Stop catching exceptions in `ScorePerformanceProcessor`

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MedalProcessorTests.cs
@@ -373,6 +373,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 AssertNoMedalsAwarded();
             }
 
+            AddBeatmapAttributes<OsuDifficultyAttributes>(allBeatmaps[0].beatmap_id, mods: [new OsuModEasy()]);
+
             // Pass the first map with Easy mod (difficulty reduction)
             SetScoreForBeatmap(allBeatmaps[0].beatmap_id, s =>
             {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
@@ -122,10 +122,17 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
                             if (cancellationToken.IsCancellationRequested)
                                 return;
 
-                            bool changed = await ScoreProcessor.ProcessScoreAsync(partition.Current, connection, transaction);
+                            try
+                            {
+                                bool changed = await ScoreProcessor.ProcessScoreAsync(partition.Current, connection, transaction);
 
-                            if (changed)
-                                Interlocked.Increment(ref changedPp);
+                                if (changed)
+                                    Interlocked.Increment(ref changedPp);
+                            }
+                            catch (Exception e)
+                            {
+                                Console.WriteLine($"Failed to process score {partition.Current.id}: {e}");
+                            }
                         }
 
                         await transaction.CommitAsync(cancellationToken);


### PR DESCRIPTION
It seems like this is occasionally failing, but due to exceptions being caught and logged to console, we have not seen an actual failure.