### PR TITLE
Add support for marking non-preserve scores in realtime

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -46,7 +46,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
         private Exception? firstError;
 
-        protected DatabaseTest(AssemblyName[]? externalProcessorAssemblies = null)
+        protected DatabaseTest(AssemblyName[]? externalProcessorAssemblies = null, string[]? disabledProcessors = null)
         {
             cancellationSource = Debugger.IsAttached
                 ? new CancellationTokenSource()
@@ -54,7 +54,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
             Environment.SetEnvironmentVariable("REALTIME_DIFFICULTY", "0");
 
-            Processor = new ScoreStatisticsQueueProcessor(externalProcessorAssemblies: externalProcessorAssemblies);
+            Processor = new ScoreStatisticsQueueProcessor(externalProcessorAssemblies: externalProcessorAssemblies, disabledProcessors: disabledProcessors);
             Processor.Error += processorOnError;
 
             Processor.ClearQueue();

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -89,7 +89,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 db.Execute("TRUNCATE TABLE `osu_user_performance_rank_highest`");
 
                 // Used in mark non-presrve tests.
-                db.Execute("TRUNCATE TABLE `multiplayer_playlist_item_scores`");
+                db.Execute("TRUNCATE TABLE `multiplayer_score_links`");
                 db.Execute("TRUNCATE TABLE `score_pins`");
             }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/DatabaseTest.cs
@@ -87,6 +87,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
 
                 db.Execute("TRUNCATE TABLE `osu_user_performance_rank`");
                 db.Execute("TRUNCATE TABLE `osu_user_performance_rank_highest`");
+
+                // Used in mark non-presrve tests.
+                db.Execute("TRUNCATE TABLE `multiplayer_playlist_item_scores`");
+                db.Execute("TRUNCATE TABLE `score_pins`");
             }
 
             BeatmapStore.PurgeCaches();

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MarkNonPreservedProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MarkNonPreservedProcessorTests.cs
@@ -11,11 +11,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
     /// <summary>
     /// This tests realtime non-preserved marking, handled by `UserTotalPerformanceProcessor`.
     /// </summary>
-    public class MarkNonPreservedTests : DatabaseTest
+    public class MarkNonPreservedProcessorTests : DatabaseTest
     {
         private readonly Beatmap beatmap;
 
-        public MarkNonPreservedTests()
+        public MarkNonPreservedProcessorTests()
         {
             beatmap = AddBeatmap();
         }

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MarkNonPreservedScoresCommandTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MarkNonPreservedScoresCommandTest.cs
@@ -15,9 +15,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         private readonly Beatmap beatmap;
 
         public MarkNonPreservedScoresCommandTest()
-            // The UserTotalPerformanceProcessor does realtime non-preserved marking.
+            // The `MarkNonPreservedProcessor` does realtime non-preserved marking.
             // In these tests, we want to test the batch version of this and therefore must bypass the realtime processing.
-            : base(disabledProcessors: [nameof(UserTotalPerformanceProcessor)])
+            : base(disabledProcessors: [nameof(MarkNonPreservedProcessor)])
         {
             beatmap = AddBeatmap();
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MarkNonPreservedScoresCommandTest.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MarkNonPreservedScoresCommandTest.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Dapper;
 using osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using osu.Server.Queues.ScoreStatisticsProcessor.Processors;
 using Xunit;
 
 namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
@@ -14,6 +15,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         private readonly Beatmap beatmap;
 
         public MarkNonPreservedScoresCommandTest()
+            // The UserTotalPerformanceProcessor does realtime non-preserved marking.
+            // In these tests, we want to test the batch version of this and therefore must bypass the realtime processing.
+            : base(disabledProcessors: [nameof(UserTotalPerformanceProcessor)])
         {
             beatmap = AddBeatmap();
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MarkNonPreservedTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MarkNonPreservedTests.cs
@@ -18,11 +18,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
         public MarkNonPreservedTests()
         {
             beatmap = AddBeatmap();
-
-            using var db = Processor.GetDatabaseConnection();
-
-            db.Execute("DELETE FROM `multiplayer_playlist_item_scores`");
-            db.Execute("TRUNCATE TABLE `score_pins`");
         }
 
         [Fact]

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MarkNonPreservedTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/MarkNonPreservedTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading.Tasks;
+using Dapper;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using Xunit;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
+{
+    /// <summary>
+    /// This tests realtime non-preserved marking, handled by `UserTotalPerformanceProcessor`.
+    /// </summary>
+    public class MarkNonPreservedTests : DatabaseTest
+    {
+        private readonly Beatmap beatmap;
+
+        public MarkNonPreservedTests()
+        {
+            beatmap = AddBeatmap();
+
+            using var db = Processor.GetDatabaseConnection();
+
+            db.Execute("DELETE FROM `multiplayer_playlist_item_scores`");
+            db.Execute("TRUNCATE TABLE `score_pins`");
+        }
+
+        [Fact]
+        public void OnlyBestPPAndTotalScoresArePreserved()
+        {
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 1;
+                s.Score.ScoreData.TotalScoreWithoutMods = s.Score.total_score = 800_000;
+                s.Score.pp = 95;
+            });
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 2;
+                s.Score.ScoreData.TotalScoreWithoutMods = s.Score.total_score = 850_000;
+                s.Score.pp = 90;
+            });
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 3;
+                s.Score.ScoreData.TotalScoreWithoutMods = s.Score.total_score = 500_000;
+                s.Score.pp = 85;
+            });
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 1", 2, CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 0", 1, CancellationToken);
+            WaitForDatabaseState("SELECT `preserve` FROM `scores` WHERE `id` = 3", false, CancellationToken);
+        }
+
+        [Fact]
+        public async Task NonBestScoresRemainPreservedIfPinned()
+        {
+            using var db = Processor.GetDatabaseConnection();
+
+            await db.ExecuteAsync("INSERT INTO `score_pins` (`user_id`, `score_id`, `ruleset_id`, `display_order`) VALUES (2, 2, 0, 0)");
+
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 1;
+                s.Score.total_score = 800_000;
+                s.Score.pp = 95;
+            });
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 2;
+                s.Score.total_score = 500_000;
+                s.Score.pp = 85;
+            });
+
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 1", 2, CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 0", 0, CancellationToken);
+            WaitForDatabaseState("SELECT `preserve` FROM `scores` WHERE `id` = 2", true, CancellationToken);
+        }
+
+        [Fact]
+        public async Task NonBestScoresRemainPreservedIfAssociatedWithPlaylistItem()
+        {
+            using var db = Processor.GetDatabaseConnection();
+
+            await db.ExecuteAsync("INSERT INTO `multiplayer_playlist_item_scores` (`user_id`, `playlist_item_id`, `score_id`) VALUES (2, 1, 2)");
+
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 1;
+                s.Score.total_score = 800_000;
+                s.Score.pp = 95;
+            });
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 2;
+                s.Score.total_score = 500_000;
+                s.Score.pp = 85;
+            });
+
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 1", 2, CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 0", 0, CancellationToken);
+            WaitForDatabaseState("SELECT `preserve` FROM `scores` WHERE `id` = 2", true, CancellationToken);
+        }
+
+        [Fact]
+        public void ScoreNotConsideredBestIfNotRanked()
+        {
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 1;
+                s.Score.total_score = 800_000;
+                s.Score.pp = 95;
+                s.Score.ranked = false;
+            });
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 2;
+                s.Score.total_score = 500_000;
+                s.Score.pp = 85;
+            });
+
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 1", 1, CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 0", 1, CancellationToken);
+            WaitForDatabaseState("SELECT `preserve` FROM `scores` WHERE `id` = 1", false, CancellationToken);
+        }
+
+        [Fact]
+        public void ScorePreserveOnlyBestNotRanked()
+        {
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 1;
+                s.Score.total_score = 800_000;
+                s.Score.pp = 95;
+                s.Score.ranked = false;
+            });
+            SetScoreForBeatmap(beatmap.beatmap_id, s =>
+            {
+                s.Score.id = 2;
+                s.Score.total_score = 500_000;
+                s.Score.pp = 85;
+                s.Score.ranked = false;
+            });
+
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 1", 1, CancellationToken);
+            WaitForDatabaseState("SELECT COUNT(1) FROM `scores` WHERE `preserve` = 0", 1, CancellationToken);
+            WaitForDatabaseState("SELECT `preserve` FROM `scores` WHERE `id` = 1", true, CancellationToken);
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor.Tests/PerformanceProcessorTests.cs
@@ -66,7 +66,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 attr.SpeedDifficulty = 3;
             });
 
-            SetScoreForBeatmap(TEST_BEATMAP_ID, score =>
+            var score1 = SetScoreForBeatmap(TEST_BEATMAP_ID, score =>
             {
                 score.Score.ScoreData.Statistics[HitResult.Great] = 100;
                 score.Score.max_combo = 100;
@@ -79,7 +79,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             WaitForDatabaseState("SELECT rank_score FROM osu_user_stats WHERE user_id = 2", 131, CancellationToken);
 
             // purposefully identical to score above, to confirm that you don't get pp for two scores on the same map twice
-            SetScoreForBeatmap(TEST_BEATMAP_ID, score =>
+            var score2 = SetScoreForBeatmap(TEST_BEATMAP_ID, score =>
             {
                 score.Score.ScoreData.Statistics[HitResult.Great] = 100;
                 score.Score.max_combo = 100;
@@ -88,8 +88,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
                 score.Score.preserve = true;
             });
 
-            // 129pp from the single score above + 4pp from playcount bonus
-            WaitForDatabaseState("SELECT rank_score FROM osu_user_stats WHERE user_id = 2", 133, CancellationToken);
+            // 129pp from the single score above + 2pp from playcount bonus
+            WaitForDatabaseState("SELECT rank_score FROM osu_user_stats WHERE user_id = 2", 131, CancellationToken);
+
+            WaitForDatabaseState($"SELECT preserve FROM scores WHERE id = {score1.Score.id}", true, CancellationToken);
+            WaitForDatabaseState($"SELECT preserve FROM scores WHERE id = {score2.Score.id}", false, CancellationToken);
         }
 
         /// <summary>
@@ -614,10 +617,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Tests
             SetScoreForBeatmap(beatmap.beatmap_id, s =>
             {
                 s.Score.preserve = s.Score.ranked = true;
-                s.Score.pp = 600; // ~606 pp total, including bonus pp
+                s.Score.pp = 600; // ~604 pp total, including bonus pp
             });
 
-            WaitForDatabaseState("SELECT `r13`, `r14` FROM `osu_user_performance_rank` WHERE `user_id` = @userId AND `mode` = @mode", (597, 395), CancellationToken, new
+            WaitForDatabaseState("SELECT `r13`, `r14` FROM `osu_user_performance_rank` WHERE `user_id` = @userId AND `mode` = @mode", (597, 397), CancellationToken, new
             {
                 userId = 2,
                 mode = 0,

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MarkNonPreservedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/MarkNonPreservedScoresCommand.cs
@@ -170,7 +170,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                     break;
 
                 // check whether this score is a user high (either total_score or pp)
-                if (checkIsUserHigh(scores, score, out var preservedAlternatives))
+                if (CheckIsUserHigh(scores, score, out var preservedAlternatives))
                 {
                     if (Verbose)
                         formatOutput(score, false, "user high");
@@ -242,7 +242,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
         private static readonly HashSet<string> a_hash_set = new HashSet<string>();
         private static readonly HashSet<string> b_hash_set = new HashSet<string>();
 
-        private static bool checkIsUserHigh(IEnumerable<SoloScore> userScores, SoloScore candidate, out HashSet<SoloScore> preservedAlternatives)
+        public static bool CheckIsUserHigh(IEnumerable<SoloScore> userScores, SoloScore candidate, out HashSet<SoloScore> preservedAlternatives)
         {
             var scores = userScores.Where(s =>
                 s.beatmap_id == candidate.beatmap_id

--- a/osu.Server.Queues.ScoreStatisticsProcessor/IProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/IProcessor.cs
@@ -47,7 +47,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         /// <param name="transaction">Ongoing database transactions.</param>
         /// <param name="postTransactionActions">Queue of relevant actions to execute after the transaction ends.</param>
         /// <param name="dogStatsd">Instance of <see cref="DogStatsdService"/> to use for collecting metrics.</param>
-        void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+        void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions,
                                  DogStatsdService dogStatsd);
 
         /// <summary>
@@ -59,7 +59,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         /// <param name="transaction">Ongoing database transactions.</param>
         /// <param name="postTransactionActions">Queue of relevant actions to execute after the transaction ends.</param>
         /// <param name="dogStatsd">Instance of <see cref="DogStatsdService"/> to use for collecting metrics.</param>
-        void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd);
+        void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions,
+                              DogStatsdService dogStatsd);
 
         /// <summary>
         /// Adjust any global statistics outside of the user transaction.

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ProcessorContext.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ProcessorContext.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using MySqlConnector;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor
+{
+    public record ProcessorContext
+    {
+        public required MySqlConnection Connection { get; init; }
+
+        public required ElasticQueuePusher ElasticProcessor { get; init; }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/HighBeatmapLeaderboardRankEventEmitter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/HighBeatmapLeaderboardRankEventEmitter.cs
@@ -29,13 +29,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         /// </remarks>
         public bool RunOnLegacyScores => true;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
-                                        DogStatsdService dogStatsd)
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction,
+                                        List<Action<ProcessorContext>> postTransactionActions, DogStatsdService dogStatsd)
         {
             // not applicable because `ApplyToUserStats()` does nothing.
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions,
+                                     DogStatsdService dogStatsd)
         {
             // not applicable.
             // this processor is pretty much an orchestrator of external calls based on a few db queries

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/HitStatisticsProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/HitStatisticsProcessor.cs
@@ -21,14 +21,14 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnLegacyScores => false;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions,
                                         DogStatsdService dogStatsd)
         {
             if (previousVersion >= 2)
                 adjustStatisticsFromScore(score, userStats, true);
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions, DogStatsdService dogStatsd)
         {
             adjustStatisticsFromScore(score, userStats);
         }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/LastPlayedDateProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/LastPlayedDateProcessor.cs
@@ -20,12 +20,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         public bool RunOnFailedScores => true;
         public bool RunOnLegacyScores => false;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions,
                                         DogStatsdService dogStatsd)
         {
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions, DogStatsdService dogStatsd)
         {
             if (userStats.last_played < score.ended_at || userStats.playcount == 0)
                 userStats.last_played = score.ended_at;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ManiaKeyModeUserStatsProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ManiaKeyModeUserStatsProcessor.cs
@@ -27,12 +27,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         public bool RunOnFailedScores => false;
         public bool RunOnLegacyScores => true;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions,
                                         DogStatsdService dogStatsd)
         {
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats fullRulesetStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
+        public void ApplyToUserStats(SoloScore score, UserStats fullRulesetStats, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions, DogStatsdService dogStatsd)
         {
             if (score.ruleset_id != 3)
                 return;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MarkNonPreservedProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MarkNonPreservedProcessor.cs
@@ -2,11 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Dapper;
-using Microsoft.Extensions.Caching.Memory;
 using MySqlConnector;
 using osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
@@ -27,10 +25,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         public bool RunOnFailedScores => false;
 
         public bool RunOnLegacyScores => true;
-
-        // [ruleset_id, [rank_score, count_users_above]]
-        private readonly ConcurrentDictionary<int, MemoryCache> rankScoreIndexPartitionCache =
-            new ConcurrentDictionary<int, MemoryCache>();
 
         public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction,
                                         List<Action<ProcessorContext>> postTransactionActions,

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MarkNonPreservedProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MarkNonPreservedProcessor.cs
@@ -19,8 +19,8 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
     /// </summary>
     public class MarkNonPreservedProcessor : IProcessor
     {
-        // This processor needs to run before user total processor as bonus PP relies on the preserved flag.
-        public const int ORDER = UserTotalPerformanceProcessor.ORDER - 1;
+        // This processor needs to run after PP is calculated as this is used in cleanup rules.
+        public const int ORDER = ScorePerformanceProcessor.ORDER + 1;
 
         public int Order => ORDER;
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MarkNonPreservedProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MarkNonPreservedProcessor.cs
@@ -1,0 +1,88 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Dapper;
+using Microsoft.Extensions.Caching.Memory;
+using MySqlConnector;
+using osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance;
+using osu.Server.Queues.ScoreStatisticsProcessor.Models;
+using StatsdClient;
+
+namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
+{
+    /// <summary>
+    /// Marks irrelevant scores as non-preserved ahead of calculating totals which may depend on this flag.
+    /// </summary>
+    public class MarkNonPreservedProcessor : IProcessor
+    {
+        // This processor needs to run before user total processor as bonus PP relies on the preserved flag.
+        public const int ORDER = UserTotalPerformanceProcessor.ORDER - 1;
+
+        public int Order => ORDER;
+
+        public bool RunOnFailedScores => false;
+
+        public bool RunOnLegacyScores => true;
+
+        // [ruleset_id, [rank_score, count_users_above]]
+        private readonly ConcurrentDictionary<int, MemoryCache> rankScoreIndexPartitionCache =
+            new ConcurrentDictionary<int, MemoryCache>();
+
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction,
+                                        List<Action<ProcessorContext>> postTransactionActions,
+                                        DogStatsdService dogStatsd)
+        {
+        }
+
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions,
+                                     DogStatsdService dogStatsd)
+        {
+            List<SoloScore> scores = (conn.Query<SoloScore>(
+                """
+                SELECT
+                    s.id, s.beatmap_id, s.ranked,
+                    IF(s.data->'$.mods' IS NULL, '{}', JSON_OBJECT('mods', s.data->'$.mods')) AS data,
+                    s.total_score, s.legacy_total_score, s.pp
+                FROM scores s
+                WHERE
+                    s.user_id = @UserId
+                    AND s.ruleset_id = @RulesetId
+                    AND s.beatmap_id = @BeatmapId
+                    AND s.pp IS NOT NULL
+                    AND s.preserve = 1
+                    AND NOT EXISTS (SELECT 1 FROM score_pins pins WHERE pins.score_id = s.id AND pins.user_id = @UserId AND pins.ruleset_id = @RulesetId)
+                    AND NOT EXISTS (SELECT 1 FROM multiplayer_playlist_item_scores mp WHERE mp.score_id = s.id AND mp.user_id = @UserId);
+                """, new
+                {
+                    UserId = score.user_id,
+                    RulesetId = score.ruleset_id,
+                    BeatmapId = score.beatmap_id,
+                }, transaction: transaction)).ToList();
+
+            foreach (var s in scores)
+            {
+                // check whether this score is a user high (either total_score or pp)
+                if (MarkNonPreservedScoresCommand.CheckIsUserHigh(scores, s, out _))
+                    continue;
+
+                conn.Execute("UPDATE scores SET preserve = 0, unix_updated_at = UNIX_TIMESTAMP() WHERE id = @scoreId", new
+                {
+                    scoreId = s.id
+                }, transaction: transaction);
+
+                postTransactionActions.Add(context =>
+                {
+                    context.ElasticProcessor.PushToQueue(new ElasticQueuePusher.ElasticScoreItem { ScoreId = (long?)s.id });
+                });
+            }
+        }
+
+        public void ApplyGlobal(SoloScore score, MySqlConnection conn)
+        {
+        }
+    }
+}

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MaxComboProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MaxComboProcessor.cs
@@ -24,13 +24,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnLegacyScores => false;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions,
                                         DogStatsdService dogStatsd)
         {
             // TODO: this will require access to stable scores to be implemented correctly.
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions, DogStatsdService dogStatsd)
         {
             Ruleset ruleset = ScoreStatisticsQueueProcessor.AVAILABLE_RULESETS.Single(r => r.RulesetInfo.OnlineID == score.ruleset_id);
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/MedalProcessor.cs
@@ -51,12 +51,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         // This processor needs to run after the play count and hit statistics have been applied, at very least.
         public int Order => int.MaxValue - 1;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions,
                                         DogStatsdService dogStatsd)
         {
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions, DogStatsdService dogStatsd)
         {
             if (score.beatmap!.approved <= 0)
                 return;
@@ -94,7 +94,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
                 foreach (var awardedMedal in awarder.Check(availableMedalsForUser, context))
                 {
-                    postTransactionActions.Add(() => awardMedal(score, awardedMedal));
+                    postTransactionActions.Add(_ => awardMedal(score, awardedMedal));
                 }
             }
         }

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayCountProcessor.cs
@@ -27,7 +27,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnLegacyScores => false;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions,
                                         DogStatsdService dogStatsd)
         {
             if (previousVersion >= 1)
@@ -40,7 +40,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             }
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions, DogStatsdService dogStatsd)
         {
             const int beatmap_count = 12;
             const int over_time = 120;
@@ -82,7 +82,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             }
         }
 
-        private static void adjustGlobalBeatmapPlaycount(SoloScore score, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions)
+        private static void adjustGlobalBeatmapPlaycount(SoloScore score, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions)
         {
             // We want to reduce database overhead here, so we only update the global beatmap playcount every n plays.
             // Note that we use a non-round number to make the display more natural.
@@ -108,7 +108,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
                 // Reindex beatmap occasionally.
                 if (RNG.Next(0, 10) == 0)
-                    postTransactionActions.Add(() => WebRequestHelper.RunSharedInteropCommand("indexing/bulk", "POST", new { beatmapset = new[] { score.beatmap.beatmapset_id } }));
+                    postTransactionActions.Add(_ => WebRequestHelper.RunSharedInteropCommand("indexing/bulk", "POST", new { beatmapset = new[] { score.beatmap.beatmapset_id } }));
 
                 // TODO: announce playcount milestones
                 // const int notify_amount = 1000000;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/PlayTimeProcessor.cs
@@ -21,7 +21,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnLegacyScores => false;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions,
                                         DogStatsdService dogStatsd)
         {
             int lengthInSeconds = PlayValidityHelper.GetPlayLength(score);
@@ -30,7 +30,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 userStats.total_seconds_played -= lengthInSeconds;
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions, DogStatsdService dogStatsd)
         {
             int lengthInSeconds = PlayValidityHelper.GetPlayLength(score);
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/RankedScoreProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/RankedScoreProcessor.cs
@@ -21,7 +21,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnLegacyScores => false;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions,
                                         DogStatsdService dogStatsd)
         {
             if (!score.BeatmapValidForRankedCounts())
@@ -47,7 +47,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             }
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions, DogStatsdService dogStatsd)
         {
             if (!score.BeatmapValidForRankedCounts())
                 return;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScoreMultiplierValidator.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScoreMultiplierValidator.cs
@@ -47,12 +47,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         // Must run before any processor that reads total score.
         public int Order => int.MinValue;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions,
                                         DogStatsdService dogStatsd)
         {
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions, DogStatsdService dogStatsd)
         {
             if (score.ScoreData.Mods.Length == 0)
                 return;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs
@@ -39,12 +39,12 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         private static readonly bool write_legacy_score_pp = Environment.GetEnvironmentVariable("WRITE_LEGACY_SCORE_PP") != "0";
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions,
                                         DogStatsdService dogStatsd)
         {
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions, DogStatsdService dogStatsd)
         {
             double? valueBeforeProcessing = score.pp;
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/TotalScoreProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/TotalScoreProcessor.cs
@@ -24,7 +24,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnLegacyScores => false;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions,
                                         DogStatsdService dogStatsd)
         {
             if (previousVersion < 2)
@@ -46,7 +46,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             userStats.level = calculateLevel(userStats.total_score);
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions, DogStatsdService dogStatsd)
         {
             long classicTotalScore = score.ToScoreInfo().GetDisplayScore(ScoringMode.Classic);
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserRankCountProcessor.cs
@@ -24,7 +24,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
 
         public bool RunOnLegacyScores => true;
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions,
                                         DogStatsdService dogStatsd)
         {
             if (!score.BeatmapValidForRankedCounts())
@@ -50,7 +50,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             }
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions, DogStatsdService dogStatsd)
         {
             if (!score.BeatmapValidForRankedCounts())
                 return;

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -20,8 +20,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
     /// </summary>
     public class UserTotalPerformanceProcessor : IProcessor
     {
-        // This processor needs to run after the score's PP value has been processed.
-        public const int ORDER = ScorePerformanceProcessor.ORDER + 1;
+        // This processor needs to run after the score's PP value has been processed,
+        // and any non-preserved scores have been cleaned up (for bonus PP calculation).
+        public const int ORDER = MarkNonPreservedProcessor.ORDER + 1;
 
         public int Order => ORDER;
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Dapper;
 using Microsoft.Extensions.Caching.Memory;
 using MySqlConnector;
-using osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 using StatsdClient;
@@ -22,7 +21,9 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
     public class UserTotalPerformanceProcessor : IProcessor
     {
         // This processor needs to run after the score's PP value has been processed.
-        public int Order => ScorePerformanceProcessor.ORDER + 1;
+        public const int ORDER = ScorePerformanceProcessor.ORDER + 1;
+
+        public int Order => ORDER;
 
         public bool RunOnFailedScores => false;
 
@@ -46,7 +47,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             if (DatabaseHelper.IsUserRestricted(conn, userStats.user_id, transaction))
                 return;
 
-            markNonPreserved(score, conn, transaction, postTransactionActions).Wait();
             UpdateUserStatsAsync(userStats, score.ruleset_id, conn, transaction).Wait();
             updateGlobalRank(userStats, conn, transaction, dbInfo).Wait();
         }
@@ -81,48 +81,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 }, transaction: transaction)).ToList();
 
             (userStats.rank_score, userStats.accuracy_new) = UserTotalPerformanceAggregateHelper.CalculateUserTotalPerformanceAggregates(userStats.user_id, scores);
-        }
-
-        private async Task markNonPreserved(SoloScore score, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions)
-        {
-            List<SoloScore> scores = (await conn.QueryAsync<SoloScore>(
-                """
-                SELECT
-                    s.id, s.beatmap_id, s.ranked,
-                    IF(s.data->'$.mods' IS NULL, '{}', JSON_OBJECT('mods', s.data->'$.mods')) AS data,
-                    s.total_score, s.legacy_total_score, s.pp
-                FROM scores s
-                WHERE
-                    s.user_id = @UserId
-                    AND s.ruleset_id = @RulesetId
-                    AND s.beatmap_id = @BeatmapId
-                    AND s.pp IS NOT NULL
-                    AND s.preserve = 1
-                    AND NOT EXISTS (SELECT 1 FROM score_pins pins WHERE pins.score_id = s.id AND pins.user_id = @UserId AND pins.ruleset_id = @RulesetId)
-                    AND NOT EXISTS (SELECT 1 FROM multiplayer_playlist_item_scores mp WHERE mp.score_id = s.id AND mp.user_id = @UserId);
-                """, new
-                {
-                    UserId = score.user_id,
-                    RulesetId = score.ruleset_id,
-                    BeatmapId = score.beatmap_id,
-                }, transaction: transaction)).ToList();
-
-            foreach (var s in scores)
-            {
-                // check whether this score is a user high (either total_score or pp)
-                if (MarkNonPreservedScoresCommand.CheckIsUserHigh(scores, s, out _))
-                    continue;
-
-                await conn.ExecuteAsync("UPDATE scores SET preserve = 0, unix_updated_at = UNIX_TIMESTAMP() WHERE id = @scoreId", new
-                {
-                    scoreId = s.id
-                }, transaction: transaction);
-
-                postTransactionActions.Add(context =>
-                {
-                    context.ElasticProcessor.PushToQueue(new ElasticQueuePusher.ElasticScoreItem { ScoreId = (long?)s.id });
-                });
-            }
         }
 
         private async Task updateGlobalRank(UserStats userStats, MySqlConnection connection, MySqlTransaction? transaction, LegacyDatabaseHelper.RulesetDatabaseInfo dbInfo)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -32,19 +32,21 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
         private readonly ConcurrentDictionary<int, MemoryCache> rankScoreIndexPartitionCache =
             new ConcurrentDictionary<int, MemoryCache>();
 
-        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions,
+        public void RevertFromUserStats(SoloScore score, UserStats userStats, int previousVersion, MySqlConnection conn, MySqlTransaction transaction,
+                                        List<Action<ProcessorContext>> postTransactionActions,
                                         DogStatsdService dogStatsd)
         {
         }
 
-        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action> postTransactionActions, DogStatsdService dogStatsd)
+        public void ApplyToUserStats(SoloScore score, UserStats userStats, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions,
+                                     DogStatsdService dogStatsd)
         {
             var dbInfo = LegacyDatabaseHelper.GetRulesetSpecifics(score.ruleset_id);
 
             if (DatabaseHelper.IsUserRestricted(conn, userStats.user_id, transaction))
                 return;
 
-            markNonPreserved(score, conn, transaction).Wait();
+            markNonPreserved(score, conn, transaction, postTransactionActions).Wait();
             UpdateUserStatsAsync(userStats, score.ruleset_id, conn, transaction).Wait();
             updateGlobalRank(userStats, conn, transaction, dbInfo).Wait();
         }
@@ -81,7 +83,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             (userStats.rank_score, userStats.accuracy_new) = UserTotalPerformanceAggregateHelper.CalculateUserTotalPerformanceAggregates(userStats.user_id, scores);
         }
 
-        private async Task markNonPreserved(SoloScore score, MySqlConnection conn, MySqlTransaction transaction)
+        private async Task markNonPreserved(SoloScore score, MySqlConnection conn, MySqlTransaction transaction, List<Action<ProcessorContext>> postTransactionActions)
         {
             List<SoloScore> scores = (await conn.QueryAsync<SoloScore>(
                 """
@@ -116,11 +118,10 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                     scoreId = s.id
                 }, transaction: transaction);
 
-                // TODO: make this work
-                // elasticQueueProcessor.PushToQueue(new ElasticQueuePusher.ElasticScoreItem
-                // {
-                //     ScoreId = (long?)s.id
-                // });
+                postTransactionActions.Add(context =>
+                {
+                    context.ElasticProcessor.PushToQueue(new ElasticQueuePusher.ElasticScoreItem { ScoreId = (long?)s.id });
+                });
             }
         }
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Processors/UserTotalPerformanceProcessor.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Dapper;
 using Microsoft.Extensions.Caching.Memory;
 using MySqlConnector;
+using osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance;
 using osu.Server.Queues.ScoreStatisticsProcessor.Helpers;
 using osu.Server.Queues.ScoreStatisticsProcessor.Models;
 using StatsdClient;
@@ -43,6 +44,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
             if (DatabaseHelper.IsUserRestricted(conn, userStats.user_id, transaction))
                 return;
 
+            markNonPreserved(score, conn, transaction).Wait();
             UpdateUserStatsAsync(userStats, score.ruleset_id, conn, transaction).Wait();
             updateGlobalRank(userStats, conn, transaction, dbInfo).Wait();
         }
@@ -77,6 +79,49 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Processors
                 }, transaction: transaction)).ToList();
 
             (userStats.rank_score, userStats.accuracy_new) = UserTotalPerformanceAggregateHelper.CalculateUserTotalPerformanceAggregates(userStats.user_id, scores);
+        }
+
+        private async Task markNonPreserved(SoloScore score, MySqlConnection conn, MySqlTransaction transaction)
+        {
+            List<SoloScore> scores = (await conn.QueryAsync<SoloScore>(
+                """
+                SELECT
+                    s.id, s.beatmap_id, s.ranked,
+                    IF(s.data->'$.mods' IS NULL, '{}', JSON_OBJECT('mods', s.data->'$.mods')) AS data,
+                    s.total_score, s.legacy_total_score, s.pp
+                FROM scores s
+                WHERE
+                    s.user_id = @UserId
+                    AND s.ruleset_id = @RulesetId
+                    AND s.beatmap_id = @BeatmapId
+                    AND s.pp IS NOT NULL
+                    AND s.preserve = 1
+                    AND NOT EXISTS (SELECT 1 FROM score_pins pins WHERE pins.score_id = s.id AND pins.user_id = @UserId AND pins.ruleset_id = @RulesetId)
+                    AND NOT EXISTS (SELECT 1 FROM multiplayer_playlist_item_scores mp WHERE mp.score_id = s.id AND mp.user_id = @UserId);
+                """, new
+                {
+                    UserId = score.user_id,
+                    RulesetId = score.ruleset_id,
+                    BeatmapId = score.beatmap_id,
+                }, transaction: transaction)).ToList();
+
+            foreach (var s in scores)
+            {
+                // check whether this score is a user high (either total_score or pp)
+                if (MarkNonPreservedScoresCommand.CheckIsUserHigh(scores, s, out _))
+                    continue;
+
+                await conn.ExecuteAsync("UPDATE scores SET preserve = 0, unix_updated_at = UNIX_TIMESTAMP() WHERE id = @scoreId", new
+                {
+                    scoreId = s.id
+                }, transaction: transaction);
+
+                // TODO: make this work
+                // elasticQueueProcessor.PushToQueue(new ElasticQueuePusher.ElasticScoreItem
+                // {
+                //     ScoreId = (long?)s.id
+                // });
+            }
         }
 
         private async Task updateGlobalRank(UserStats userStats, MySqlConnection connection, MySqlTransaction? transaction, LegacyDatabaseHelper.RulesetDatabaseInfo dbInfo)

--- a/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/ScoreStatisticsQueueProcessor.cs
@@ -167,7 +167,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
         {
             var stopwatch = new Stopwatch();
             var tags = new List<string>();
-            var postTransactionActions = new List<Action>();
+            var postTransactionActions = new List<Action<ProcessorContext>>();
 
             try
             {
@@ -263,7 +263,11 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor
                     {
                         try
                         {
-                            action.Invoke();
+                            action.Invoke(new ProcessorContext
+                            {
+                                Connection = conn,
+                                ElasticProcessor = elasticQueueProcessor,
+                            });
                         }
                         catch (Exception e)
                         {


### PR DESCRIPTION
This removes the need to repeatedly run `MarkNonPreservedScoresCommand`. If this turns out to run efficiently, this is great news as the batch command is still quite slow (takes days for a full pass).

The result of this change is that users will no longer see bonus PP incorrectly increasing, then getting reset to a lower value when the batch command runs – it will always be in a correct state. It also allows for score cleanup to happen as soon as it can, similar to web-10's handling.

- Test coverage is copied directly from the existing batch process coverage. This command is already known to produce correct results, so hopefully this should be pretty good coverage.
- Could optionally be moved into its own processor if we want. Maybe better for tracking time spent doing the processing? Would need to be run with higher priority than `UserTotalPerformanceProcessor` if so.


Has not yet been performance tested on production, but based on the query execution plan, thing look like they will be okay.