### PR TITLE
Write last processed score id to counts table

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
@@ -250,12 +250,15 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
 
                     if (score.passed && !score.preserve)
                         Console.WriteLine($"Passed score {score.id} was processed but not preserved");
+
+                    conn.Execute("REPLACE INTO osu_counts (name, count) SELECT 'last_processed_score_id', MAX(score_id) FROM score_process_history");
                 }
 
                 elasticQueueProcessor.PushToQueue(new ElasticQueuePusher.ElasticScoreItem
                 {
                     ScoreId = (long)item.Score.id,
                 });
+
                 publishScoreProcessed(item);
             }
             catch (Exception e)


### PR DESCRIPTION
For use in `osu-web` for knowing whether a scores has been processed or not, now that it is not guaranteed that `score_process_history` rows exist for eternity.

Note that this may be slightly inaccurate if there are multiple runners processing the queue, but only by sub-second values.