### PR TITLE
Encapsulate difficulty attribute lookup logic in medal processing code to prevent invalid lookups

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/MedalAwarderContext.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/MedalAwarderContext.cs
@@ -1,7 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading.Tasks;
 using MySqlConnector;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Mods;
 using osu.Server.Queues.ScoreStatisticsProcessor.Processors;
 using osu.Server.Queues.ScoreStatisticsProcessor.Stores;
 
@@ -10,17 +14,83 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
     /// <summary>
     /// Contains all necessary context and access method for implementing <see cref="IMedalAwarder"/>s.
     /// </summary>
-    /// <param name="Score">The score to check for medals.</param>
-    /// <param name="UserStats">The calculated user statistics after <see cref="Score"/>.</param>
-    /// <param name="DailyChallengeUserStats">The user's daily challenge stats after <see cref="Score"/>.</param>
-    /// <param name="BeatmapStore">Allows retrieval of <see cref="Beatmap"/>s from database.</param>
-    /// <param name="Connection">MySQL connection for manual retrieval from database.</param>
-    /// <param name="Transaction">MySQL transaction for manual retrieval from database.</param>
-    public record MedalAwarderContext(
-        SoloScore Score,
-        UserStats UserStats,
-        DailyChallengeUserStats DailyChallengeUserStats,
-        BeatmapStore BeatmapStore,
-        MySqlConnection Connection,
-        MySqlTransaction Transaction);
+    public record MedalAwarderContext
+    {
+        /// <summary>
+        /// The score to check for medals.
+        /// </summary>
+        public SoloScore Score { get; }
+
+        /// <summary>
+        /// The calculated user statistics after <see cref="Score"/>.
+        /// </summary>
+        public UserStats UserStats { get; }
+
+        /// <summary>
+        /// The user's daily challenge stats after <see cref="Score"/>.
+        /// </summary>
+        public DailyChallengeUserStats DailyChallengeUserStats { get; }
+
+        /// <summary>
+        /// Allows retrieval of <see cref="Beatmap"/>s from database.
+        /// </summary>
+        private BeatmapStore beatmapStore { get; }
+
+        /// <summary>
+        /// MySQL connection for manual retrieval from database.
+        /// </summary>
+        public MySqlConnection Connection { get; }
+
+        /// <summary>
+        /// MySQL transaction for manual retrieval from database.
+        /// </summary>
+        public MySqlTransaction Transaction { get; }
+
+        /// <param name="score">The score to check for medals.</param>
+        /// <param name="userStats">The calculated user statistics after <see cref="Score"/>.</param>
+        /// <param name="dailyChallengeUserStats">The user's daily challenge stats after <see cref="Score"/>.</param>
+        /// <param name="beatmapStore">Allows retrieval of <see cref="Beatmap"/>s from database.</param>
+        /// <param name="connection">MySQL connection for manual retrieval from database.</param>
+        /// <param name="transaction">MySQL transaction for manual retrieval from database.</param>
+        public MedalAwarderContext(
+            SoloScore score,
+            UserStats userStats,
+            DailyChallengeUserStats dailyChallengeUserStats,
+            BeatmapStore beatmapStore,
+            MySqlConnection connection,
+            MySqlTransaction transaction)
+        {
+            Score = score;
+            UserStats = userStats;
+            DailyChallengeUserStats = dailyChallengeUserStats;
+            this.beatmapStore = beatmapStore;
+            Connection = connection;
+            Transaction = transaction;
+        }
+
+        public MedalAwarderContext(MedalAwarderContext other)
+        {
+            Score = other.Score;
+            UserStats = other.UserStats;
+            DailyChallengeUserStats = other.DailyChallengeUserStats;
+            beatmapStore = other.beatmapStore;
+            Connection = other.Connection;
+            Transaction = other.Transaction;
+        }
+
+        /// <summary>
+        /// Returns difficulty attributes for the supplied <paramref name="beatmap"/>, <param name="ruleset"></param>,
+        /// and <paramref name="mods"/> combination.
+        /// If the <paramref name="beatmap"/> is not ranked, approved, qualified, or loved, this will return <see langword="null"/>
+        /// (because the attributes are not available).
+        /// </summary>
+        public async Task<DifficultyAttributes?> GetDifficultyAttributesAsync(Beatmap beatmap, Ruleset ruleset, Mod[] mods)
+        {
+            // matches https://github.com/ppy/osu-difficulty-calculator/blob/2da917fb21e752879d34820a60e76a95d90ac24f/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs#L79-L82
+            if (beatmap.approved > 0)
+                return await beatmapStore.GetDifficultyAttributesAsync(beatmap, ruleset, mods, Connection, Transaction);
+
+            return null;
+        }
+    }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/StarRatingMedalAwarder.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalAwarders/StarRatingMedalAwarder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -47,7 +48,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors.MedalAwarders
                 yield break;
 
             // Get map star rating (including mods)
-            DifficultyAttributes difficultyAttributes = await context.BeatmapStore.GetDifficultyAttributesAsync(beatmap, ruleset, mods, context.Connection, context.Transaction);
+            DifficultyAttributes? difficultyAttributes = await context.GetDifficultyAttributesAsync(beatmap, ruleset, mods);
+
+            // This should never happen - `MedalProcessor` already checks the approved state of the beatmap.
+            // Therefore, throw if it does, because it may indicate larger breakage.
+            if (difficultyAttributes == null)
+                throw new InvalidOperationException("Star rating medal awarder attempted to fetch star rating for non-ranked beatmap!");
 
             // Award pass medals
             foreach (var medal in medals)


### PR DESCRIPTION
Since 2f603b7c22f6b53de53b4718394b96e8c562c053, difficulty attribute lookups no longer soft-fail if the rows are missing in the database, and instead hard-fail. In addition, from the latest star rating recalculation onward, only `approved > 0` beatmaps have difficulty attributes populated in the database.

This makes `MedalAwarderContext.BeatmapStore.GetDifficultyAttributesAsync()` unsafe, as medal processors (in particular, hush-hush ones) will attempt beatmap attribute lookups that may not necessarily hit *ranked* beatmaps, which will henceforth hard-fail rather than return `null` as previously.

To prevent this from happening, prevent medal awarders from being able to directly retrieve difficulty attributes via the beatmap store, and instead add a redirection method that does the `approved > 0` check, and does a soft fallback to `null` if it is called on an unranked beatmap.