### PR TITLE
Add server-side revalidation of total score matching active mods

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -187,6 +187,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                     { HitResult.Great, 5 },
                     { HitResult.LargeBonus, 2 }
                 },
+                TotalScoreWithoutMods = 100000,
             };
 
             row.ScoreData = scoreData;

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ManiaKeyModeUserStatsProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ManiaKeyModeUserStatsProcessorTests.cs
@@ -174,7 +174,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             SetScoreForBeatmap(beatmap4K.beatmap_id, s =>
             {
                 s.Score.ranked = s.Score.preserve = true;
-                s.Score.total_score = 500_000;
+                s.Score.ScoreData.TotalScoreWithoutMods = s.Score.total_score = 500_000;
                 s.Score.rank = ScoreRank.A;
                 s.Score.ruleset_id = 3;
             });
@@ -184,7 +184,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             SetScoreForBeatmap(beatmap4K.beatmap_id, s =>
             {
                 s.Score.ranked = s.Score.preserve = true;
-                s.Score.total_score = 300_000; // same map and keymode as above, lower score => should not count
+                s.Score.ScoreData.TotalScoreWithoutMods = s.Score.total_score = 300_000; // same map and keymode as above, lower score => should not count
                 s.Score.rank = ScoreRank.S;
                 s.Score.ruleset_id = 3;
             });
@@ -194,7 +194,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             SetScoreForBeatmap(beatmap4K.beatmap_id, s =>
             {
                 s.Score.ranked = s.Score.preserve = true;
-                s.Score.total_score = 700_000; // same map and keymode as above, higher score => should count
+                s.Score.ScoreData.TotalScoreWithoutMods = s.Score.total_score = 700_000; // same map and keymode as above, higher score => should count
                 s.Score.rank = ScoreRank.S;
                 s.Score.ruleset_id = 3;
             });
@@ -204,7 +204,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             SetScoreForBeatmap(beatmap7K.beatmap_id, s =>
             {
                 s.Score.ranked = s.Score.preserve = true;
-                s.Score.total_score = 200_000;
+                s.Score.ScoreData.TotalScoreWithoutMods = s.Score.total_score = 200_000;
                 s.Score.ruleset_id = 3;
                 s.Score.rank = ScoreRank.A;
             });
@@ -235,7 +235,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             SetScoreForBeatmap(beatmap4K.beatmap_id, s =>
             {
                 s.Score.ranked = s.Score.preserve = true;
-                s.Score.total_score = 500_000;
+                s.Score.ScoreData.TotalScoreWithoutMods = s.Score.total_score = 500_000;
                 s.Score.rank = ScoreRank.A;
                 s.Score.ruleset_id = 3;
             });
@@ -245,7 +245,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             SetScoreForBeatmap(beatmap4K.beatmap_id, s =>
             {
                 s.Score.ranked = s.Score.preserve = true;
-                s.Score.total_score = 300_000; // same map and keymode as above, lower score => should not count
+                s.Score.ScoreData.TotalScoreWithoutMods = s.Score.total_score = 300_000; // same map and keymode as above, lower score => should not count
                 s.Score.rank = ScoreRank.S;
                 s.Score.ruleset_id = 3;
             });
@@ -255,7 +255,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             SetScoreForBeatmap(beatmap4K.beatmap_id, s =>
             {
                 s.Score.ranked = s.Score.preserve = true;
-                s.Score.total_score = 700_000; // same map and keymode as above, higher score => should count
+                s.Score.ScoreData.TotalScoreWithoutMods = s.Score.total_score = 700_000; // same map and keymode as above, higher score => should count
                 s.Score.rank = ScoreRank.S;
                 s.Score.ruleset_id = 3;
             });

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MarkNonPreservedScoresCommandTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MarkNonPreservedScoresCommandTest.cs
@@ -29,19 +29,19 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             SetScoreForBeatmap(beatmap.beatmap_id, s =>
             {
                 s.Score.id = 1;
-                s.Score.total_score = 800_000;
+                s.Score.ScoreData.TotalScoreWithoutMods = s.Score.total_score = 800_000;
                 s.Score.pp = 95;
             });
             SetScoreForBeatmap(beatmap.beatmap_id, s =>
             {
                 s.Score.id = 2;
-                s.Score.total_score = 850_000;
+                s.Score.ScoreData.TotalScoreWithoutMods = s.Score.total_score = 850_000;
                 s.Score.pp = 90;
             });
             SetScoreForBeatmap(beatmap.beatmap_id, s =>
             {
                 s.Score.id = 3;
-                s.Score.total_score = 500_000;
+                s.Score.ScoreData.TotalScoreWithoutMods = s.Score.total_score = 500_000;
                 s.Score.pp = 85;
             });
             WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 1", 3, CancellationToken);

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/RankedScoreProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/RankedScoreProcessorTests.cs
@@ -78,7 +78,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             SetScoreForBeatmap(TEST_BEATMAP_ID, s => s.Score.ranked = false);
             waitForRankedScore("osu_user_stats", 0);
 
-            SetScoreForBeatmap(TEST_BEATMAP_ID, s => s.Score.total_score = 50000);
+            SetScoreForBeatmap(TEST_BEATMAP_ID, s => s.Score.ScoreData.TotalScoreWithoutMods = s.Score.total_score = 50000);
             waitForRankedScore("osu_user_stats", 5041);
         }
 
@@ -139,7 +139,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             SetScoreForBeatmap(TEST_BEATMAP_ID, score =>
             {
-                score.Score.total_score = 50000;
+                score.Score.ScoreData.TotalScoreWithoutMods = score.Score.total_score = 50000;
                 score.Score.ScoreData.Statistics[HitResult.Perfect] = 0;
                 score.Score.ScoreData.Statistics[HitResult.Ok] = 5;
             });
@@ -175,7 +175,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             SetScoreForBeatmap(TEST_BEATMAP_ID, score =>
             {
-                score.Score.total_score = 50000;
+                score.Score.ScoreData.TotalScoreWithoutMods = score.Score.total_score = 50000;
                 score.Score.ScoreData.Statistics[HitResult.Perfect] = 0;
                 score.Score.ScoreData.Statistics[HitResult.Ok] = 5;
             });
@@ -206,7 +206,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             var secondScore = SetScoreForBeatmap(TEST_BEATMAP_ID, score =>
             {
-                score.Score.total_score = 50000;
+                score.Score.ScoreData.TotalScoreWithoutMods = score.Score.total_score = 50000;
                 score.Score.ScoreData.Statistics[HitResult.Perfect] = 0;
                 score.Score.ScoreData.Statistics[HitResult.Ok] = 5;
             });

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ScoreMultiplierRecalculationTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ScoreMultiplierRecalculationTest.cs
@@ -136,11 +136,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var recalculateCommand = new RecalculateModMultipliersCommand { StartId = score.id };
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 1001683, CancellationToken, score);
+            // `StandardisedScoreMigrationTools.UpdateFromLegacy()` calculates `TotalScoreWithoutMods` as 894871
+            // 894871 * 1.23 (DT) * 1.09 (HR) * 0.985 (CL) = 1181757.2464545 ≈ 1181757
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 1181757, CancellationToken, score);
 
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 1001683, CancellationToken, score);
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 1181757, CancellationToken, score);
         }
 
         /// <summary>
@@ -237,11 +239,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var recalculateCommand = new RecalculateModMultipliersCommand { StartId = score.id };
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 239050, CancellationToken, score);
+            // 452747 * 1.23 (DT) * 0.8 (EZ) * 0.985 (CL) = 438820.50228 ≈ 438821
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 438821, CancellationToken, score);
 
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 239050, CancellationToken, score);
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 438821, CancellationToken, score);
         }
 
         /// <summary>
@@ -327,7 +330,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var recalculateCommand = new RecalculateModMultipliersCommand { StartId = score.id };
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 417278, CancellationToken, score);
+            // `StandardisedScoreMigrationTools.UpdateFromLegacy()` calculates `TotalScoreWithoutMods` as 434665
+            // 434665 * 0.985 (CL) = 428145.025 ≈ 428145
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 428145, CancellationToken, score);
         }
 
         /// <summary>
@@ -525,11 +530,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var recalculateCommand = new RecalculateModMultipliersCommand { StartId = score.id };
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 200732, CancellationToken, score);
+            // 364967 * 0.5 (NF) * 1.23 (DT) = 224454.705 ≈ 224455
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 224455, CancellationToken, score);
 
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 200732, CancellationToken, score);
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 224455, CancellationToken, score);
         }
 
         /// <summary>
@@ -724,11 +730,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var recalculateCommand = new RecalculateModMultipliersCommand { StartId = score.id };
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 468585, CancellationToken, score);
+            // 379126 * 1.09 (HR) * 1.23 (NC) * 1.04 (HD) = 528625.997328 ≈ 528626
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 528626, CancellationToken, score);
 
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 468585, CancellationToken, score);
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 528626, CancellationToken, score);
         }
 
         /// <summary>
@@ -827,11 +834,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var recalculateCommand = new RecalculateModMultipliersCommand { StartId = score.id };
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 84678, CancellationToken, score);
+            // 156811 * 1.174 (NC 1.49x) * 0.65 (DA, AR portion) * 0.75 (DA, OD portion) = 89746.855575 ≈ 89747
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 89747, CancellationToken, score);
 
             await recalculateCommand.OnExecuteAsync(CancellationToken);
 
-            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 84678, CancellationToken, score);
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 89747, CancellationToken, score);
         }
 
         /// <summary>

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ScoreMultiplierValidatorTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ScoreMultiplierValidatorTest.cs
@@ -1,0 +1,112 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Online.API;
+using osu.Game.Rulesets.Osu.Difficulty;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using Xunit;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
+{
+    public class ScoreMultiplierValidatorTest : DatabaseTest
+    {
+        private readonly Beatmap beatmap;
+
+        public ScoreMultiplierValidatorTest()
+        {
+            beatmap = AddBeatmap(b =>
+            {
+                b.diff_size = 3;
+                b.diff_approach = 4;
+                b.diff_drain = 5;
+                b.diff_overall = 6;
+            });
+            AddBeatmapAttributes<OsuDifficultyAttributes>(beatmap.beatmap_id, attr => attr.Mods = [new OsuModDoubleTime()]);
+        }
+
+        [Fact]
+        public void TestScoreWhereTotalScoreWithoutModsIsMissingIsRejected()
+        {
+            using var conn = Processor.GetDatabaseConnection();
+            var score = CreateTestScore(0, beatmap.beatmap_id);
+            score.Score.ScoreData.TotalScoreWithoutMods = null;
+            InsertScore(conn, score);
+
+            Processor.PushToQueue(score);
+            WaitForDatabaseState("SELECT `ranked` FROM `scores` WHERE `id` = @id", 0, CancellationToken, new { score.Score.id });
+            WaitForDatabaseState("SELECT `total_score` FROM `osu_user_stats` WHERE user_id = 2", 0, CancellationToken);
+        }
+
+        [Fact]
+        public void TestScoreWhereTotalScoreWithoutModsMismatchesTotalScoreIsAdjustedAutomatically()
+        {
+            using var conn = Processor.GetDatabaseConnection();
+            var score = CreateTestScore(0, beatmap.beatmap_id);
+            score.Score.ScoreData.TotalScoreWithoutMods = 1_000_000;
+            score.Score.ScoreData.Mods = [new APIMod(new OsuModDoubleTime())];
+            score.Score.total_score = 1_100_000;
+            InsertScore(conn, score);
+
+            PushToQueueAndWaitForProcess(score);
+            WaitForDatabaseState("SELECT `total_score` FROM `scores` WHERE `id` = @id", 1_230_000, CancellationToken, new { score.Score.id });
+            // classic score = round(100814.25 * standardised score / 1000000)
+            WaitForDatabaseState("SELECT `total_score` FROM `osu_user_stats` WHERE user_id = 2", 124_002, CancellationToken);
+        }
+
+        [Fact]
+        public void TestScoreWhereTotalScoreWithoutModsIsCorrectIsUntouched()
+        {
+            using var conn = Processor.GetDatabaseConnection();
+            var score = CreateTestScore(0, beatmap.beatmap_id);
+            score.Score.ScoreData.TotalScoreWithoutMods = 1_000_000;
+            score.Score.ScoreData.Mods = [new APIMod(new OsuModDoubleTime())];
+            score.Score.total_score = 1_230_000;
+            InsertScore(conn, score);
+
+            PushToQueueAndWaitForProcess(score);
+            WaitForDatabaseState("SELECT `total_score` FROM `scores` WHERE `id` = @id", 1_230_000, CancellationToken, new { score.Score.id });
+            // classic score = round(100814.25 * standardised score / 1000000)
+            WaitForDatabaseState("SELECT `total_score` FROM `osu_user_stats` WHERE user_id = 2", 124_002, CancellationToken);
+        }
+
+        [Fact]
+        public void TestModsWithSettings()
+        {
+            using var conn = Processor.GetDatabaseConnection();
+            var score = CreateTestScore(0, beatmap.beatmap_id);
+            score.Score.ScoreData.TotalScoreWithoutMods = 1_000_000;
+            score.Score.ScoreData.Mods = [new APIMod(new OsuModNightcore { SpeedChange = { Value = 2 } }), new APIMod(new OsuModHidden { OnlyFadeApproachCircles = { Value = true } })];
+            score.Score.total_score = 1_200_000;
+            InsertScore(conn, score);
+
+            Processor.PushToQueue(score);
+            WaitForDatabaseState("SELECT `total_score` FROM `scores` WHERE `id` = @id", 1_479_000, CancellationToken, new { score.Score.id });
+            // classic score = round(100814.25 * standardised score / 1000000)
+            WaitForDatabaseState("SELECT `total_score` FROM `osu_user_stats` WHERE user_id = 2", 149_104, CancellationToken);
+        }
+
+        [Fact]
+        public void TestDifficultyAdjust()
+        {
+            using var conn = Processor.GetDatabaseConnection();
+            var score = CreateTestScore(0, beatmap.beatmap_id);
+            score.Score.ScoreData.TotalScoreWithoutMods = 1_000_000;
+            score.Score.ScoreData.Mods =
+            [
+                new APIMod(new OsuModDifficultyAdjust
+                {
+                    ApproachRate = { Value = 4.2f },
+                    CircleSize = { Value = 3.5f },
+                })
+            ];
+            score.Score.total_score = 500_000;
+            InsertScore(conn, score);
+
+            Processor.PushToQueue(score);
+            WaitForDatabaseState("SELECT `total_score` FROM `scores` WHERE `id` = @id", 675_000, CancellationToken, new { score.Score.id });
+            // classic score = round(100814.25 * standardised score / 1000000)
+            WaitForDatabaseState("SELECT `total_score` FROM `osu_user_stats` WHERE user_id = 2", 68050, CancellationToken);
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/TotalScoreProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/TotalScoreProcessorTests.cs
@@ -163,7 +163,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             {
                 [HitResult.LargeBonus] = int.MaxValue
             };
-            score.Score.total_score = 5_000_010;
+            score.Score.ScoreData.TotalScoreWithoutMods = score.Score.total_score = 5_000_010;
             score.Score.started_at = DateTimeOffset.Now;
             score.Score.ended_at = score.Score.started_at.Value.AddSeconds(1);
 
@@ -193,7 +193,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             {
                 [HitResult.LargeBonus] = int.MaxValue
             };
-            score.Score.total_score = 5_000_010;
+            score.Score.ScoreData.TotalScoreWithoutMods = score.Score.total_score = 5_000_010;
             score.Score.started_at = DateTimeOffset.Now;
             score.Score.ended_at = score.Score.started_at.Value.AddSeconds(1);
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/UserRankCountProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/UserRankCountProcessorTests.cs
@@ -178,7 +178,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
             {
                 item.Score.rank = ScoreRank.A;
-                item.Score.total_score = 600_000;
+                item.Score.ScoreData.TotalScoreWithoutMods = item.Score.total_score = 600_000;
             });
             waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
             {
@@ -188,7 +188,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
             {
                 item.Score.rank = ScoreRank.X;
-                item.Score.total_score = 500_000;
+                item.Score.ScoreData.TotalScoreWithoutMods = item.Score.total_score = 500_000;
             });
             waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
             {
@@ -348,7 +348,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
             {
                 item.Score.rank = ScoreRank.A;
-                item.Score.total_score = 700_000;
+                item.Score.ScoreData.TotalScoreWithoutMods = item.Score.total_score = 700_000;
             });
             waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>
             {
@@ -358,7 +358,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             var secondScore = SetScoreForBeatmap(TEST_BEATMAP_ID, item =>
             {
                 item.Score.rank = ScoreRank.X;
-                item.Score.total_score = 600_000;
+                item.Score.ScoreData.TotalScoreWithoutMods = item.Score.total_score = 600_000;
             });
 
             waitForRankCounts("osu_user_stats", new Dictionary<ScoreRank, int>

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/PopulateTotalScoreWithoutModsCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/PopulateTotalScoreWithoutModsCommand.cs
@@ -118,6 +118,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                         throw new InvalidOperationException($"Aborting: score {score.id} has missing or invalid build ID of {score.build_id}!");
 
                     scoreInfo.ClientVersion = buildVersion;
+                    // This is hardcoding the total score version preceding the first (and simultaneously last, at time of writing) mod multiplier rebalance.
+                    // This information cannot be easily populated using the `scores` table alone, as it's only in replays,
+                    // and so the simplest thing to do is to hardcode it.
+                    // This command should hopefully be never needed again at the time of writing (as it has already been run on production),
+                    // but if it is, this hardcoding should be HEAVILY scrutinised in terms of its correctness.
+                    scoreInfo.TotalScoreVersion = 30000016;
 
                     var ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(scoreInfo.RulesetID);
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/IProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/IProcessor.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using MySqlConnector;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using StatsdClient;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor
 {
@@ -39,7 +40,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         /// <param name="conn">Database connection to use when executing queries and commands.</param>
         /// <param name="transaction">Ongoing database transactions.</param>
         /// <param name="postTransactionActions">Queue of relevant actions to execute after the transaction ends.</param>
-        void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions);
+        /// <param name="dogStatsd">Instance of <see cref="DogStatsdService"/> to use for collecting metrics.</param>
+        void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+                                 DogStatsdService dogStatsd);
 
         /// <summary>
         /// Applies the effect of <paramref name="score"/> to all relevant statistics.
@@ -49,7 +52,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         /// <param name="conn">Database connection to use when executing queries and commands.</param>
         /// <param name="transaction">Ongoing database transactions.</param>
         /// <param name="postTransactionActions">Queue of relevant actions to execute after the transaction ends.</param>
-        void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions);
+        /// <param name="dogStatsd">Instance of <see cref="DogStatsdService"/> to use for collecting metrics.</param>
+        void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd);
 
         /// <summary>
         /// Adjust any global statistics outside of the user transaction.

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/HighBeatmapLeaderboardRankEventEmitter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/HighBeatmapLeaderboardRankEventEmitter.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 using MySqlConnector;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using StatsdClient;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 {
@@ -28,12 +29,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         /// </remarks>
         public bool RunOnLegacyScores => true;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+                                        DogStatsdService dogStatsd)
         {
             // not applicable because `ApplyToUserStats()` does nothing.
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
         {
             // not applicable.
             // this processor is pretty much an orchestrator of external calls based on a few db queries

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/HitStatisticsProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/HitStatisticsProcessor.cs
@@ -7,6 +7,7 @@ using JetBrains.Annotations;
 using MySqlConnector;
 using osu.Game.Rulesets.Scoring;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using StatsdClient;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 {
@@ -20,13 +21,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnLegacyScores => false;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+                                        DogStatsdService dogStatsd)
         {
             if (previousVersion >= 2)
                 adjustStatisticsFromScore(score, userStats, true);
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
         {
             adjustStatisticsFromScore(score, userStats);
         }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/LastPlayedDateProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/LastPlayedDateProcessor.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using JetBrains.Annotations;
 using MySqlConnector;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using StatsdClient;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 {
@@ -19,11 +20,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         public bool RunOnFailedScores => true;
         public bool RunOnLegacyScores => false;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+                                        DogStatsdService dogStatsd)
         {
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
         {
             if (userStats.last_played < score.ended_at || userStats.playcount == 0)
                 userStats.last_played = score.ended_at;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ManiaKeyModeUserStatsProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ManiaKeyModeUserStatsProcessor.cs
@@ -15,6 +15,7 @@ using osu.Game.Scoring;
 using osu.Game.Scoring.Legacy;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using StatsdClient;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 {
@@ -26,11 +27,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         public bool RunOnFailedScores => false;
         public bool RunOnLegacyScores => true;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+                                        DogStatsdService dogStatsd)
         {
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats fullRulesetStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void ApplyToUserStats(SoloScore score, UserStats fullRulesetStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
         {
             if (score.ruleset_id != 3)
                 return;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MaxComboProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MaxComboProcessor.cs
@@ -10,6 +10,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using StatsdClient;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 {
@@ -23,12 +24,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnLegacyScores => false;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+                                        DogStatsdService dogStatsd)
         {
             // TODO: this will require access to stable scores to be implemented correctly.
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
         {
             Ruleset ruleset = ScoreStatisticsQueueProcessor.AVAILABLE_RULESETS.Single(r => r.RulesetInfo.OnlineID == score.ruleset_id);
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
@@ -12,6 +12,7 @@ using MySqlConnector;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using StatsdClient;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 {
@@ -50,11 +51,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         // This processor needs to run after the play count and hit statistics have been applied, at very least.
         public int Order => int.MaxValue - 1;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+                                        DogStatsdService dogStatsd)
         {
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
         {
             if (score.beatmap!.approved <= 0)
                 return;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
@@ -11,6 +11,7 @@ using osu.Framework.Development;
 using osu.Framework.Utils;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using StatsdClient;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 {
@@ -26,7 +27,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnLegacyScores => false;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+                                        DogStatsdService dogStatsd)
         {
             if (previousVersion >= 1)
                 userStats.playcount--;
@@ -38,7 +40,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             }
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
         {
             const int beatmap_count = 12;
             const int over_time = 120;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
@@ -7,6 +7,7 @@ using JetBrains.Annotations;
 using MySqlConnector;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using StatsdClient;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 {
@@ -20,7 +21,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnLegacyScores => false;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+                                        DogStatsdService dogStatsd)
         {
             int lengthInSeconds = PlayValidityHelper.GetPlayLength(score);
 
@@ -28,7 +30,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 userStats.total_seconds_played -= lengthInSeconds;
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
         {
             int lengthInSeconds = PlayValidityHelper.GetPlayLength(score);
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/RankedScoreProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/RankedScoreProcessor.cs
@@ -10,6 +10,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring.Legacy;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using StatsdClient;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 {
@@ -20,7 +21,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnLegacyScores => false;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+                                        DogStatsdService dogStatsd)
         {
             if (!score.BeatmapValidForRankedCounts())
                 return;
@@ -45,7 +47,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             }
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
         {
             if (!score.BeatmapValidForRankedCounts())
                 return;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScoreMultiplierValidator.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScoreMultiplierValidator.cs
@@ -1,0 +1,57 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Dapper;
+using JetBrains.Annotations;
+using MySqlConnector;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Scoring;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
+{
+    [UsedImplicitly]
+    public class ScoreMultiplierValidator : IProcessor
+    {
+        public bool RunOnFailedScores => true;
+        public bool RunOnLegacyScores => true;
+
+        // Must run before any processor that reads total score.
+        public int Order => int.MinValue;
+
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        {
+        }
+
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        {
+            if (score.ScoreData.TotalScoreWithoutMods is not long totalScoreWithoutMods)
+            {
+                // TODO: probably add some visibility measure to track how often this is happening
+                throw new ProcessingAbortedException("Score is missing total score without mods.");
+            }
+
+            Ruleset ruleset = ScoreStatisticsQueueProcessor.AVAILABLE_RULESETS.Single(r => r.RulesetInfo.OnlineID == score.ruleset_id);
+            var scoreMultiplierCalculator = ruleset.CreateScoreMultiplierCalculator(new ScoreMultiplierContext(score.beatmap!.GetLegacyBeatmapConversionDifficultyInfo()));
+            uint expectedTotalScore = (uint)Math.Round(totalScoreWithoutMods * scoreMultiplierCalculator.CalculateFor(score.ScoreData.Mods.Select(m => m.ToMod(ruleset))));
+
+            if (expectedTotalScore != score.total_score)
+            {
+                // TODO: probably add some visibility measure to track how often this is happening
+                score.total_score = expectedTotalScore;
+                conn.Execute(@"UPDATE `scores` SET `total_score` = @expectedTotal WHERE `id` = @id", new
+                {
+                    expectedTotal = expectedTotalScore,
+                    id = score.id,
+                }, transaction);
+            }
+        }
+
+        public void ApplyGlobal(SoloScore score, MySqlConnection conn)
+        {
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScoreMultiplierValidator.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScoreMultiplierValidator.cs
@@ -10,6 +10,7 @@ using MySqlConnector;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Scoring;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using StatsdClient;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 {
@@ -22,11 +23,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         // Must run before any processor that reads total score.
         public int Order => int.MinValue;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+                                        DogStatsdService dogStatsd)
         {
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
         {
             if (score.ScoreData.TotalScoreWithoutMods is not long totalScoreWithoutMods)
             {

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScoreMultiplierValidator.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScoreMultiplierValidator.cs
@@ -17,6 +17,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
     [UsedImplicitly]
     public class ScoreMultiplierValidator : IProcessor
     {
+        private const string scores_modified_metric = $@"{nameof(ScoreMultiplierValidator)}.scores_modified";
+
         public bool RunOnFailedScores => true;
         public bool RunOnLegacyScores => true;
 
@@ -32,7 +34,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         {
             if (score.ScoreData.TotalScoreWithoutMods is not long totalScoreWithoutMods)
             {
-                // TODO: probably add some visibility measure to track how often this is happening
+                dogStatsd.Increment(scores_modified_metric, tags: ["unranked"]);
                 throw new ProcessingAbortedException("Score is missing total score without mods.");
             }
 
@@ -42,13 +44,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
             if (expectedTotalScore != score.total_score)
             {
-                // TODO: probably add some visibility measure to track how often this is happening
                 score.total_score = expectedTotalScore;
                 conn.Execute(@"UPDATE `scores` SET `total_score` = @expectedTotal WHERE `id` = @id", new
                 {
                     expectedTotal = expectedTotalScore,
                     id = score.id,
                 }, transaction);
+                dogStatsd.Increment(scores_modified_metric, tags: ["total_score_corrected"]);
             }
         }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -14,6 +14,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 using osu.Server.Queues.ScoreStatisticsProcessor.Stores;
+using StatsdClient;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 {
@@ -38,11 +39,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         private static readonly bool write_legacy_score_pp = Environment.GetEnvironmentVariable("WRITE_LEGACY_SCORE_PP") != "0";
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+                                        DogStatsdService dogStatsd)
         {
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
         {
             ProcessScoreAsync(score, conn, transaction).Wait();
         }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/TotalScoreProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/TotalScoreProcessor.cs
@@ -10,6 +10,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring.Legacy;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using StatsdClient;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 {
@@ -23,7 +24,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnLegacyScores => false;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+                                        DogStatsdService dogStatsd)
         {
             if (previousVersion < 2)
                 return;
@@ -44,7 +46,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             userStats.level = calculateLevel(userStats.total_score);
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
         {
             long classicTotalScore = score.ToScoreInfo().GetDisplayScore(ScoringMode.Classic);
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
@@ -10,6 +10,7 @@ using osu.Game.Scoring;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 using Sentry;
+using StatsdClient;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 {
@@ -23,7 +24,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnLegacyScores => true;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+                                        DogStatsdService dogStatsd)
         {
             if (!score.BeatmapValidForRankedCounts())
                 return;
@@ -48,7 +50,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             }
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
         {
             if (!score.BeatmapValidForRankedCounts())
                 return;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Caching.Memory;
 using MySqlConnector;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using StatsdClient;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 {
@@ -30,11 +31,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         private readonly ConcurrentDictionary<int, MemoryCache> rankScoreIndexPartitionCache =
             new ConcurrentDictionary<int, MemoryCache>();
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+                                        DogStatsdService dogStatsd)
         {
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
         {
             var dbInfo = LegacyDatabaseHelper.GetRulesetSpecifics(score.ruleset_id);
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
@@ -225,7 +225,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
                                 byte version = item.ProcessHistory.processed_version;
 
                                 foreach (var p in enumerateValidProcessors(score))
-                                    p.RevertFromUserStats(score, userStats, version, conn, transaction, postTransactionActions);
+                                    p.RevertFromUserStats(score, userStats, version, conn, transaction, postTransactionActions, DogStatsd);
                             }
                             else
                             {
@@ -240,7 +240,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
 
                                 try
                                 {
-                                    p.ApplyToUserStats(score, userStats, conn, transaction, postTransactionActions);
+                                    p.ApplyToUserStats(score, userStats, conn, transaction, postTransactionActions, DogStatsd);
                                 }
                                 catch (ProcessingAbortedException abortException)
                                 {


### PR DESCRIPTION
- Part of https://github.com/ppy/osu/issues/37818
- [x] Depends on https://github.com/ppy/osu-queue-score-statistics/pull/378 for mergeability
- [x] Will want to re-test locally in practice again with old and new clients, it's annoying to do without the above

This PR adds a processor that checks whether for incoming scores `data->'$.total_score_without_mods'` matches `total_score` as defined by the latest score multiplier calculator. This allows an instant cutoff rollout of the new multipliers for all incoming scores without needing to wait on client rollouts.

- If `total_score` does not match `total_score_without_mods`, `total_score` is rewritten based on `total_score_without_mods` and the active mods for the score.
- If `total_score_without_mods` is missing, the score is marked unranked. Production was checked for this, and there have been no incoming legitimate scores without `total_score_without_mods` for more than a year now.

Of particular note, this processor must run *before* everything else, because of data dependencies. Other processors read and do things with `total_score`, such as add it to profile ranked score, or check it for medal purposes, and so on.

The processor is instrumented with a Datadog counter of scores it rewrote. For this counter I had to commit https://github.com/ppy/osu-queue-score-statistics/commit/19c343dd2bd788e232ba5ffc65a65bf6b488e7bf because otherwise it's kind of not possible to log things with the correct Datadog prefix.