### PR TITLE
Fix reflection-based processors failing with latest game

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
@@ -33,7 +33,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             // add each processor automagically.
             foreach (var t in AppDomain.CurrentDomain
                                        .GetAssemblies()
-                                       .SelectMany(t => t.GetTypes())
+                                       .SelectMany(t => t.GetExportedTypes())
                                        .Where(t => !t.IsInterface && typeof(IMedalAwarder).IsAssignableFrom(t)))
             {
                 if (Activator.CreateInstance(t) is IMedalAwarder awarder)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
@@ -111,7 +111,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         {
             List<Type> enabledTypes = AppDomain.CurrentDomain
                                                .GetAssemblies()
-                                               .SelectMany(a => a.GetTypes())
+                                               .SelectMany(a => a.GetExportedTypes())
                                                .Where(t => !t.IsInterface && typeof(IProcessor).IsAssignableFrom(t))
                                                .ToList();
 


### PR DESCRIPTION
> [!CAUTION]
> If this is merged and deployed to production, it should be checked that all processors and medal awarders are running correctly afterwards. There are tests exercising this, I have run them and I am somewhat confident that it should be OK, but the test setup does not exactly match the production setup, so exercise caution.

- Indirectly relevant to https://github.com/ppy/osu/issues/37818

On current master, when I run `./UseLocalOsu.sh` and run more than one test, the first passes, and the second fails with

```
Unable to load one or more of the requested types.
Could not load type 'AlsaSharp.anonymous_type_1' from assembly 'alsa-sharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' because it contains an object field at offset 0 that is incorrectly aligned or overlapped by a non-object field.
Could not load type 'AlsaSharp.anonymous_type_1' from assembly 'alsa-sharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' because it contains an object field at offset 0 that is incorrectly aligned or overlapped by a non-object field.
Could not load type 'AlsaSharp.anonymous_type_1' from assembly 'alsa-sharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' because it contains an object field at offset 0 that is incorrectly aligned or overlapped by a non-object field.
```

The broken type is indeed in [AlsaSharp source](https://github.com/atsushieno/alsa-sharp/blob/eb3b528b02e8a0ebbbf319c7c2aa04c466b303dc/alsa-sharp/AlsaSharp/alsa-interop.cs#L1003-L1020).

Upon bisecting with a game checkout and then a framework checkout on top of that, this bisected to
https://github.com/ppy/osu-framework/commit/2ac847ec001982cbcf90a976c3bd4605fb0b0671.

After even further investigation, I am pretty confident that none of the `MidiHandler` code ever *actually* runs inside
`osu-queue-score-statistics`. At this point my conclusions are emprical and thus prone to being inaccurate, but it *appears* that changing `refreshDevices()` in the bad commit to be `async` is the primary trigger for the failure, which is relevant as that method is calling into `managed-midi`.

Via deductive reasoning, it must somehow be the case that changing the method to `async` changes the emitted IL of the method, which then prompts the CLR assembly resolver to load `managed-midi`, which then pulls in `AlsaSharp` and results in the failure.

To verify this:

1. Apply a game checkout to this project via `./UseLocalOsu.sh`.
2. Apply a framework checkout to the game via `../osu/UseLocalFramework.sh`.
3. Manually add `../osu-framework/osu.Framework/osu.Framework.csproj` to the `osu-queue-score-statistics` solution.
4. Check out https://github.com/ppy/osu-framework/commit/ab389cc4cab166f7836e132a9c2dca4a65e72212 in framework (last good commit as given by bisect).
5. Run tests and observe that they are green.
6. Apply the following patch to framework:

   ```diff
   diff --git a/osu.Framework/Input/Handlers/Midi/MidiHandler.cs b/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
   index 41f8cc8d4d..710605bbf2 100644
   --- a/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
   +++ b/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
   @@ -82,6 +82,8 @@ public override bool Initialize(GameHost host)
                return true;
            }

   +        private async Task hijinks(string whatever) => await MidiAccessManager.Default.OpenInputAsync(whatever).ConfigureAwait(false);
   +
            private bool refreshDevices()
            {
                try

   ```

7. Run tests and observe that they are red.

As for the fix, there is a lot going wrong here (why is a server-side component pulling in `ppy.osu.Framework` *twice*, both directly via `ppy.osu` and ruleset projects, *and* indirectly via `ppy.osu.QueueProcessor`?), but it does not seem particularly expedient to be getting stuck in the fine print at this time, so the applied fix is a minimum effort change from `GetTypes()` to `GetExportedTypes()`, which limits the scope of lookup to public types from the traversed assemblies, which skips the broken `AlsaSharp` types while simultaneously preserving desired function.