### PR TITLE
Fix total score without mods population command not flushing buffer when not in dry run

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/PopulateTotalScoreWithoutModsCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/PopulateTotalScoreWithoutModsCommand.cs
@@ -130,6 +130,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                 Console.WriteLine();
                 Console.WriteLine($"Flushing sql batch ({bufferLength:N0} bytes)");
                 conn.Execute(sqlBuffer.ToString());
+                sqlBuffer.Clear();
             }
         }
     }


### PR DESCRIPTION
Found when cross-checking method against other implementations of the similar operation in other commands.

Of note other commands' implementation features indexing the score to ES, which in this case does not appear to be necessary as `total_score_without_mods` [does not appear to be indexed to ES](https://github.com/ppy/osu-elastic-indexer/blob/master/osu.ElasticIndexer/Score.cs). Reviewers are asked to confirm this understanding.