### PR TITLE
Log suspicious user rank count decrement operations to sentry

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/BeatmapSet.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/BeatmapSet.cs
@@ -24,5 +24,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
         public double bpm { get; set; }
 
         public BeatmapOnlineStatus approved { get; set; }
+        public DateTimeOffset? approved_date { get; set; }
     }
 }


### PR DESCRIPTION
There have been many recurrent reports about user rank count totals going negative (such as
https://osu.ppy.sh/community/forums/topics/2076246?n=1). I've spent probably too much time trying to figure out how this is possible because it bothers me to no end. It doesn't appear to be anything from old web still being active and ruining things.

This temporary logging is supposed to maybe help me understand what's going on here. It's predicated on the fact that people keep reporting that this has something to do with playing qualified maps. Maybe if this collects enough data I might be able to establish some pattern of behaviour that causes this.

If you wish to test that this should detect the case I'm trying to detect, you can apply the following diff:

```diff
diff --git a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/UserRankCountProcessorTests.cs b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/UserRankCountProcessorTests.cs index 3abf01d..e5bcee1 100644
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/UserRankCountProcessorTests.cs +++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/UserRankCountProcessorTests.cs @@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.

+using System;
 using System.Collections.Generic;
+using Dapper;
 using osu.Game.Beatmaps;
 using osu.Game.Scoring;
 using Xunit;
@@ -379,6 +381,42 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             });
         }

+        [Fact]
+        public void TestBeatmapBecomesRanked()
+        {
+            var beatmap = AddBeatmap(b => b.approved = BeatmapOnlineStatus.Qualified);
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
+            {
+                item.Score.total_score = 100_000;
+                item.Score.rank = ScoreRank.A;
+                item.Score.ranked = true;
+                item.Score.legacy_score_id = 12345;
+                item.Score.ended_at = new DateTimeOffset(2025, 5, 27, 12, 30, 0, TimeSpan.Zero);
+            });
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>());
+
+            using (var db = Processor.GetDatabaseConnection())
+            {
+                db.Execute($"UPDATE `osu_beatmaps` SET `approved` = 1 WHERE `beatmap_id` = {TEST_BEATMAP_ID}");
+                db.Execute($"UPDATE `osu_beatmapsets` SET `approved` = 1, `approved_date` = '2025-05-27 13:00:00' WHERE `beatmapset_id` = {beatmap.beatmapset_id}");
+            }
+
+            SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
+            {
+                item.Score.total_score = 110_000;
+                item.Score.rank = ScoreRank.S;
+                item.Score.ranked = true;
+                item.Score.legacy_score_id = 12346;
+                item.Score.ended_at = new DateTimeOffset(2025, 5, 27, 13, 30, 0, TimeSpan.Zero);
+            });
+            waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
+            {
+                [ScoreRank.S] = 1
+            });
+        }
+
         private void waitForRankCounts(string tableName, Dictionary<ScoreRank, int> counts)
         {
             WaitForDatabaseState($"SELECT `xh_rank_count` from {tableName} WHERE `user_id` = 2", counts.GetValueOrDefault(ScoreRank.XH), CancellationToken);


```

and see that the new conditional before the sentry call gets hit. (Unless, that is, some stupid timezone shenanigans cause this to *not* get hit in production.)

I've tested that this should submit to sentry via my own instance of it:

![Screenshot 2025-05-27 at 10 45 45](https://github.com/user-attachments/assets/faf4cbce-1fbd-4252-ad8a-d6f655928454)
