### PR TITLE
Optimise score storage by allowing `total_score_without_mods` to be absent from certain scores

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ScoreMultiplierValidatorTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/ScoreMultiplierValidatorTest.cs
@@ -28,11 +28,48 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         }
 
         [Fact]
-        public void TestScoreWhereTotalScoreWithoutModsIsMissingIsRejected()
+        public void TestStableScoreWhereTotalScoreWithoutModsIsMissingIsAccepted()
         {
             using var conn = Processor.GetDatabaseConnection();
             var score = CreateTestScore(0, beatmap.beatmap_id);
             score.Score.ScoreData.TotalScoreWithoutMods = null;
+            score.Score.legacy_score_id = 12345678;
+            score.Score.legacy_total_score = 123_123_123;
+            score.Score.total_score = 245_000;
+            InsertScore(conn, score);
+
+            Processor.PushToQueue(score);
+            WaitForDatabaseState("SELECT `ranked` FROM `scores` WHERE `id` = @id", 1, CancellationToken, new { score.Score.id });
+            WaitForDatabaseState("SELECT `total_score` FROM `scores` WHERE `id` = @id", 245_000, CancellationToken, new { score.Score.id });
+            // total score processor does not run for stable scores, so use rank count instead as a stopgap for covering that other processors still run for this score
+            WaitForDatabaseState("SELECT `s_rank_count` FROM `osu_user_stats` WHERE user_id = 2", 1, CancellationToken);
+        }
+
+        [Fact]
+        public void TestLazerScoreWithoutModsWhereTotalScoreWithoutModsIsMissingIsAccepted()
+        {
+            using var conn = Processor.GetDatabaseConnection();
+            var score = CreateTestScore(0, beatmap.beatmap_id);
+            score.Score.ScoreData.TotalScoreWithoutMods = null;
+            score.Score.ScoreData.Mods = [];
+            score.Score.total_score = 990_000;
+            InsertScore(conn, score);
+
+            Processor.PushToQueue(score);
+            WaitForDatabaseState("SELECT `ranked` FROM `scores` WHERE `id` = @id", 1, CancellationToken, new { score.Score.id });
+            WaitForDatabaseState("SELECT `total_score` FROM `scores` WHERE `id` = @id", 990_000, CancellationToken, new { score.Score.id });
+            // classic score = round(100814.25 * standardised score / 1000000)
+            WaitForDatabaseState("SELECT `total_score` FROM `osu_user_stats` WHERE user_id = 2", 99_806, CancellationToken);
+        }
+
+        [Fact]
+        public void TestLazerScoreWithModsWhereTotalScoreWithoutModsIsMissingIsRejected()
+        {
+            using var conn = Processor.GetDatabaseConnection();
+            var score = CreateTestScore(0, beatmap.beatmap_id);
+            score.Score.ScoreData.TotalScoreWithoutMods = null;
+            score.Score.ScoreData.Mods = [new APIMod(new OsuModDoubleTime())];
+            score.Score.total_score = 1_230_000;
             InsertScore(conn, score);
 
             Processor.PushToQueue(score);

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/BatchInserter.cs
@@ -221,7 +221,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
                 Mods = referenceScore.Mods.Select(m => new APIMod(m)).ToArray(),
                 Statistics = referenceScore.Statistics,
                 MaximumStatistics = referenceScore.MaximumStatistics,
-                TotalScoreWithoutMods = referenceScore.TotalScoreWithoutMods,
+                // TotalScoreWithoutMods is intentionally skipped as storing it is redundant
+                // (both it and `total_score` are wholly derived from `legacy_total_score` and legacy beatmap scoring attributes,
+                // see `StandardisedScoreMigrationTools.UpdateFromLegacy()` call lower down)
             }, new JsonSerializerSettings
             {
                 DefaultValueHandling = DefaultValueHandling.Ignore

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScoreMultiplierValidator.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScoreMultiplierValidator.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Dapper;
 using JetBrains.Annotations;
 using MySqlConnector;
+using osu.Game.Database;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Scoring;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
@@ -20,7 +21,20 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         private const string scores_modified_metric = $@"{nameof(ScoreMultiplierValidator)}.scores_modified";
 
         public bool RunOnFailedScores => true;
-        public bool RunOnLegacyScores => true;
+
+        /// <summary>
+        /// Legacy scores are excluded from validation for two reasons:
+        /// <list type="bullet">
+        /// <item>They are imported via a server-side process, so there is no room for user tampering or version mismatches there.</item>
+        /// <item>
+        /// In the case of legacy scores, both <see cref="SoloScore.total_score"/> and <see cref="SoloScoreData.TotalScoreWithoutMods"/>
+        /// are derived wholly from <see cref="SoloScore.legacy_total_score"/> through the estimated score conversion process
+        /// (see <see cref="StandardisedScoreMigrationTools"/>).
+        /// </item>
+        /// </list>
+        /// </summary>
+        public bool RunOnLegacyScores => false;
+
         public bool RunOnVeryShortPlays => true;
 
         // Must run before any processor that reads total score.
@@ -33,6 +47,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
         {
+            if (score.ScoreData.Mods.Length == 0)
+                return;
+
             if (score.ScoreData.TotalScoreWithoutMods is not long totalScoreWithoutMods)
             {
                 dogStatsd.Increment(scores_modified_metric, tags: ["unranked"]);


### PR DESCRIPTION
- Part of post-https://github.com/ppy/osu/issues/37818 cleanup

## [Exclude scores which are permitted to have total score without mods missing from multiplier validation](https://github.com/ppy/osu-queue-score-statistics/commit/a28f9d6e4d88625b4c7998f7533a63fa5b128aad)

As previously outlined in https://github.com/ppy/osu-queue-score-statistics/pull/374, the only scores that *need* `total_score_without_mods` populated are lazer scores with at least one mod present. To that end, this commit adjusts the validator added in https://github.com/ppy/osu-queue-score-statistics/pull/379 such that it does not mark scores which are allowed to have it unpopulated as unranked, because of not having it populated.

## [Do not populate total score without mods when importing stable scores](https://github.com/ppy/osu-queue-score-statistics/commit/0fdd0f481f4622a4140d515cc1f1d07079fed36f)

Self-explanatory.