### PR TITLE
Disallow all processors from running if score is too short

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -201,8 +201,16 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
         protected Beatmap AddBeatmap(Action<Beatmap>? beatmapSetup = null, Action<BeatmapSet>? beatmapSetSetup = null)
         {
-            var beatmap = new Beatmap { approved = BeatmapOnlineStatus.Ranked };
-            var beatmapSet = new BeatmapSet { approved = BeatmapOnlineStatus.Ranked, approved_date = DateTimeOffset.Now.AddHours(-1) };
+            var beatmap = new Beatmap
+            {
+                approved = BeatmapOnlineStatus.Ranked,
+                total_length = 158,
+            };
+            var beatmapSet = new BeatmapSet
+            {
+                approved = BeatmapOnlineStatus.Ranked,
+                approved_date = DateTimeOffset.Now.AddHours(-1),
+            };
 
             beatmapSetup?.Invoke(beatmap);
             beatmapSetSetup?.Invoke(beatmapSet);

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/HitStatisticsProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/HitStatisticsProcessorTests.cs
@@ -8,11 +8,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 {
     public class HitStatisticsProcessorTests : DatabaseTest
     {
+        public HitStatisticsProcessorTests()
+        {
+            AddBeatmap();
+        }
+
         [Fact]
         public void TestHitStatisticsIncrease()
         {
-            AddBeatmap();
-
             WaitForDatabaseState("SELECT count300 FROM osu_user_stats WHERE user_id = 2", (int?)null, CancellationToken);
 
             PushToQueueAndWaitForProcess(CreateTestScore());
@@ -25,8 +28,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         [Fact]
         public void TestHitStatisticsReprocessOldVersionIncrease()
         {
-            AddBeatmap();
-
             var score = CreateTestScore();
 
             WaitForDatabaseState("SELECT count300 FROM osu_user_stats WHERE user_id = 2", (int?)null, CancellationToken);
@@ -47,21 +48,23 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         [Fact]
         public void TestDoesNotIncreaseIfFailedAndPlayTooShort()
         {
-            WaitForDatabaseState("SELECT count300 FROM osu_user_stats WHERE user_id = 2", (int?)null, CancellationToken);
-
             var score = CreateTestScore();
+
+            WaitForDatabaseState("SELECT count300 FROM osu_user_stats WHERE user_id = 2", (int?)null, CancellationToken);
+            PushToQueueAndWaitForProcess(score);
+            WaitForDatabaseState("SELECT count300 FROM osu_user_stats WHERE user_id = 2", 5, CancellationToken);
+
+            score = CreateTestScore();
             score.Score.ended_at = score.Score.started_at!.Value + TimeSpan.FromSeconds(4);
             score.Score.passed = false;
 
             PushToQueueAndWaitForProcess(score);
-            WaitForDatabaseState("SELECT count300 FROM osu_user_stats WHERE user_id = 2", 0, CancellationToken);
+            WaitForDatabaseState("SELECT count300 FROM osu_user_stats WHERE user_id = 2", 5, CancellationToken);
         }
 
         [Fact]
         public void TestHitStatisticsReprocessDoesntIncrease()
         {
-            AddBeatmap();
-
             var score = CreateTestScore();
 
             WaitForDatabaseState("SELECT count300 FROM osu_user_stats WHERE user_id = 2", (int?)null, CancellationToken);
@@ -79,8 +82,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         [Fact]
         public void TestHitStatisticsIncreaseOnCatchTickHits()
         {
-            AddBeatmap();
-
             WaitForDatabaseState("SELECT count300 FROM osu_user_stats_fruits WHERE user_id = 2", (int?)null, CancellationToken);
 
             var testScore = CreateTestScore(rulesetId: 2);

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/HitStatisticsProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/HitStatisticsProcessorTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using osu.Game.Rulesets.Scoring;
@@ -41,6 +42,19 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             PushToQueueAndWaitForProcess(score);
             WaitForDatabaseState("SELECT count300 FROM osu_user_stats WHERE user_id = 2", 10, CancellationToken);
+        }
+
+        [Fact]
+        public void TestDoesNotIncreaseIfFailedAndPlayTooShort()
+        {
+            WaitForDatabaseState("SELECT count300 FROM osu_user_stats WHERE user_id = 2", (int?)null, CancellationToken);
+
+            var score = CreateTestScore();
+            score.Score.ended_at = score.Score.started_at!.Value + TimeSpan.FromSeconds(4);
+            score.Score.passed = false;
+
+            PushToQueueAndWaitForProcess(score);
+            WaitForDatabaseState("SELECT count300 FROM osu_user_stats WHERE user_id = 2", 0, CancellationToken);
         }
 
         [Fact]

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/LastPlayedDateProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/LastPlayedDateProcessorTests.cs
@@ -20,6 +20,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var secondDate = new DateTimeOffset(2024, 3, 1, 0, 0, 0, TimeSpan.Zero);
             SetScoreForBeatmap(beatmap.beatmap_id, s =>
             {
+                s.Score.started_at = secondDate - TimeSpan.FromSeconds(20);
                 s.Score.ended_at = secondDate;
                 s.Score.passed = false;
             });
@@ -29,6 +30,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var thirdDate = new DateTimeOffset(2024, 2, 1, 0, 0, 0, TimeSpan.Zero);
             SetScoreForBeatmap(beatmap.beatmap_id, s =>
             {
+                s.Score.started_at = thirdDate - TimeSpan.FromSeconds(20);
                 s.Score.ended_at = thirdDate;
                 s.Score.passed = false;
             });

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PlayCountProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PlayCountProcessorTests.cs
@@ -10,11 +10,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 {
     public class PlayCountProcessorTests : DatabaseTest
     {
-        private const int beatmap_length = 158;
-
         public PlayCountProcessorTests()
         {
-            AddBeatmap(b => b.total_length = beatmap_length);
+            AddBeatmap();
         }
 
         [Fact]

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/PlayValidityHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/PlayValidityHelper.cs
@@ -21,10 +21,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
         /// <seealso cref="PlayCountProcessor"/>
         /// <seealso cref="PlayTimeProcessor"/>
         /// <param name="score">The score to check.</param>
-        /// <param name="lengthInSeconds">The total length of play in seconds in the supplied <paramref name="score"/>.</param>
-        public static bool IsValidForPlayTracking(this SoloScore score, out int lengthInSeconds)
+        public static bool IsValidForPlayTracking(this SoloScore score)
         {
-            lengthInSeconds = GetPlayLength(score);
+            int lengthInSeconds = GetPlayLength(score);
 
             int totalObjectsJudged = score.ScoreData.Statistics.Where(kv => kv.Key.IsScorable()).Sum(kv => kv.Value);
             int totalObjects = score.ScoreData.MaximumStatistics.Where(kv => kv.Key.IsScorable()).Sum(kv => kv.Value);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/PlayValidityHelper.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/PlayValidityHelper.cs
@@ -23,15 +23,17 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
         /// <param name="score">The score to check.</param>
         public static bool IsValidForPlayTracking(this SoloScore score)
         {
+            if (score.passed)
+                return true;
+
             int lengthInSeconds = GetPlayLength(score);
 
             int totalObjectsJudged = score.ScoreData.Statistics.Where(kv => kv.Key.IsScorable()).Sum(kv => kv.Value);
             int totalObjects = score.ScoreData.MaximumStatistics.Where(kv => kv.Key.IsScorable()).Sum(kv => kv.Value);
 
-            return score.passed
-                   || (lengthInSeconds >= 8
-                       && score.total_score >= 5000
-                       && totalObjectsJudged >= Math.Min(0.1f * totalObjects, 20));
+            return lengthInSeconds >= 8
+                   && score.total_score >= 5000
+                   && totalObjectsJudged >= Math.Min(0.1f * totalObjects, 20);
         }
 
         /// <summary>

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
@@ -28,9 +28,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
         {
-            if (!score.IsValidForPlayTracking(out _) && previousVersion >= 10)
-                return;
-
             if (previousVersion >= 1)
                 userStats.playcount--;
 
@@ -43,9 +40,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
         {
-            if (!score.IsValidForPlayTracking(out _))
-                return;
-
             const int beatmap_count = 12;
             const int over_time = 120;
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
@@ -22,8 +22,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
         {
-            if (!score.IsValidForPlayTracking(out int lengthInSeconds) && previousVersion >= 10)
-                return;
+            int lengthInSeconds = PlayValidityHelper.GetPlayLength(score);
 
             if (previousVersion >= 6)
                 userStats.total_seconds_played -= lengthInSeconds;
@@ -31,8 +30,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
         {
-            if (!score.IsValidForPlayTracking(out int lengthInSeconds))
-                return;
+            int lengthInSeconds = PlayValidityHelper.GetPlayLength(score);
 
             userStats.total_seconds_played += lengthInSeconds;
         }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
@@ -204,6 +204,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
                         BeatmapSetId = score.beatmap.beatmapset_id
                     });
 
+                    if (!score.IsValidForPlayTracking())
+                        return;
+
                     using (var transaction = conn.BeginTransaction(IsolationLevel.ReadCommitted))
                     {
                         var userStats = DatabaseHelper.GetUserStatsAsync(score, conn, transaction).Result;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
@@ -204,9 +204,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
                         BeatmapSetId = score.beatmap.beatmapset_id
                     });
 
-                    if (!score.IsValidForPlayTracking())
-                        return;
-
                     using (var transaction = conn.BeginTransaction(IsolationLevel.ReadCommitted))
                     {
                         var userStats = DatabaseHelper.GetUserStatsAsync(score, conn, transaction).Result;
@@ -219,43 +216,46 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
                             return;
                         }
 
-                        // if required, we can rollback any previous version of processing then reapply with the latest.
-                        if (item.ProcessHistory != null)
+                        if (score.IsValidForPlayTracking())
                         {
-                            tags.Add("type:upgraded");
-                            byte version = item.ProcessHistory.processed_version;
-
-                            foreach (var p in enumerateValidProcessors(score))
-                                p.RevertFromUserStats(score, userStats, version, conn, transaction, postTransactionActions);
-                        }
-                        else
-                        {
-                            tags.Add("type:new");
-                        }
-
-                        item.Tags = tags.ToArray();
-
-                        foreach (IProcessor p in enumerateValidProcessors(score))
-                        {
-                            stopwatch.Restart();
-
-                            try
+                            // if required, we can rollback any previous version of processing then reapply with the latest.
+                            if (item.ProcessHistory != null)
                             {
-                                p.ApplyToUserStats(score, userStats, conn, transaction, postTransactionActions);
+                                tags.Add("type:upgraded");
+                                byte version = item.ProcessHistory.processed_version;
+
+                                foreach (var p in enumerateValidProcessors(score))
+                                    p.RevertFromUserStats(score, userStats, version, conn, transaction, postTransactionActions);
                             }
-                            catch (ProcessingAbortedException abortException)
+                            else
                             {
-                                Console.WriteLine($"Aborting processing of score {item.Score.id}: {abortException.Message}");
-                                tags.Add("type:aborted");
-                                transaction.Rollback();
-                                conn.Execute("UPDATE `scores` SET `ranked` = 0 WHERE `id` = @scoreId", new { scoreId = score.id });
-                                return;
+                                tags.Add("type:new");
                             }
 
-                            DogStatsd.Timer("apply_time_elapsed", stopwatch.ElapsedMilliseconds, tags: item.Tags.Append($"processor:{p.GetType().ReadableName()}").ToArray());
-                        }
+                            item.Tags = tags.ToArray();
 
-                        DatabaseHelper.UpdateUserStatsAsync(userStats, conn, transaction).Wait();
+                            foreach (IProcessor p in enumerateValidProcessors(score))
+                            {
+                                stopwatch.Restart();
+
+                                try
+                                {
+                                    p.ApplyToUserStats(score, userStats, conn, transaction, postTransactionActions);
+                                }
+                                catch (ProcessingAbortedException abortException)
+                                {
+                                    Console.WriteLine($"Aborting processing of score {item.Score.id}: {abortException.Message}");
+                                    tags.Add("type:aborted");
+                                    transaction.Rollback();
+                                    conn.Execute("UPDATE `scores` SET `ranked` = 0 WHERE `id` = @scoreId", new { scoreId = score.id });
+                                    return;
+                                }
+
+                                DogStatsd.Timer("apply_time_elapsed", stopwatch.ElapsedMilliseconds, tags: item.Tags.Append($"processor:{p.GetType().ReadableName()}").ToArray());
+                            }
+
+                            DatabaseHelper.UpdateUserStatsAsync(userStats, conn, transaction).Wait();
+                        }
 
                         updateHistoryEntry(item, conn, transaction);
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
@@ -256,6 +256,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
 
                             DatabaseHelper.UpdateUserStatsAsync(userStats, conn, transaction).Wait();
                         }
+                        else
+                        {
+                            tags.Add("type:too-short");
+                        }
 
                         updateHistoryEntry(item, conn, transaction);
 


### PR DESCRIPTION
Have not run tests locally yet, just a quick PoC based on [recent report](https://discord.com/channels/188630481301012481/188630652340404224/1506626367264133151).

FWIW I think we should guard against this client side as well (client should not submit under said circumstances eagerly, to reduce network / client strain.