### PR TITLE
Remove pp column checks from verify scores command

### DIFF
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Maintenance/VerifyImportedScoresCommand.cs
@@ -94,7 +94,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                     + "`has_replay`, "
                     + "s.ranked,"
                     + "s.`rank`, "
-                    + "s.`pp`, "
                     + "s.`data`, "
                     + "h.* "
                     + "FROM scores s "
@@ -189,15 +188,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
                             continue;
 
                         var referenceScore = importedScore.ReferenceScore!;
-
-                        if (!check(importedScore.id, "performance", importedScore.pp ?? 0, importedScore.HighScore.pp ?? 0))
-                        {
-                            Interlocked.Increment(ref fail);
-                            requiresIndexing = true;
-
-                            // PP was reset (had a value in new table but no value in old) or doesn't match.
-                            sqlBuffer.Append($"UPDATE scores SET pp = {importedScore.HighScore.pp.ToString() ?? "NULL"} WHERE id = {importedScore.id};");
-                        }
 
                         if (!check(importedScore.id, "ranked", importedScore.ranked, true))
                         {
@@ -359,7 +349,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Maintenance
             public bool has_replay;
             public ScoreRank rank;
             public bool ranked;
-            public float? pp;
 
             public SoloScoreData ScoreData = new SoloScoreData();
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Performance/Scores/UpdateAllScoresCommand.cs
@@ -127,7 +127,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
                 await Task.WhenAll(Partitioner.Create(scores).GetPartitions(Threads).Select(async partition =>
                 {
                     List<(ulong id, double val)> updates = new List<(ulong id, double val)>();
-                    Dictionary<ushort, List<(ulong id, double val)>> legacyUpdates = new Dictionary<ushort, List<(ulong id, double val)>>();
 
                     connections.TryDequeue(out var connection);
 
@@ -151,14 +150,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
                                     // pp is guaranteed to be non-null after this processing pathway.
                                     updates.Add((score.id, score.pp!.Value));
 
-                                    if (score.is_legacy_score)
-                                    {
-                                        if (!legacyUpdates.TryGetValue(score.ruleset_id, out var legacyRulesetUpdates))
-                                            legacyUpdates[score.ruleset_id] = legacyRulesetUpdates = new List<(ulong id, double val)>();
-
-                                        legacyRulesetUpdates.Add((score.id, score.pp!.Value));
-                                    }
-
                                     Interlocked.Increment(ref changedPp);
                                     elasticItems.Add(new ElasticQueuePusher.ElasticScoreItem { ScoreId = (long?)score.id });
                                 }
@@ -171,12 +162,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Commands.Performance.Scores
                     }
 
                     DatabaseHelper.BatchUpdateScoresTable(connection, tableName: "scores", idColumnName: "id", valueColumnName: "pp", updates);
-
-                    foreach (var kvp in legacyUpdates)
-                    {
-                        var ruleset = LegacyDatabaseHelper.GetRulesetSpecifics(kvp.Key);
-                        DatabaseHelper.BatchUpdateScoresTable(connection, tableName: ruleset.HighScoreTable, idColumnName: "score_id", valueColumnName: "pp", kvp.Value);
-                    }
 
                     connections.Enqueue(connection);
                 }));

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/BatchInserter.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/BatchInserter.cs
@@ -153,7 +153,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
                     bool isRanked = highScore.ShouldPreserve;
 
                     highScore.InsertSql =
-                        $"({highScore.user_id}, {rulesetId}, {highScore.beatmap_id}, {(highScore.replay ? "1" : "0")}, {(highScore.ShouldPreserve ? "1" : "0")}, {(isRanked ? "1" : "0")}, '{referenceScore.Rank.ToString()}', {(highScore.pass ? "1" : "0")}, {referenceScore.Accuracy}, {referenceScore.MaxCombo}, {referenceScore.TotalScore}, '{serialisedScore}', {highScore.pp?.ToString() ?? "null"}, {highScore.score_id}, {referenceScore.LegacyTotalScore}, '{highScore.date:yyyy-MM-dd HH:mm:ss}', {highScore.date.ToUnixTimeSeconds()})";
+                        $"({highScore.user_id}, {rulesetId}, {highScore.beatmap_id}, {(highScore.replay ? "1" : "0")}, {(highScore.ShouldPreserve ? "1" : "0")}, {(isRanked ? "1" : "0")}, '{referenceScore.Rank.ToString()}', {(highScore.pass ? "1" : "0")}, {referenceScore.Accuracy}, {referenceScore.MaxCombo}, {referenceScore.TotalScore}, '{serialisedScore}', {highScore.score_id}, {referenceScore.LegacyTotalScore}, '{highScore.date:yyyy-MM-dd HH:mm:ss}', {highScore.date.ToUnixTimeSeconds()})";
                 }
                 catch (Exception e)
                 {
@@ -174,7 +174,7 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Helpers
 
             bool first = true;
             StringBuilder insertBuilder = new StringBuilder(
-                "INSERT INTO scores (`user_id`, `ruleset_id`, `beatmap_id`, `has_replay`, `preserve`, `ranked`, `rank`, `passed`, `accuracy`, `max_combo`, `total_score`, `data`, `pp`, `legacy_score_id`, `legacy_total_score`, `ended_at`, `unix_updated_at`) VALUES ");
+                "INSERT INTO scores (`user_id`, `ruleset_id`, `beatmap_id`, `has_replay`, `preserve`, `ranked`, `rank`, `passed`, `accuracy`, `max_combo`, `total_score`, `data`, `legacy_score_id`, `legacy_total_score`, `ended_at`, `unix_updated_at`) VALUES ");
 
             scores = scores.Where(score => !string.IsNullOrEmpty(score.InsertSql)).ToArray();
 

--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/HighScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/HighScore.cs
@@ -26,7 +26,6 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
         public bool perfect { get; set; }
         public int enabled_mods { get; set; }
         public DateTimeOffset date { get; set; }
-        public float? pp { get; set; }
         public bool replay { get; set; }
         public bool hidden { get; set; }
         public string country_acronym { get; set; } = null!;


### PR DESCRIPTION
New table is source of truth going forward. Old table's column is basically unused at this point. Remaining usages will be migrated away in coming days (probably).