### PR TITLE
Purge beatmap store caches on every test

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -22,6 +22,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Difficulty;
 using osu.Game.Scoring;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using osu.Server.Queues.ScoreStatisticsProcessor.Stores;
 using Xunit;
 using Xunit.Sdk;
 using Beatmap = osu.Server.Queues.ScoreStatisticsProcessor.Models.Beatmap;
@@ -87,6 +88,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 db.Execute("TRUNCATE TABLE `osu_user_performance_rank`");
                 db.Execute("TRUNCATE TABLE `osu_user_performance_rank_highest`");
             }
+
+            BeatmapStore.PurgeCaches();
 
             Task.Run(() => Processor.Run(CancellationToken), CancellationToken);
         }

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
@@ -35,8 +35,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 db.Execute("TRUNCATE TABLE osu_scores_high");
                 db.Execute("TRUNCATE TABLE osu_beatmap_difficulty_attribs");
             }
-
-            BeatmapStore.PurgeCaches();
         }
 
         [Fact]


### PR DESCRIPTION
Some tests, especially medal-related, especially non-public ones, rely on being able to add difficulty attributes to the database, and don't really care about reuse of beatmap and beatmap set IDs between test fixtures (and rightly so). However, because the beatmap store is now assembly-static, this would lead to accidental test crosstalk wherein one test adding difficulty attributes for a beatmap would break another test elsewhere because of the caching layer and beatmap ID reuse.

The store cache purging was already being done, but only locally in a single test class.