### PR TITLE
Don't attempt to guess `StartId` for verifying scores

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
@@ -71,17 +71,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
             using var conn = await DatabaseAccess.GetConnectionAsync(cancellationToken);
 
-            if (lastId == 0)
-            {
-                lastId = await conn.QuerySingleAsync<ulong?>(
-                    "SELECT id FROM scores WHERE ruleset_id = @rulesetId AND legacy_score_id = (SELECT MIN(legacy_score_id) FROM scores WHERE ruleset_id = @rulesetId AND id >= @lastId AND legacy_score_id > 0)",
-                    new
-                    {
-                        lastId,
-                        rulesetId = RulesetId,
-                    }) ?? lastId;
-            }
-
             Console.WriteLine();
             Console.WriteLine($"Verifying scores starting from {lastId} for ruleset {RulesetId}");
 


### PR DESCRIPTION
This came up recently after we found a small number of scores which were never verified in previous runs. This comes due to `legacy_score_id` and `id` not being monotonic in relation to each other. Probably due to issues with the original score import process.

This process is seldom run, and already has support for skipping rows which are not relevant (ie. it's not going to timeout on a long query if the `start_id` is wrong), so let's just not bother trying to guess at it for nominal savings.