### PR TITLE
Remove envvar to disable global rank updates

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/PerformanceCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/PerformanceCommand.cs
@@ -110,7 +110,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance
                 double rankScoreBefore = userStats.rank_score;
                 double accBefore = userStats.accuracy_new;
 
-                await TotalProcessor.UpdateUserStatsAsync(userStats, RulesetId, db, transaction, updateIndex: false);
+                await TotalProcessor.UpdateUserStatsAsync(userStats, RulesetId, db, transaction, updateMilestones: false);
 
                 if (Math.Abs(rankScoreBefore - userStats.rank_score) > 0.1 ||
                     Math.Abs(accBefore - userStats.accuracy_new) > 0.1)


### PR DESCRIPTION
This would still update `rank_score`, which we're not doing going forward. So rather than have an explicit envvar, it's easier to just disable the whole `UserTotalPerformanceProcessor` during deploy stages.