### PR TITLE
Fix `total_score_without_mods` population failing if beatmap was deleted

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MarkNonPreservedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MarkNonPreservedScoresCommand.cs
@@ -113,6 +113,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                 rulesetId = RulesetId,
             };
 
+            // TODO: clean up scores with missing beatmaps, probably.
+
             if (Verbose) Console.WriteLine("Fetching scores..");
 
             // We only care about beatmaps where the user has more than one score.

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/PopulateTotalScoreWithoutModsCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/PopulateTotalScoreWithoutModsCommand.cs
@@ -81,7 +81,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
                 foreach (var score in scoresWithMissing)
                 {
-                    score.beatmap = beatmapsById[score.beatmap_id];
+                    if (!beatmapsById.TryGetValue(score.beatmap_id, out var beatmap))
+                    {
+                        Console.WriteLine($"Skipping score {score.id} (missing beatmap {score.beatmap_id})");
+                        continue;
+                    }
+
+                    score.beatmap = beatmap;
                     var scoreInfo = score.ToScoreInfo();
                     LegacyScoreDecoder.PopulateTotalScoreWithoutMods(scoreInfo);
 


### PR DESCRIPTION
There are cases where scores are in the scores table for deleted beatmaps. This can happen when the beatmap creator submits a new version of a beatmap and causes the old one to be completely nuked from the table. From what I can tell, this is the only case that soft deletion is not a thing for the beatmaps table.

For such scores we don't really have a recover method, so let's just leave them in a state without this field.

Relevant failure:

```
Processed up to 2315947751 (9560059 backfilled)
Processed up to 2315952751 (9560457 backfilled)
Processed up to 2315957751 (9560911 backfilled)
Unhandled exception. System.Collections.Generic.KeyNotFoundException: The given key '2283259' was not present in the dictionary.
   at osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance.PopulateTotalScoreWithoutModsCommand.OnExecuteAsync(CancellationToken cancellationToken) in /app/osu-queue-score-statistics/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/PopulateTotalScoreWithoutModsCommand.cs:line 84
   at McMaster.Extensions.CommandLineUtils.SourceGeneration.ReflectionExecuteHandler.InvokeAsyncMethod(Object instance, Object[] arguments)
   at McMaster.Extensions.CommandLineUtils.SourceGeneration.ReflectionExecuteHandler.InvokeAsync(Object model, CommandLineApplication app, CancellationToken cancellationToken)
   at McMaster.Extensions.CommandLineUtils.Conventions.ExecuteMethodConvention.<>c__DisplayClass0_0.<<Apply>b__1>d.MoveNext()
--- End of stack trace from previous location ---
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.ExecuteAsync(String[] args, CancellationToken cancellationToken)
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.ExecuteAsync[TApp](CommandLineContext context, CancellationToken cancellationToken)
   at osu.Server.Queues.ScoreStatisticsProcessor.Program.Main(String[] args) in /app/osu-queue-score-statistics/osu.Server.Queues.ScoreStatisticsProcessor/Program.cs:line 27
   at osu.Server.Queues.ScoreStatisticsProcessor.Program.<Main>(String[] args)
```