### PR TITLE
Reduce web request timeouts

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/WebRequestHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/WebRequestHelper.cs
@@ -27,7 +27,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
         private static string? accessToken;
         private static DateTimeOffset? accessTokenExpiry;
 
-        private static readonly HttpClient http = new HttpClient();
+        private static readonly HttpClient http = new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(10)
+        };
 
         public static HttpResponseMessage RunSharedInteropCommand(string command, string method = "GET", dynamic? postObject = null)
         {


### PR DESCRIPTION
After deploying the latest changes whose aim is to emit high scoreboard rank events for lazer leaderboards, many systems started having a conniption around 00:00 UTC.

The likely explanation is that some job is running every day at midnight UTC, which causes `osu-web` to respond to API requests made by `osu-queue-score-statistics`  for scores with some delay, which - because of `osu-queue-score-statistics` performing the request inside a transaction - probably is bringing down everything else.

Performing web requests with a transaction held is suboptimal to say the least, but let's start with decreasing the timeout for now given that the rank achieved stuff is generally non-critical to the functioning of the game.

This timeout will also apply to LIO requests, which I think is probably fine - LIO requests will retry up to three times anyway.