### PR TITLE
Improve speed of score recalculation by caching per-score lookups

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/RecalculateModMultipliersCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/RecalculateModMultipliersCommand.cs
@@ -31,10 +31,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
         public int BatchSize { get; set; } = 5000;
 
         [Option(CommandOptionType.SingleOrNoValue, Template = "--dry-run")]
+        [MemberNotNullWhen(false, nameof(elasticQueuePusher))]
         public bool DryRun { get; set; }
 
         [Option(CommandOptionType.SingleOrNoValue, Template = "-v|--verbose", Description = "Output verbose information on processing.")]
-        [MemberNotNullWhen(false, nameof(elasticQueuePusher))]
         public bool Verbose { get; set; }
 
         private readonly StringBuilder sqlBuffer = new StringBuilder();
@@ -188,7 +188,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
                     if (elasticItems.Count > 0)
                     {
-                        elasticQueuePusher!.PushToQueue(elasticItems.ToList());
+                        elasticQueuePusher.PushToQueue(elasticItems.ToList());
                         Console.WriteLine($"Queued {elasticItems.Count} items for indexing");
                     }
                 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/RecalculateModMultipliersCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/RecalculateModMultipliersCommand.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -32,11 +33,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
         public bool DryRun { get; set; }
 
         [Option(CommandOptionType.SingleOrNoValue, Template = "-v|--verbose", Description = "Output verbose information on processing.")]
+        [MemberNotNullWhen(false, nameof(elasticQueuePusher))]
         public bool Verbose { get; set; }
 
         private readonly StringBuilder sqlBuffer = new StringBuilder();
 
-        private readonly ElasticQueuePusher elasticQueuePusher = new ElasticQueuePusher();
+        private ElasticQueuePusher? elasticQueuePusher;
+
         private readonly List<ElasticQueuePusher.ElasticScoreItem> elasticItems = new List<ElasticQueuePusher.ElasticScoreItem>();
 
         [UsedImplicitly]
@@ -51,10 +54,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
             Console.WriteLine();
             Console.WriteLine($"Recalculating total score in line with new mod multipliers, starting from ID {lastId}");
-            Console.WriteLine($"Indexing to elastic queue(s) {elasticQueuePusher.ActiveQueues}");
 
             if (DryRun)
                 Console.WriteLine("RUNNING IN DRY RUN MODE.");
+            else
+            {
+                elasticQueuePusher = new ElasticQueuePusher();
+                Console.WriteLine($"Indexing to elastic queue(s) {elasticQueuePusher.ActiveQueues}");
+            }
 
             await Task.Delay(5000, cancellationToken);
 
@@ -192,7 +199,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
                     if (elasticItems.Count > 0)
                     {
-                        elasticQueuePusher.PushToQueue(elasticItems.ToList());
+                        elasticQueuePusher!.PushToQueue(elasticItems.ToList());
                         Console.WriteLine($"Queued {elasticItems.Count} items for indexing");
                     }
                 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/RecalculateModMultipliersCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/RecalculateModMultipliersCommand.cs
@@ -17,6 +17,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Server.QueueProcessor;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using BeatmapStore = osu.Server.Queues.ScoreStatisticsProcessor.Stores.BeatmapStore;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 {
@@ -41,6 +42,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
         private ElasticQueuePusher? elasticQueuePusher;
 
         private readonly List<ElasticQueuePusher.ElasticScoreItem> elasticItems = new List<ElasticQueuePusher.ElasticScoreItem>();
+
+        private Dictionary<uint, Beatmap> beatmapsById = new Dictionary<uint, Beatmap>();
 
         [UsedImplicitly]
         public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
@@ -87,15 +90,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                     continue;
                 }
 
-                uint[] beatmapIds = scoresWithMods.Select(score => score.beatmap_id).Distinct().ToArray();
-                var beatmapsById = (await conn.QueryAsync<Beatmap>(@"SELECT * FROM `osu_beatmaps` WHERE `beatmap_id` IN @ids", new { ids = beatmapIds }))
-                    .ToDictionary(beatmap => beatmap.beatmap_id);
-
                 foreach (var score in scoresWithMods)
                 {
                     string source = score.is_legacy_score ? "stable" : "lazer ";
 
-                    if (!beatmapsById.TryGetValue(score.beatmap_id, out var beatmap))
+                    var beatmap = await BeatmapStore.GetBeatmapAsync(score.beatmap_id, conn);
+
+                    if (beatmap == null)
                     {
                         if (Verbose)
                             Console.WriteLine($"[{score.id,11} {source}] Skipped due to missing beatmap");

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/RecalculateModMultipliersCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/RecalculateModMultipliersCommand.cs
@@ -113,7 +113,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
                     if (score.is_legacy_score)
                     {
-                        var scoringAttributes = getScoringAttributesFor(score, conn)?.ToAttributes();
+                        var scoringAttributes = BatchInserter.GetCachedScoringAttributes(new BatchInserter.BeatmapLookup((int)score.beatmap_id, score.ruleset_id), conn)?.ToAttributes();
 
                         if (scoringAttributes == null)
                         {
@@ -168,18 +168,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
             flush(conn, true);
 
             return 0;
-        }
-
-        private static BeatmapScoringAttributes? getScoringAttributesFor(SoloScore score, MySqlConnection conn)
-        {
-            BeatmapScoringAttributes? scoreAttributes = conn.QuerySingleOrDefault<BeatmapScoringAttributes>(
-                "SELECT * FROM osu_beatmap_scoring_attribs WHERE beatmap_id = @BeatmapId AND mode = @RulesetId", new
-                {
-                    BeatmapId = score.beatmap_id,
-                    RulesetId = score.ruleset_id,
-                });
-
-            return scoreAttributes;
         }
 
         private void flush(MySqlConnection conn, bool force = false)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/RecalculateModMultipliersCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/RecalculateModMultipliersCommand.cs
@@ -43,8 +43,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
         private readonly List<ElasticQueuePusher.ElasticScoreItem> elasticItems = new List<ElasticQueuePusher.ElasticScoreItem>();
 
-        private Dictionary<uint, Beatmap> beatmapsById = new Dictionary<uint, Beatmap>();
-
         [UsedImplicitly]
         public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
         {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/BatchInserter.cs
@@ -294,7 +294,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
             // A special hit result is used to pad out the combo value to match, based on the max combo from the beatmap attributes.
             int maxComboFromStatistics = scoreInfo.MaximumStatistics.Where(kvp => kvp.Key.AffectsCombo()).Select(kvp => kvp.Value).DefaultIfEmpty(0).Sum();
 
-            var scoreAttributes = getScoringAttributes(new BeatmapLookup(highScore.beatmap_id, rulesetId));
+            var scoreAttributes = GetCachedScoringAttributes(new BeatmapLookup(highScore.beatmap_id, rulesetId));
 
             if (scoreAttributes == null)
             {
@@ -348,22 +348,25 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
         private static readonly ConcurrentDictionary<BeatmapLookup, BeatmapScoringAttributes?> scoring_attributes_cache =
             new ConcurrentDictionary<BeatmapLookup, BeatmapScoringAttributes?>();
 
-        private static BeatmapScoringAttributes? getScoringAttributes(BeatmapLookup lookup)
+        public static BeatmapScoringAttributes? GetCachedScoringAttributes(BeatmapLookup lookup)
+        {
+            using (var conn = DatabaseAccess.GetConnection())
+                return GetCachedScoringAttributes(lookup, conn);
+        }
+
+        public static BeatmapScoringAttributes? GetCachedScoringAttributes(BeatmapLookup lookup, MySqlConnection conn)
         {
             if (scoring_attributes_cache.TryGetValue(lookup, out var existing))
                 return existing;
 
-            using (var connection = DatabaseAccess.GetConnection())
-            {
-                BeatmapScoringAttributes? scoreAttributes = connection.QuerySingleOrDefault<BeatmapScoringAttributes>(
-                    "SELECT * FROM osu_beatmap_scoring_attribs WHERE beatmap_id = @BeatmapId AND mode = @RulesetId", new
-                    {
-                        BeatmapId = lookup.BeatmapId,
-                        RulesetId = lookup.RulesetId,
-                    });
+            BeatmapScoringAttributes? scoreAttributes = conn.QuerySingleOrDefault<BeatmapScoringAttributes>(
+                "SELECT * FROM osu_beatmap_scoring_attribs WHERE beatmap_id = @BeatmapId AND mode = @RulesetId", new
+                {
+                    BeatmapId = lookup.BeatmapId,
+                    RulesetId = lookup.RulesetId,
+                });
 
-                return scoring_attributes_cache[lookup] = scoreAttributes;
-            }
+            return scoring_attributes_cache[lookup] = scoreAttributes;
         }
 
         private static readonly ConcurrentDictionary<int, LegacyBeatmapConversionDifficultyInfo> difficulty_info_cache =
@@ -432,7 +435,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
 
         private record RulesetCache(Ruleset Ruleset, HitResult MaxBasicResult, Mod ClassicMod);
 
-        private record BeatmapLookup(int BeatmapId, int RulesetId)
+        public record BeatmapLookup(int BeatmapId, int RulesetId)
         {
             public override string ToString()
             {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/BatchInserter.cs
@@ -350,8 +350,20 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
 
         public static BeatmapScoringAttributes? GetCachedScoringAttributes(BeatmapLookup lookup)
         {
+            if (scoring_attributes_cache.TryGetValue(lookup, out var existing))
+                return existing;
+
             using (var conn = DatabaseAccess.GetConnection())
-                return GetCachedScoringAttributes(lookup, conn);
+            {
+                BeatmapScoringAttributes? scoreAttributes = conn.QuerySingleOrDefault<BeatmapScoringAttributes>(
+                    "SELECT * FROM osu_beatmap_scoring_attribs WHERE beatmap_id = @BeatmapId AND mode = @RulesetId", new
+                    {
+                        BeatmapId = lookup.BeatmapId,
+                        RulesetId = lookup.RulesetId,
+                    });
+
+                return scoring_attributes_cache[lookup] = scoreAttributes;
+            }
         }
 
         public static BeatmapScoringAttributes? GetCachedScoringAttributes(BeatmapLookup lookup, MySqlConnection conn)


### PR DESCRIPTION
Local testing shows ~800x improvement on dry run, but I'm also testing with production database at high latency so providing accurate benchmark results here is omitted (local db mirror is still nor reinit yet).

Fully aware of potential memory concerns for `GetCachedScoringAttributes`. Will deal with that if we need to (convert to `MemoryCache` like the more mature methods), but the actual amount of data stored is quite small, so I'm not sure it will be required.