### PR TITLE
Adjustments for new mod multipliers

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ScoreMultiplierRecalculationTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ScoreMultiplierRecalculationTest.cs
@@ -136,11 +136,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var recalculateCommand = new RecalculateModMultipliersCommand { StartId = score.id };
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 1001683, CancellationToken, score);
+            // `StandardisedScoreMigrationTools.UpdateFromLegacy()` calculates `TotalScoreWithoutMods` as 894871
+            // 894871 * 1.23 (DT) * 1.09 (HR) * 0.985 (CL) = 1181757.2464545 ≈ 1181757
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 1181757, CancellationToken, score);
 
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 1001683, CancellationToken, score);
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 1181757, CancellationToken, score);
         }
 
         /// <summary>
@@ -237,11 +239,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var recalculateCommand = new RecalculateModMultipliersCommand { StartId = score.id };
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 239050, CancellationToken, score);
+            // 452747 * 1.23 (DT) * 0.8 (EZ) * 0.985 (CL) = 438820.50228 ≈ 438821
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 438821, CancellationToken, score);
 
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 239050, CancellationToken, score);
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 438821, CancellationToken, score);
         }
 
         /// <summary>
@@ -327,7 +330,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var recalculateCommand = new RecalculateModMultipliersCommand { StartId = score.id };
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 417278, CancellationToken, score);
+            // `StandardisedScoreMigrationTools.UpdateFromLegacy()` calculates `TotalScoreWithoutMods` as 434665
+            // 434665 * 0.985 (CL) = 428145.025 ≈ 428145
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 428145, CancellationToken, score);
         }
 
         /// <summary>
@@ -525,11 +530,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var recalculateCommand = new RecalculateModMultipliersCommand { StartId = score.id };
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 200732, CancellationToken, score);
+            // 364967 * 0.5 (NF) * 1.23 (DT) = 224454.705 ≈ 224455
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 224455, CancellationToken, score);
 
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 200732, CancellationToken, score);
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 224455, CancellationToken, score);
         }
 
         /// <summary>
@@ -724,11 +730,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var recalculateCommand = new RecalculateModMultipliersCommand { StartId = score.id };
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 468585, CancellationToken, score);
+            // 379126 * 1.09 (HR) * 1.23 (NC) * 1.04 (HD) = 528625.997328 ≈ 528626
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 528626, CancellationToken, score);
 
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 468585, CancellationToken, score);
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 528626, CancellationToken, score);
         }
 
         /// <summary>
@@ -827,11 +834,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var recalculateCommand = new RecalculateModMultipliersCommand { StartId = score.id };
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 84678, CancellationToken, score);
+            // 156811 * 1.174 (NC 1.49x) * 0.65 (DA, AR portion) * 0.75 (DA, OD portion) = 89746.855575 ≈ 89747
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 89747, CancellationToken, score);
 
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 84678, CancellationToken, score);
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 89747, CancellationToken, score);
         }
 
         /// <summary>

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/PopulateTotalScoreWithoutModsCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/PopulateTotalScoreWithoutModsCommand.cs
@@ -118,6 +118,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                         throw new InvalidOperationException($"Aborting: score {score.id} has missing or invalid build ID of {score.build_id}!");
 
                     scoreInfo.ClientVersion = buildVersion;
+                    // This is hardcoding the total score version preceding the first (and simultaneously last, at time of writing) mod multiplier rebalance.
+                    // This information cannot be easily populated using the `scores` table alone, as it's only in replays,
+                    // and so the simplest thing to do is to hardcode it.
+                    // This command should hopefully be never needed again at the time of writing (as it has already been run on production),
+                    // but if it is, this hardcoding should be HEAVILY scrutinised in terms of its correctness.
+                    scoreInfo.TotalScoreVersion = 30000016;
 
                     var ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(scoreInfo.RulesetID);
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/osu.Server.Queues.ScoreStatisticsProcessor.csproj
@@ -14,11 +14,11 @@
         <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="5.0.1" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
-        <PackageReference Include="ppy.osu.Game" Version="2026.601.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2026.601.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2026.601.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2026.601.0" />
-        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2026.601.0" />
+        <PackageReference Include="ppy.osu.Game" Version="2026.605.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2026.605.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2026.605.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2026.605.0" />
+        <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2026.605.0" />
         <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2026.317.0" />
     </ItemGroup>
 


### PR DESCRIPTION
- Part of https://github.com/ppy/osu/issues/37818
- [x] Depends on NuGet package containing https://github.com/ppy/osu/pull/37967

## [Fix populate total score without mods command always using latest version of multiplier calculator](https://github.com/ppy/osu-queue-score-statistics/commit/c9fc3c937bf26f9e7471feb0e73c2db91ad264d4)

The fix is somewhat dicey, but as per inline commentary, my hope is that it being dicey is not relevant anymore, because we won't need this command again.

## [Adjust score multiplier recalculation tests to work with new multipliers](https://github.com/ppy/osu-queue-score-statistics/commit/a2d9d65577d17866701f773a892c2e0a91a55a83)

Self-explanatory, relevant calculations included as inline comments.