### PR TITLE
Make `BeatmapStore` static

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
@@ -582,11 +582,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             using (var db = Processor.GetDatabaseConnection())
             {
-                var beatmapStore = await BeatmapStore.CreateAsync(db);
-
-                await Assert.ThrowsAnyAsync<DifficultyAttributesMissingException>(() => beatmapStore.GetDifficultyAttributesAsync(beatmap, new OsuRuleset(), [], db));
-                await Assert.ThrowsAnyAsync<DifficultyAttributesMissingException>(() => beatmapStore.GetDifficultyAttributesAsync(beatmap, new OsuRuleset(), [], db));
-                await Assert.ThrowsAnyAsync<DifficultyAttributesMissingException>(() => beatmapStore.GetDifficultyAttributesAsync(beatmap, new OsuRuleset(), [], db));
+                await Assert.ThrowsAnyAsync<DifficultyAttributesMissingException>(() => BeatmapStore.GetDifficultyAttributesAsync(beatmap, new OsuRuleset(), [], db));
+                await Assert.ThrowsAnyAsync<DifficultyAttributesMissingException>(() => BeatmapStore.GetDifficultyAttributesAsync(beatmap, new OsuRuleset(), [], db));
+                await Assert.ThrowsAnyAsync<DifficultyAttributesMissingException>(() => BeatmapStore.GetDifficultyAttributesAsync(beatmap, new OsuRuleset(), [], db));
             }
 
             Assert.ThrowsAny<Exception>(() => SetScoreForBeatmap(TEST_BEATMAP_ID, score =>

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
@@ -35,6 +35,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 db.Execute("TRUNCATE TABLE osu_scores_high");
                 db.Execute("TRUNCATE TABLE osu_beatmap_difficulty_attribs");
             }
+
+            BeatmapStore.PurgeCaches();
         }
 
         [Fact]

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresByUserCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresByUserCommand.cs
@@ -10,6 +10,7 @@ using Dapper;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Server.QueueProcessor;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
+using osu.Server.Queues.ScoreStatisticsProcessor.Stores;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
 {
@@ -90,7 +91,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
                 else
                     rate = rate * 0.95 + 0.05 * ((double)userIds.Length / sw.ElapsedMilliseconds * 1000);
 
-                Console.WriteLine(ScoreProcessor.BeatmapStore?.GetCacheStats());
+                Console.WriteLine(BeatmapStore.GetCacheStats());
                 Console.WriteLine($"id: {currentUserId:N0} changed scores: {totalScores:N0} ({processedUsers:N0} of {totalUsers:N0} {(float)processedUsers / totalUsers:P1}) {rate:N0}/s");
 
                 await DatabaseHelper.SetCountAsync(databaseInfo.LastProcessedPpUserCount, currentUserId, db);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
@@ -14,6 +14,7 @@ using MySqlConnector;
 using osu.Server.QueueProcessor;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using osu.Server.Queues.ScoreStatisticsProcessor.Stores;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
 {
@@ -153,7 +154,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
                 else
                     rate = rate * 0.95 + 0.05 * ((double)scores.Count / sw.ElapsedMilliseconds * 1000);
 
-                Console.WriteLine(ScoreProcessor.BeatmapStore?.GetCacheStats());
+                Console.WriteLine(BeatmapStore.GetCacheStats());
                 Console.WriteLine($"processed up to: {currentScoreId} changed: {changedPp:N0} {(float)(currentScoreId - From) / (lastScoreId - From):P1} {rate:N0}/s");
             }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/MedalAwarderContext.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/MedalAwarderContext.cs
@@ -32,11 +32,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
         public DailyChallengeUserStats DailyChallengeUserStats { get; }
 
         /// <summary>
-        /// Allows retrieval of <see cref="Beatmap"/>s from database.
-        /// </summary>
-        private BeatmapStore beatmapStore { get; }
-
-        /// <summary>
         /// MySQL connection for manual retrieval from database.
         /// </summary>
         public MySqlConnection Connection { get; }
@@ -49,21 +44,18 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
         /// <param name="score">The score to check for medals.</param>
         /// <param name="userStats">The calculated user statistics after <see cref="Score"/>.</param>
         /// <param name="dailyChallengeUserStats">The user's daily challenge stats after <see cref="Score"/>.</param>
-        /// <param name="beatmapStore">Allows retrieval of <see cref="Beatmap"/>s from database.</param>
         /// <param name="connection">MySQL connection for manual retrieval from database.</param>
         /// <param name="transaction">MySQL transaction for manual retrieval from database.</param>
         public MedalAwarderContext(
             SoloScore score,
             UserStats userStats,
             DailyChallengeUserStats dailyChallengeUserStats,
-            BeatmapStore beatmapStore,
             MySqlConnection connection,
             MySqlTransaction transaction)
         {
             Score = score;
             UserStats = userStats;
             DailyChallengeUserStats = dailyChallengeUserStats;
-            this.beatmapStore = beatmapStore;
             Connection = connection;
             Transaction = transaction;
         }
@@ -73,7 +65,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
             Score = other.Score;
             UserStats = other.UserStats;
             DailyChallengeUserStats = other.DailyChallengeUserStats;
-            beatmapStore = other.beatmapStore;
             Connection = other.Connection;
             Transaction = other.Transaction;
         }
@@ -88,7 +79,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
         {
             // matches https://github.com/ppy/osu-difficulty-calculator/blob/2da917fb21e752879d34820a60e76a95d90ac24f/osu.Server.DifficultyCalculator/ServerDifficultyCalculator.cs#L79-L82
             if (beatmap.approved > 0)
-                return await beatmapStore.GetDifficultyAttributesAsync(beatmap, ruleset, mods, Connection, Transaction);
+                return await BeatmapStore.GetDifficultyAttributesAsync(beatmap, ruleset, mods, Connection, Transaction);
 
             return null;
         }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
@@ -12,7 +12,6 @@ using MySqlConnector;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
-using osu.Server.Queues.ScoreStatisticsProcessor.Stores;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 {
@@ -78,8 +77,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 },
                 transaction) ?? new DailyChallengeUserStats();
 
-            var beatmapStore = BeatmapStore.CreateAsync(conn, transaction).Result;
-            var context = new MedalAwarderContext(score, userStats, dailyChallengeUserStats, beatmapStore, conn, transaction);
+            var context = new MedalAwarderContext(score, userStats, dailyChallengeUserStats, conn, transaction);
 
             foreach (var awarder in medal_awarders)
             {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -26,7 +26,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public const int ORDER = 0;
 
-        public BeatmapStore? BeatmapStore { get; private set; }
         private BuildStore? buildStore;
 
         public int Order => ORDER;
@@ -120,7 +119,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             if (!score.passed)
                 return false;
 
-            BeatmapStore ??= await BeatmapStore.CreateAsync(connection, transaction);
             buildStore ??= new BuildStore();
 
             score.beatmap ??= await BeatmapStore.GetBeatmapAsync(score.beatmap_id, connection, transaction);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BeatmapStore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BeatmapStore.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
@@ -26,7 +27,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
     /// <summary>
     /// A store for retrieving <see cref="Models.Beatmap"/>s.
     /// </summary>
-    public class BeatmapStore
+    public static class BeatmapStore
     {
         public static readonly string? DIFF_ATTRIB_DATABASE = Environment.GetEnvironmentVariable("DB_NAME_DIFFICULTY") ?? Environment.GetEnvironmentVariable("DB_NAME") ?? "osu";
 
@@ -50,17 +51,18 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
         /// </summary>
         private const int beatmap_size = 72;
 
-        private readonly MemoryCache attributeMemoryCache;
+        private static readonly MemoryCache attribute_memory_cache;
 
-        private readonly MemoryCache beatmapMemoryCache;
-        private readonly IReadOnlyDictionary<BlacklistEntry, byte> blacklist;
+        private static readonly MemoryCache beatmap_memory_cache;
 
-        private int beatmapCacheMiss;
-        private int attribCacheMiss;
+        private static readonly IReadOnlyDictionary<BlacklistEntry, byte> blacklist;
 
-        public string GetCacheStats()
+        private static int beatmapCacheMiss;
+        private static int attribCacheMiss;
+
+        public static string GetCacheStats()
         {
-            string output = $"caches: [beatmap {beatmapMemoryCache.Count:N0} +{beatmapCacheMiss:N0}] [attrib {attributeMemoryCache.Count:N0} +{attribCacheMiss:N0}]";
+            string output = $"caches: [beatmap {beatmap_memory_cache.Count:N0} +{beatmapCacheMiss:N0}] [attrib {attribute_memory_cache.Count:N0} +{attribCacheMiss:N0}]";
 
             Interlocked.Exchange(ref beatmapCacheMiss, 0);
             Interlocked.Exchange(ref attribCacheMiss, 0);
@@ -68,16 +70,20 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
             return output;
         }
 
-        private BeatmapStore(IEnumerable<KeyValuePair<BlacklistEntry, byte>> blacklist)
+        static BeatmapStore()
         {
-            this.blacklist = new Dictionary<BlacklistEntry, byte>(blacklist);
+            using (var connection = DatabaseAccess.GetConnection())
+            {
+                var dbBlacklist = connection.Query<PerformanceBlacklistEntry>("SELECT * FROM osu_beatmap_performance_blacklist");
+                blacklist = dbBlacklist.Select(b => new KeyValuePair<BlacklistEntry, byte>(new BlacklistEntry(b.beatmap_id, b.mode), 1)).ToImmutableDictionary();
+            }
 
-            attributeMemoryCache = new MemoryCache(new MemoryCacheOptions
+            attribute_memory_cache = new MemoryCache(new MemoryCacheOptions
             {
                 SizeLimit = memory_cache_size_limit,
             });
 
-            beatmapMemoryCache = new MemoryCache(new MemoryCacheOptions
+            beatmap_memory_cache = new MemoryCache(new MemoryCacheOptions
             {
                 SizeLimit = memory_cache_size_limit,
             });
@@ -88,40 +94,24 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
                 {
                     using (var db = DatabaseAccess.GetConnection())
                     {
-                        var attributeCacheKeys = attributeMemoryCache.Keys.OfType<DifficultyAttributeKey>();
+                        var attributeCacheKeys = attribute_memory_cache.Keys.OfType<DifficultyAttributeKey>();
 
                         foreach (int beatmapId in db.Query<int>("SELECT beatmap_id FROM osu_beatmaps WHERE beatmapset_id = @beatmapSetId AND `deleted_at` IS NULL",
                                      new { beatmapSetId }))
                         {
                             Console.WriteLine($"Invalidating cache for beatmap_id {beatmapId}");
 
-                            beatmapMemoryCache.Remove(beatmapId);
+                            beatmap_memory_cache.Remove(beatmapId);
 
                             foreach (var key in attributeCacheKeys)
                             {
                                 if (key.BeatmapId == beatmapId)
-                                    attributeMemoryCache.Remove(key);
+                                    attribute_memory_cache.Remove(key);
                             }
                         }
                     }
                 }
             });
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="BeatmapStore"/>.
-        /// </summary>
-        /// <param name="connection">The <see cref="MySqlConnection"/>.</param>
-        /// <param name="transaction">An existing transaction.</param>
-        /// <returns>The created <see cref="BeatmapStore"/>.</returns>
-        public static async Task<BeatmapStore> CreateAsync(MySqlConnection connection, MySqlTransaction? transaction = null)
-        {
-            var dbBlacklist = await connection.QueryAsync<PerformanceBlacklistEntry>("SELECT * FROM osu_beatmap_performance_blacklist", transaction: transaction);
-
-            return new BeatmapStore
-            (
-                dbBlacklist.Select(b => new KeyValuePair<BlacklistEntry, byte>(new BlacklistEntry(b.beatmap_id, b.mode), 1))
-            );
         }
 
         /// <summary>
@@ -135,7 +125,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
         /// <returns>The difficulty attributes or <c>null</c> if not existing.</returns>
         /// <exception cref="DifficultyAttributesMissingException">If the difficulty attributes don't exist in the database.</exception>
         /// <exception cref="Exception">If realtime difficulty attributes couldn't be computed.</exception>
-        public async Task<DifficultyAttributes> GetDifficultyAttributesAsync(Beatmap beatmap, Ruleset ruleset, Mod[] mods, MySqlConnection connection, MySqlTransaction? transaction = null)
+        public static async Task<DifficultyAttributes> GetDifficultyAttributesAsync(Beatmap beatmap, Ruleset ruleset, Mod[] mods, MySqlConnection connection, MySqlTransaction? transaction = null)
         {
             if (use_realtime_difficulty_calculation)
             {
@@ -156,7 +146,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
 
             DifficultyAttributeKey key = new DifficultyAttributeKey(beatmap.beatmap_id, (uint)ruleset.RulesetInfo.OnlineID, (uint)getLegacyModsForAttributeLookup(beatmap, ruleset, mods));
 
-            return (await attributeMemoryCache.GetOrCreateAsync(key, async cacheEntry =>
+            return (await attribute_memory_cache.GetOrCreateAsync(key, async cacheEntry =>
             {
                 try
                 {
@@ -212,7 +202,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
         /// <param name="connection">The <see cref="MySqlConnection"/>.</param>
         /// <param name="transaction">An existing transaction.</param>
         /// <returns>The retrieved beatmap, or <c>null</c> if not existing.</returns>
-        public Task<Beatmap?> GetBeatmapAsync(uint beatmapId, MySqlConnection connection, MySqlTransaction? transaction = null) => beatmapMemoryCache.GetOrCreateAsync(
+        public static Task<Beatmap?> GetBeatmapAsync(uint beatmapId, MySqlConnection connection, MySqlTransaction? transaction = null) => beatmap_memory_cache.GetOrCreateAsync(
             beatmapId,
             cacheEntry =>
             {
@@ -232,7 +222,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
         /// </summary>
         /// <param name="beatmap">The beatmap.</param>
         /// <param name="rulesetId">The ruleset.</param>
-        public bool IsBeatmapValidForPerformance(Beatmap beatmap, uint rulesetId)
+        public static bool IsBeatmapValidForPerformance(Beatmap beatmap, uint rulesetId)
         {
             if (blacklist.ContainsKey(new BlacklistEntry(beatmap.beatmap_id, rulesetId)))
                 return false;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BeatmapStore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Stores/BeatmapStore.cs
@@ -60,6 +60,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Stores
         private static int beatmapCacheMiss;
         private static int attribCacheMiss;
 
+        public static void PurgeCaches()
+        {
+            attribute_memory_cache.Clear();
+            beatmap_memory_cache.Clear();
+        }
+
         public static string GetCacheStats()
         {
             string output = $"caches: [beatmap {beatmap_memory_cache.Count:N0} +{beatmapCacheMiss:N0}] [attrib {attribute_memory_cache.Count:N0} +{attribCacheMiss:N0}]";


### PR DESCRIPTION
This fixes the fact that we were instantiating one of these per scores processed, causing thousands of background pollers 🙈.

It also means the caches are now shared over multiple usages, which is beneficial.