### PR TITLE
Add invalidation flow to `BatchInserter`

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/BatchInserter.cs
@@ -232,6 +232,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
 
             string sql = insertBuilder.ToString();
 
+            if (dryRun)
+            {
+                Console.WriteLine($" DRY RUN would insert command with {sql.Length:#,0} bytes");
+                return;
+            }
+
             Console.WriteLine($" Running insert command with {sql.Length:#,0} bytes");
             sw.Restart();
 
@@ -493,13 +499,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
                 }
                 else
                 {
-                    if (dryRun)
-                    {
-                        // We can't retrieve this from the database because it hasn't been inserted.
-                        ScoreStatisticsItems.Add(new ScoreItem(new SoloScore(), new ProcessHistory()));
-                        return;
-                    }
-
                     // the legacy PP value was not imported.
                     // push the score to redis for PP processing.
                     // on completion of PP processing, the score will be pushed to ES for indexing.

--- a/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
@@ -19,7 +19,7 @@
         <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2025.304.0" />
         <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2025.304.0" />
         <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2025.304.0" />
-        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2024.1111.0" />
+        <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2025.317.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes https://github.com/ppy/osu-queue-score-statistics/issues/324

I went through multiple iterations, trying to make `BatchInserter` use `BeatmapStore` but it's all a bit of a PITA due to slightly different interfaces. So as a starting point, I've fixed the problematic case in isolation.

`BeatmapStore` can benefit from similar invalidation but requires a slightly different approach due to `MemoryCache` usage. It's also not as urgent because it currently purges itself [every minute](https://github.com/ppy/osu-queue-score-statistics/blob/0eaf633c6495aa37bcd421336def85df04faedae/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs#L129-L135). I will PR a separate change for that later today or tomorrow.

Tested locally:

https://github.com/user-attachments/assets/93ff2463-afd0-4e01-8f2a-959e27df8f91

