### PR TITLE
Fix some discrepancies in score multiplier recalculation pieces

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ScoreMultiplierRecalculationTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ScoreMultiplierRecalculationTest.cs
@@ -1416,5 +1416,83 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 987248, CancellationToken, score);
         }
+
+        [Fact]
+        public async Task TestStableScoreImportedInBrokenStateIsLeftAlone()
+        {
+            using var conn = Processor.GetDatabaseConnection();
+
+            var beatmap = AddBeatmap(b =>
+            {
+                b.beatmap_id = 4451949;
+                b.total_length = 287;
+                b.hit_length = 266;
+                b.countTotal = 6151;
+                b.countNormal = 6151;
+                b.countSlider = 0;
+                b.countSpinner = 0;
+                b.diff_drain = 8;
+                b.diff_size = 4;
+                b.diff_overall = 8;
+                b.diff_approach = 5;
+                b.playmode = 3;
+                b.approved = BeatmapOnlineStatus.Graveyard;
+                b.difficultyrating = 6.57933f;
+            });
+            await conn.ExecuteAsync(
+                """
+                INSERT INTO `osu_beatmap_scoring_attribs`
+                    (`beatmap_id`, `mode`, `legacy_accuracy_score`, `legacy_combo_score`, `legacy_bonus_score_ratio`, `legacy_bonus_score`, `max_combo`)
+                VALUES
+                    (4451949, 3, 0, 1000000, 0, 0, 0)
+                """);
+
+            var score = new SoloScore
+            {
+                // https://osu.ppy.sh/scores/3901512042
+                id = 6895750096,
+                user_id = 31502117,
+                ruleset_id = 3,
+                beatmap_id = beatmap.beatmap_id,
+                has_replay = false,
+                preserve = false,
+                ranked = false,
+                rank = ScoreRank.D,
+                passed = true,
+                accuracy = 0,
+                max_combo = 643,
+                total_score = 0,
+                ScoreData = new SoloScoreData
+                {
+                    Mods = [new APIMod(new ManiaModClassic())],
+                    Statistics =
+                    {
+                        [HitResult.Ok] = 112,
+                        [HitResult.Meh] = 10,
+                        [HitResult.Good] = 573,
+                        [HitResult.Miss] = 146,
+                        [HitResult.Great] = 2126,
+                        [HitResult.Perfect] = 3184,
+                    },
+                    MaximumStatistics =
+                    {
+                        [HitResult.Perfect] = 6151,
+                    },
+                },
+                pp = null,
+                legacy_score_id = 0,
+                legacy_total_score = 741164,
+                started_at = null,
+                ended_at = new DateTimeOffset(2026, 6, 17, 6, 41, 16, TimeSpan.Zero),
+                build_id = null,
+            };
+
+            InsertScore(conn, new ScoreItem(score, new ProcessHistory()));
+
+            var recalculateCommand = new RecalculateModMultipliersCommand { StartId = score.id };
+            await recalculateCommand.OnExecuteAsync(CancellationToken);
+
+            WaitForDatabaseState(@"SELECT `total_score` FROM `scores` WHERE `id` = @id", 0, CancellationToken, score);
+        }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ScoreMultiplierValidatorTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ScoreMultiplierValidatorTest.cs
@@ -1,9 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Game.Online.API;
 using osu.Game.Rulesets.Osu.Difficulty;
 using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Scoring;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 using Xunit;
 
@@ -107,6 +109,26 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             WaitForDatabaseState("SELECT `total_score` FROM `scores` WHERE `id` = @id", 675_000, CancellationToken, new { score.Score.id });
             // classic score = round(100814.25 * standardised score / 1000000)
             WaitForDatabaseState("SELECT `total_score` FROM `osu_user_stats` WHERE user_id = 2", 68050, CancellationToken);
+        }
+
+        [Fact]
+        public void TestVeryShortScore()
+        {
+            using var conn = Processor.GetDatabaseConnection();
+            var score = CreateTestScore(0, beatmap.beatmap_id);
+            score.Score.ScoreData.TotalScoreWithoutMods = 100;
+            score.Score.ScoreData.Mods = [new APIMod(new OsuModDoubleTime())];
+            score.Score.ScoreData.Statistics = new Dictionary<HitResult, int> { [HitResult.Great] = 3 };
+            score.Score.ScoreData.MaximumStatistics = new Dictionary<HitResult, int> { [HitResult.Great] = 3000 };
+            score.Score.total_score = 110;
+            score.Score.ended_at = score.Score.started_at!.Value.AddSeconds(5);
+            score.Score.passed = false;
+            InsertScore(conn, score);
+
+            Processor.PushToQueue(score);
+            WaitForDatabaseState("SELECT `total_score` FROM `scores` WHERE `id` = @id", 123, CancellationToken, new { score.Score.id });
+            // classic score is not updated as score is too short
+            WaitForDatabaseState("SELECT `total_score` FROM `osu_user_stats` WHERE user_id = 2", 0, CancellationToken);
         }
     }
 }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/RecalculateModMultipliersCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/RecalculateModMultipliersCommand.cs
@@ -121,6 +121,19 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
 
                     if (score.is_legacy_score)
                     {
+                        // this guard is designed to catch scenarios such as:
+                        // https://github.com/ppy/osu-queue-score-statistics/blob/c538ae9523b5e15145483f72a903b8a88f33733f/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/BatchInserter.cs#L340-L345
+                        // https://github.com/ppy/osu-queue-score-statistics/blob/c538ae9523b5e15145483f72a903b8a88f33733f/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/BatchInserter.cs#L364-L369
+                        // in particular the guards below get hit when importing non-high stable scores, which will have `legacy_score_id == 0` from
+                        // https://github.com/ppy/osu-queue-score-statistics/blob/c538ae9523b5e15145483f72a903b8a88f33733f/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/BatchInserter.cs#L187-L190
+                        if (score.legacy_score_id == 0 && !score.preserve && score.total_score == 0)
+                        {
+                            if (Verbose)
+                                Console.WriteLine($"[{score.id,11} {source}] Skipped due to being broken non-preserved imported score");
+                            skipped++;
+                            continue;
+                        }
+
                         var scoringAttributes = BatchInserter.GetCachedScoringAttributes(new BatchInserter.BeatmapLookup((int)score.beatmap_id, score.ruleset_id), conn)?.ToAttributes();
 
                         if (scoringAttributes == null)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/IProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/IProcessor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using MySqlConnector;
 using osu.Framework.Extensions.TypeExtensions;
+using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 using StatsdClient;
 
@@ -30,6 +31,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         /// Whether this processor should be run on imported legacy scores.
         /// </summary>
         bool RunOnLegacyScores { get; }
+
+        /// <summary>
+        /// Whether this processor should be run on very short gameplay sessions (see <see cref="PlayValidityHelper.IsValidForPlayTracking"/>).
+        /// </summary>
+        bool RunOnVeryShortPlays => false;
 
         /// <summary>
         /// Reverts the effect of <paramref name="score"/> from all relevant statistics.

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScoreMultiplierValidator.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScoreMultiplierValidator.cs
@@ -21,6 +21,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnFailedScores => true;
         public bool RunOnLegacyScores => true;
+        public bool RunOnVeryShortPlays => true;
 
         // Must run before any processor that reads total score.
         public int Order => int.MinValue;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
@@ -216,50 +216,43 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
                             return;
                         }
 
-                        if (score.IsValidForPlayTracking())
+                        // if required, we can rollback any previous version of processing then reapply with the latest.
+                        if (item.ProcessHistory != null)
                         {
-                            // if required, we can rollback any previous version of processing then reapply with the latest.
-                            if (item.ProcessHistory != null)
-                            {
-                                tags.Add("type:upgraded");
-                                byte version = item.ProcessHistory.processed_version;
+                            tags.Add("type:upgraded");
+                            byte version = item.ProcessHistory.processed_version;
 
-                                foreach (var p in enumerateValidProcessors(score))
-                                    p.RevertFromUserStats(score, userStats, version, conn, transaction, postTransactionActions, DogStatsd);
-                            }
-                            else
-                            {
-                                tags.Add("type:new");
-                            }
-
-                            item.Tags = tags.ToArray();
-
-                            foreach (IProcessor p in enumerateValidProcessors(score))
-                            {
-                                stopwatch.Restart();
-
-                                try
-                                {
-                                    p.ApplyToUserStats(score, userStats, conn, transaction, postTransactionActions, DogStatsd);
-                                }
-                                catch (ProcessingAbortedException abortException)
-                                {
-                                    Console.WriteLine($"Aborting processing of score {item.Score.id}: {abortException.Message}");
-                                    tags.Add("type:aborted");
-                                    transaction.Rollback();
-                                    conn.Execute("UPDATE `scores` SET `ranked` = 0 WHERE `id` = @scoreId", new { scoreId = score.id });
-                                    return;
-                                }
-
-                                DogStatsd.Timer("apply_time_elapsed", stopwatch.ElapsedMilliseconds, tags: item.Tags.Append($"processor:{p.GetType().ReadableName()}").ToArray());
-                            }
-
-                            DatabaseHelper.UpdateUserStatsAsync(userStats, conn, transaction).Wait();
+                            foreach (var p in enumerateValidProcessors(score))
+                                p.RevertFromUserStats(score, userStats, version, conn, transaction, postTransactionActions, DogStatsd);
                         }
                         else
                         {
-                            tags.Add("type:too-short");
+                            tags.Add("type:new");
                         }
+
+                        item.Tags = tags.ToArray();
+
+                        foreach (IProcessor p in enumerateValidProcessors(score))
+                        {
+                            stopwatch.Restart();
+
+                            try
+                            {
+                                p.ApplyToUserStats(score, userStats, conn, transaction, postTransactionActions, DogStatsd);
+                            }
+                            catch (ProcessingAbortedException abortException)
+                            {
+                                Console.WriteLine($"Aborting processing of score {item.Score.id}: {abortException.Message}");
+                                tags.Add("type:aborted");
+                                transaction.Rollback();
+                                conn.Execute("UPDATE `scores` SET `ranked` = 0 WHERE `id` = @scoreId", new { scoreId = score.id });
+                                return;
+                            }
+
+                            DogStatsd.Timer("apply_time_elapsed", stopwatch.ElapsedMilliseconds, tags: item.Tags.Append($"processor:{p.GetType().ReadableName()}").ToArray());
+                        }
+
+                        DatabaseHelper.UpdateUserStatsAsync(userStats, conn, transaction).Wait();
 
                         updateHistoryEntry(item, conn, transaction);
 
@@ -314,6 +307,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
 
             if (score.is_legacy_score)
                 result = result.Where(p => p.RunOnLegacyScores);
+
+            if (!score.IsValidForPlayTracking())
+                result = result.Where(p => p.RunOnVeryShortPlays);
 
             return result;
         }


### PR DESCRIPTION
## [Fix score multiplier validator not running on short scores](https://github.com/ppy/osu-queue-score-statistics/commit/5035875c63939f5977892d1246bbd1a5ed7da1e7)

The guard introduced in https://github.com/ppy/osu-queue-score-statistics/pull/369 was preventing the validator from running on scores that were otherwise considered "too short to process".

In a way these could just be left well alone, since it is implicitly guaranteed that such scores cannot be preserved, but for peace of mind and better consistency let's do these as well.

## [Skip broken imported non-high scores in recalculation command](https://github.com/ppy/osu-queue-score-statistics/commit/05d62b0b52368f6e3ba43145f824f4c17ece1322)

Non-high osu!mania scores on graveyarded beatmaps will import with `total_score = 0` due to [a failure to retrieve difficulty attributes in `BatchInserter`](https://github.com/ppy/osu-queue-score-statistics/blob/c538ae9523b5e15145483f72a903b8a88f33733f/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/BatchInserter.cs#L364-L369) (almost no graveyarded beatmaps currently have difficulty attributes in production, and almost all graveyarded beatmaps curently have scoring attributes in production).

This was causing some alarm as running the recalculation command post-deploy of the score multiplier validator was showing many "missed" scores. The current working theory that the above scenario explains most of them.

To eliminate this concern, adjust the command itself to skip over said broken rows. This is a somewhat dodgy thing to do, but these are generally rows that will get deleted soon (disregarding pinning for a second), and so the short term priority is to confirm that there are no more other issues with the online score multiplier validation process that could lead to scores not getting multipliers corrected when they should.