### PR TITLE
Skip mod multiplier updates for rows with suspiciously high result

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ScoreMultiplierRecalculationTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ScoreMultiplierRecalculationTest.cs
@@ -1231,6 +1231,32 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         }
 
         [Fact]
+        public async Task TestRecalculationSkippedWithoutCrashWhenTotalScoreTooHigh()
+        {
+            using var conn = Processor.GetDatabaseConnection();
+
+            var beatmap = AddBeatmap(b =>
+            {
+                b.beatmap_id = 5245944;
+            });
+
+            var score = CreateTestScore();
+            score.Score.beatmap_id = beatmap.beatmap_id;
+            score.Score.ScoreData.Mods = [new APIMod(new OsuModDoubleTime())];
+            score.Score.ScoreData.TotalScoreWithoutMods = uint.MaxValue;
+            score.Score.total_score = uint.MaxValue;
+            InsertScore(conn, score);
+
+            var populateCommand = new PopulateTotalScoreWithoutModsCommand { StartId = score.Score.id };
+            await populateCommand.OnExecuteAsync(CancellationToken);
+
+            var recalculateCommand = new RecalculateModMultipliersCommand { StartId = score.Score.id };
+            await recalculateCommand.OnExecuteAsync(CancellationToken);
+
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", uint.MaxValue, CancellationToken, score.Score);
+        }
+
+        [Fact]
         public async Task TestPopulateTotalScoreWithoutModsCommandDoesNothingWhenDryRun()
         {
             using var conn = Processor.GetDatabaseConnection();

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/RecalculateModMultipliersCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/RecalculateModMultipliersCommand.cs
@@ -158,6 +158,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                         continue;
                     }
 
+                    if (newTotalScore > 5_000_000)
+                    {
+                        if (Verbose)
+                            Console.WriteLine($"[{score.id,11} {source}] Skipped due to suspiciously high score");
+                        skipped++;
+                        continue;
+                    }
+
                     if (Verbose)
                         Console.WriteLine($"[{score.id,11} {source}] Updating score: {oldTotalScore,8} (old) -> {newTotalScore,8} (new)");
 


### PR DESCRIPTION
It's a very targeted fix but due to the update batching not much better can be done. If you try-catch the update on the entire batch and log failure, other scores from the batch won't get updated even though they could. So it's either this or very annoying logic to somehow divine which score precisely blew up the update statement and then retroactively excluding it from the batch and then trying the batch again.